### PR TITLE
Test compatibility between envelope and request

### DIFF
--- a/node/router/router_test.go
+++ b/node/router/router_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package router_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
@@ -378,6 +380,37 @@ func TestClientRouterBroadcastRequestsAgainstMultipleBatchers(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return recvCond() == uint32(10)
 	}, 60*time.Second, 10*time.Millisecond)
+}
+
+// check that a protos.request and comm.envelope are always compatible: the payload and signature fields are consistent.
+func TestCompatibilityOfRequestAndEnvelope(t *testing.T) {
+	payload := []byte("My Message 123123")
+	signature := []byte("3021020e54180cf5bcbb6133e32ac30f967a020f00c1275eb696184dbce7835413ad7f")
+	identity := []byte("My Identity")
+	identityid := uint32(7)
+	traceID := []byte("trace")
+
+	t.Run("Request To Envelope", func(t *testing.T) {
+		req := &protos.Request{Payload: payload, Signature: signature, Identity: identity, IdentityId: identityid, TraceId: traceID}
+		data, err := proto.Marshal(req)
+		require.NoError(t, err)
+		env := &common.Envelope{}
+		err = proto.Unmarshal(data, env)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(env.Payload, payload))
+		require.True(t, bytes.Equal(env.Signature, signature))
+	})
+
+	t.Run("Envelope To Request", func(t *testing.T) {
+		env := &common.Envelope{Payload: payload, Signature: signature}
+		data, err := proto.Marshal(env)
+		require.NoError(t, err)
+		req := &protos.Request{}
+		err = proto.Unmarshal(data, req)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(req.Payload, payload))
+		require.True(t, bytes.Equal(req.Signature, signature))
+	})
 }
 
 func createServerTLSClientConnection(testSetup *routerTestSetup, ca tlsgen.CA) error {


### PR DESCRIPTION
Added a test that checks a request can be converted to an envelope (via marshal and unmarshal) and vice versa.

See issue #81 