### PR TITLE
fix tests in router

### DIFF
--- a/node/router/shard_router_test.go
+++ b/node/router/shard_router_test.go
@@ -80,6 +80,11 @@ func TestShardRouterReconnectToBatcherAndForwardReq(t *testing.T) {
 	// stop the batcher
 	testSetup.stubBatcher.Stop()
 
+	// wait for the streams to become faulty
+	require.Eventually(t, func() bool {
+		return testSetup.shardRouter.IsConnectionsToBatcherDown()
+	}, 10*time.Second, 200*time.Millisecond)
+
 	// send a request, expect failure
 	responses = make(chan router.Response, 1)
 	reqID, payload = createRequestAndRequestId(1, uint32(10000))
@@ -91,7 +96,7 @@ func TestShardRouterReconnectToBatcherAndForwardReq(t *testing.T) {
 	// restart the batcher
 	testSetup.stubBatcher.Restart()
 
-	// // wait for reconnection
+	// wait for reconnection
 	require.Eventually(t, func() bool {
 		return testSetup.shardRouter.IsAllStreamsOKinSR()
 	}, 10*time.Second, 200*time.Millisecond)


### PR DESCRIPTION
When the batcher is down, in rare occasions the router will fail to send a message to the batcher **before** a recv fails, and this result in a different error message.

The fix: in test, we wait until all the streams are down, and only then submit requests.