### PR TITLE
[WIP] requests verification in router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ func (config *Configuration) ExtractRouterConfig() *nodeconfig.RouterNodeConfig 
 		NumOfgRPCStreamsPerConnection: config.LocalConfig.NodeLocalConfig.RouterParams.NumberOfStreamsPerConnection,
 		UseTLS:                        config.LocalConfig.TLSConfig.Enabled,
 		ClientAuthRequired:            config.LocalConfig.TLSConfig.ClientAuthRequired,
+		RequestMaxBytes:               config.SharedConfig.BatchingConfig.RequestMaxBytes,
 	}
 	return routerConfig
 }

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -77,6 +77,7 @@ type RouterNodeConfig struct {
 	NumOfgRPCStreamsPerConnection int
 	UseTLS                        bool
 	ClientAuthRequired            bool
+	RequestMaxBytes               uint64
 }
 
 type AssemblerNodeConfig struct {

--- a/node/router/router.go
+++ b/node/router/router.go
@@ -190,8 +190,10 @@ func createRouter(shardIDs []types.ShardID, batcherEndpoints map[types.ShardID]s
 		routerNodeConfig: rconfig,
 	}
 
+	verifier := r.createRequestVerifier()
+
 	for _, shardId := range shardIDs {
-		r.shardRouters[shardId] = NewShardRouter(logger, batcherEndpoints[shardId], batcherRootCAs[shardId], rconfig.TLSCertificateFile, rconfig.TLSPrivateKeyFile, rconfig.NumOfConnectionsForBatcher, rconfig.NumOfgRPCStreamsPerConnection)
+		r.shardRouters[shardId] = NewShardRouter(logger, batcherEndpoints[shardId], batcherRootCAs[shardId], rconfig.TLSCertificateFile, rconfig.TLSPrivateKeyFile, rconfig.NumOfConnectionsForBatcher, rconfig.NumOfgRPCStreamsPerConnection, verifier)
 	}
 
 	go func() {
@@ -325,6 +327,36 @@ func createTraceID(rand *rand2.Rand) []byte {
 	binary.BigEndian.PutUint64(trace, uint64(n1))
 	binary.BigEndian.PutUint64(trace[8:], uint64(n2))
 	return trace
+}
+
+// this struct implements the interface MaxSizeRuleSupport for the maxSize filter
+type routerFilterSupport struct {
+	router *Router
+}
+
+func (rfs *routerFilterSupport) GetMaxSizeBytes() (uint64, error) {
+	if rfs.router == nil {
+		return 0, fmt.Errorf("error: bad router filter support")
+	}
+	if rfs.router.routerNodeConfig == nil {
+		return 0, fmt.Errorf("error: bad RouterNodeConfnig")
+	}
+	return rfs.router.routerNodeConfig.RequestMaxBytes, nil
+}
+
+func (r *Router) createRequestVerifier() Verifier {
+	var requestVerifier Verifier
+
+	requestVerifier.AddRule(PayloadNotEmptyRule)
+
+	requestVerifier.AddRule(AcceptRule) // just for fun
+
+	// requestVerifier.AddRule(NewSigVerifier(support)) // not implemented for now (will accept)
+
+	rfs := routerFilterSupport{router: r}
+	requestVerifier.AddRule(NewMaxSizeRule(&rfs))
+
+	return requestVerifier
 }
 
 // IsAllStreamsOK checks that all the streams accross all shard-routers are non-faulty.

--- a/node/router/shard_router.go
+++ b/node/router/shard_router.go
@@ -69,6 +69,7 @@ type ShardRouter struct {
 	closeReconnectOnce           sync.Once
 	reconnectRequests            chan reconnectReq
 	closeReconnect               chan bool
+	requestVerifier              Verifier
 }
 
 func NewShardRouter(l types.Logger,
@@ -78,6 +79,7 @@ func NewShardRouter(l types.Logger,
 	tlsKey []byte,
 	numOfConnectionsForBatcher int,
 	numOfgRPCStreamsPerConnection int,
+	requestVerifier Verifier,
 ) *ShardRouter {
 	cc := comm.ClientConfig{
 		AsyncConnect: false,
@@ -106,6 +108,7 @@ func NewShardRouter(l types.Logger,
 		clientConfig:                 cc,
 		reconnectRequests:            make(chan reconnectReq, 2*numOfgRPCStreamsPerConnection*numOfConnectionsForBatcher),
 		closeReconnect:               make(chan bool),
+		requestVerifier:              requestVerifier,
 	}
 
 	return sr
@@ -332,6 +335,7 @@ func (sr *ShardRouter) initStream(i int, j int) error {
 			streamNum:                         j,
 			srReconnectChan:                   sr.reconnectRequests,
 			notifiedReconnect:                 false,
+			requestVerifier:                   &sr.requestVerifier,
 		}
 		go s.sendRequests()
 		go s.readResponses()

--- a/node/router/shard_router_test.go
+++ b/node/router/shard_router_test.go
@@ -162,7 +162,8 @@ func createTestSetup(t *testing.T, partyID types.PartyID) *TestSetup {
 	batcher := NewStubBatcher(t, ca, partyID, types.ShardID(1))
 
 	// create shard router
-	shardRouter := router.NewShardRouter(logger, batcher.GetBatcherEndpoint(), [][]byte{ca.CertBytes()}, ckp.Cert, ckp.Key, 10, 20)
+	var verifier router.Verifier
+	shardRouter := router.NewShardRouter(logger, batcher.GetBatcherEndpoint(), [][]byte{ca.CertBytes()}, ckp.Cert, ckp.Key, 10, 20, verifier)
 
 	// start the batcher
 	batcher.Start()

--- a/node/router/stream.go
+++ b/node/router/stream.go
@@ -32,6 +32,7 @@ type stream struct {
 	streamNum                         int
 	srReconnectChan                   chan reconnectReq
 	notifiedReconnect                 bool
+	requestVerifier                   *Verifier
 }
 
 // readResponses listens for responses from the batcher.
@@ -50,18 +51,9 @@ func (s *stream) readResponses() {
 				s.cancelOnServerError()
 				return
 			}
-
-			s.lock.Lock()
-			ch, exists := s.requestTraceIdToResponseChannel[string(resp.TraceId)]
-			delete(s.requestTraceIdToResponseChannel, string(resp.TraceId))
-			s.lock.Unlock()
-			if exists {
-				s.logger.Debugf("read response from batcher %s on request with trace id %x", s.endpoint, resp.TraceId)
-				s.logger.Debugf("registration for request with trace id %x was removed upon receiving a response", resp.TraceId)
-				ch <- Response{
-					SubmitResponse: resp,
-				}
-			} else {
+			s.logger.Debugf("read response from batcher %s on request with trace id %x", s.endpoint, resp.TraceId)
+			err = s.sendResponseToClient(resp)
+			if err != nil {
 				s.logger.Debugf("received a response from batcher %s for a request with trace id %x, which does not exist in the map, dropping response", s.endpoint, resp.TraceId)
 			}
 		}
@@ -81,14 +73,42 @@ func (s *stream) sendRequests() {
 				s.cancelOnServerError()
 				return
 			}
-			s.logger.Debugf("send request with trace id %x to batcher %s", msg.TraceId, s.endpoint)
-			err := s.requestTransmitSubmitStreamClient.Send(msg)
-			if err != nil {
-				s.logger.Errorf("Failed sending request to batcher %s", s.endpoint)
-				s.cancelOnServerError()
-				return
+			// validate the request
+			if err := s.requestVerifier.Verify(msg); err != nil {
+				s.logger.Debugf("request is invalid: %s", err)
+				// send a response to the client
+				resp := protos.SubmitResponse{Error: fmt.Sprintf("request verifying error: %s", err), TraceId: msg.TraceId}
+				err = s.sendResponseToClient(&resp)
+				if err != nil {
+					s.logger.Debugf("error sending response to client: %s", err)
+				}
+			} else {
+				s.logger.Debugf("send request with trace id %x to batcher %s", msg.TraceId, s.endpoint)
+				err := s.requestTransmitSubmitStreamClient.Send(msg)
+				if err != nil {
+					s.logger.Errorf("Failed sending request to batcher %s", s.endpoint)
+					s.cancelOnServerError()
+					return
+				}
 			}
 		}
+	}
+}
+
+func (s *stream) sendResponseToClient(response *protos.SubmitResponse) error {
+	traceID := response.TraceId
+	s.lock.Lock()
+	ch, exists := s.requestTraceIdToResponseChannel[string(traceID)]
+	delete(s.requestTraceIdToResponseChannel, string(traceID))
+	s.lock.Unlock()
+	if exists {
+		s.logger.Debugf("registration for request with trace id %x was removed upon receiving a response", traceID)
+		ch <- Response{
+			SubmitResponse: response,
+		}
+		return nil
+	} else {
+		return fmt.Errorf("request with traceID %x is not in map", traceID)
 	}
 }
 
@@ -201,6 +221,7 @@ CopyChannelLoop:
 		streamNum:                         s.streamNum,
 		srReconnectChan:                   s.srReconnectChan,
 		notifiedReconnect:                 false,
+		requestVerifier:                   s.requestVerifier,
 	}
 	s.lock.Unlock()
 

--- a/node/router/verifier.go
+++ b/node/router/verifier.go
@@ -1,0 +1,117 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package router
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-x-orderer/node/protos/comm"
+)
+
+type Rule interface {
+	Verify(request *comm.Request) error
+}
+
+// Verifier is a struct that holds a slice of rules, used to verify a request.
+type Verifier struct {
+	rules []Rule
+}
+
+// NewVerifier creates a Verifier using the provided ordered list of Rules.
+func NewVerifier(rules []Rule) *Verifier {
+	return &Verifier{
+		rules: rules,
+	}
+}
+
+// Verify checks the request against the rules in order. It returns nil if all rules pass, or an error if any rule fails.
+func (vr *Verifier) Verify(request *comm.Request) error {
+	for _, rule := range vr.rules {
+		if err := rule.Verify(request); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (vr *Verifier) AddRule(rule Rule) {
+	vr.rules = append(vr.rules, rule)
+}
+
+// PayloadNotEmptyRule - checks that the payload in the request is not nil.
+var PayloadNotEmptyRule = Rule(payloadNotEmptyRule{})
+
+type payloadNotEmptyRule struct{}
+
+func (a payloadNotEmptyRule) Verify(request *comm.Request) error {
+	if request.Payload == nil {
+		return fmt.Errorf("empty payload field")
+	}
+	return nil
+}
+
+// AcceptRule - always returns nil as a result for Apply
+var AcceptRule = Rule(acceptRule{})
+
+type acceptRule struct{}
+
+func (a acceptRule) Verify(request *comm.Request) error {
+	return nil
+}
+
+// Request Max Size rule
+
+// MaxSizeRuleSupport is an interface that gives the necessary information to verify the size of a request.
+type MaxSizeRuleSupport interface {
+	GetMaxSizeBytes() (uint64, error)
+}
+
+type MaxSizeRule struct {
+	support MaxSizeRuleSupport
+}
+
+func NewMaxSizeRule(support MaxSizeRuleSupport) *MaxSizeRule {
+	return &MaxSizeRule{support: support}
+}
+
+// Verfiy checks that the size of the request does not exceeds the maximal size in bytes.
+func (ms *MaxSizeRule) Verify(request *comm.Request) error {
+	maxSize, ok := ms.support.GetMaxSizeBytes()
+	if ok != nil {
+		return fmt.Errorf("router node config not found")
+	}
+	requestSize := requestSizeInBytes(request)
+	if requestSize > maxSize {
+		return fmt.Errorf("the request's size exceeds the maximum size")
+	}
+	return nil
+}
+
+// requestSizeInBytes return the (approximated) size in bytes of a request
+func requestSizeInBytes(request *comm.Request) uint64 {
+	return uint64(len(request.Payload) + len(request.Signature))
+}
+
+// Signature verification rule
+// ** Not Implemented **
+
+type SigVerifier struct {
+	support SigVerifySupport
+}
+
+type SigVerifySupport interface {
+	// add a proper get function if needed
+}
+
+func NewSigVerifier(support SigVerifySupport) *SigVerifier {
+	return &SigVerifier{support: support}
+}
+
+func (sf *SigVerifier) Verify(request *comm.Request) error {
+	// add signature verification logic
+	return nil
+}

--- a/node/router/verifier_test.go
+++ b/node/router/verifier_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package router
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-orderer/node/protos/comm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonEmptyFilter(t *testing.T) {
+	var v Verifier
+	v.AddRule(PayloadNotEmptyRule)
+	request := &comm.Request{Payload: nil}
+	err := v.Verify(request)
+	require.EqualError(t, err, "empty payload field")
+
+	buff := make([]byte, 300)
+	binary.BigEndian.PutUint32(buff, uint32(12345))
+	request = &comm.Request{Payload: buff}
+	err = v.Verify(request)
+	require.NoError(t, err)
+}
+
+func TestAcceptFilter(t *testing.T) {
+	var v Verifier
+	v.AddRule(AcceptRule)
+	request := &comm.Request{Payload: nil}
+	err := v.Verify(request)
+	require.NoError(t, err)
+}
+
+func TestMaxSizeFilter(t *testing.T) {
+	var v Verifier
+	var tfs testfiltersupport
+	v.AddRule(NewMaxSizeRule(&tfs))
+
+	buff := make([]byte, 3000)
+	binary.BigEndian.PutUint32(buff, uint32(12345))
+	request := &comm.Request{Payload: buff}
+	err := v.Verify(request)
+	require.EqualError(t, err, "the request's size exceeds the maximum size")
+
+	buff = make([]byte, 300)
+	binary.BigEndian.PutUint32(buff, uint32(12345))
+	request = &comm.Request{Payload: buff}
+	err = v.Verify(request)
+	require.NoError(t, err)
+}
+
+func TestSigVerifyFilter(t *testing.T) {
+	// signature verification is not implemented yet
+	t.Skip()
+	var v Verifier
+	var tfs testfiltersupport
+	v.AddRule(NewSigVerifier(&tfs))
+}
+
+type testfiltersupport struct{}
+
+func (tfs *testfiltersupport) GetMaxSizeBytes() (uint64, error) {
+	return 1 << 10, nil
+}

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -90,7 +90,8 @@ func createRouters(t *testing.T, num int, batcherInfos []nodeconfig.BatcherInfo,
 				ShardId:  shardId,
 				Batchers: batcherInfos,
 			}},
-			UseTLS: true,
+			UseTLS:          true,
+			RequestMaxBytes: 1 << 10,
 		}
 
 		router := router.NewRouter(config, l)


### PR DESCRIPTION
Added verifier.go to router. 
The verifier can check several rules: 
- request payload is not empty
- request does not exceed maxSizeBytes
- validate client signature in request (not implemented yet)

Also added relevant tests in router_test.go and verifier_test.go