### PR TITLE
Simple BAF cleanup

### DIFF
--- a/common/types/simpla_baf_test.go
+++ b/common/types/simpla_baf_test.go
@@ -16,14 +16,15 @@ import (
 
 func TestSimpleBAF(t *testing.T) {
 	t.Run("constructor setters and getters", func(t *testing.T) {
-		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, []byte{9, 10, 11, 12}, 13, [][]byte{{14, 15}, {16, 17}}, 18)
+		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 13, [][]byte{{14, 15}, {16, 17}}, 18)
 
 		require.Equal(t, types.ShardID(1), baf.Shard())
 		require.Equal(t, types.PartyID(2), baf.Primary())
 		require.Equal(t, types.BatchSequence(3), baf.Seq())
 		require.True(t, bytes.Equal([]byte{4, 5, 6, 7}, baf.Digest()))
 		require.Equal(t, types.PartyID(8), baf.Signer())
-
+		require.Nil(t, baf.Signature())
+		baf.SetSignature([]byte{9, 10, 11, 12})
 		require.True(t, bytes.Equal([]byte{9, 10, 11, 12}, baf.Signature()))
 
 		require.Equal(t, int64(13), baf.Epoch())
@@ -40,7 +41,8 @@ func TestSimpleBAF(t *testing.T) {
 	})
 
 	t.Run("ToBeSigned does not include sig", func(t *testing.T) {
-		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, []byte{9, 10, 11, 12}, 13, [][]byte{{14, 15}, {16, 17}}, 18)
+		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 13, [][]byte{{14, 15}, {16, 17}}, 18)
+		baf.SetSignature([]byte{9, 10, 11, 12})
 
 		var bafBytes []byte
 		require.NotPanics(t, func() {

--- a/common/types/simpla_baf_test.go
+++ b/common/types/simpla_baf_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSimpleBAF(t *testing.T) {
 	t.Run("constructor setters and getters", func(t *testing.T) {
-		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 13, [][]byte{{14, 15}, {16, 17}}, 18)
+		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, 13, [][]byte{{14, 15}, {16, 17}}, 18)
 
 		require.Equal(t, types.ShardID(1), baf.Shard())
 		require.Equal(t, types.PartyID(2), baf.Primary())
@@ -41,7 +41,7 @@ func TestSimpleBAF(t *testing.T) {
 	})
 
 	t.Run("ToBeSigned does not include sig", func(t *testing.T) {
-		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 13, [][]byte{{14, 15}, {16, 17}}, 18)
+		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, 13, [][]byte{{14, 15}, {16, 17}}, 18)
 		baf.SetSignature([]byte{9, 10, 11, 12})
 
 		var bafBytes []byte
@@ -63,7 +63,7 @@ func TestSimpleBAF(t *testing.T) {
 	})
 
 	t.Run("serialize and deserialize", func(t *testing.T) {
-		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 13, [][]byte{{14, 15}, {16, 17}}, 18)
+		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, 13, [][]byte{{14, 15}, {16, 17}}, 18)
 		baf.SetSignature([]byte{9, 10, 11, 12})
 
 		var bafBytes []byte

--- a/common/types/simple_baf.go
+++ b/common/types/simple_baf.go
@@ -27,13 +27,13 @@ type SimpleBatchAttestationFragment struct {
 	garbageCollect [][]byte // TODO remove
 }
 
+// NewSimpleBatchAttestationFragment creates a new, unsigned, SimpleBatchAttestationFragment.
 func NewSimpleBatchAttestationFragment(
 	shard ShardID,
 	primary PartyID,
 	seq BatchSequence,
 	digest []byte,
 	signer PartyID,
-	sig []byte,
 	epoch int64,
 	garbageCollect [][]byte,
 	configSqn ConfigSequence,
@@ -45,7 +45,6 @@ func NewSimpleBatchAttestationFragment(
 		signer:         signer,
 		shard:          shard,
 		digest:         digest,
-		signature:      sig,
 		garbageCollect: garbageCollect,
 		configSequence: configSqn,
 	}

--- a/common/types/tools_test.go
+++ b/common/types/tools_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchID_ToString(t *testing.T) {
+	baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 5, nil, 0, nil, 0)
+	str := types.BatchIDToString(baf)
+	require.Equal(t, str, "Sh,Pr,Sq,Dg: <1,2,3,04050607>")
+}
+
+func TestBatchID_Equals(t *testing.T) {
+	baf1 := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 0, nil, 0)
+
+	t.Run("equal", func(t *testing.T) {
+		baf2 := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		require.True(t, types.BatchIDEqual(baf1, baf2))
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		baf2 := types.NewSimpleBatchAttestationFragment(111, 2, 3, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		require.False(t, types.BatchIDEqual(baf1, baf2))
+		baf2 = types.NewSimpleBatchAttestationFragment(1, 111, 3, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		require.False(t, types.BatchIDEqual(baf1, baf2))
+		baf2 = types.NewSimpleBatchAttestationFragment(1, 2, 111, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		require.False(t, types.BatchIDEqual(baf1, baf2))
+		baf2 = types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{111, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		require.False(t, types.BatchIDEqual(baf1, baf2))
+	})
+}

--- a/common/types/tools_test.go
+++ b/common/types/tools_test.go
@@ -14,27 +14,27 @@ import (
 )
 
 func TestBatchID_ToString(t *testing.T) {
-	baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 5, nil, 0, nil, 0)
+	baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 5, 0, nil, 0)
 	str := types.BatchIDToString(baf)
 	require.Equal(t, str, "Sh,Pr,Sq,Dg: <1,2,3,04050607>")
 }
 
 func TestBatchID_Equals(t *testing.T) {
-	baf1 := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, nil, 0, nil, 0)
+	baf1 := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, 0, nil, 0)
 
 	t.Run("equal", func(t *testing.T) {
-		baf2 := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		baf2 := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 9, 1, [][]byte{{11}, {12}}, 13)
 		require.True(t, types.BatchIDEqual(baf1, baf2))
 	})
 
 	t.Run("not equal", func(t *testing.T) {
-		baf2 := types.NewSimpleBatchAttestationFragment(111, 2, 3, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		baf2 := types.NewSimpleBatchAttestationFragment(111, 2, 3, []byte{4, 5, 6, 7}, 9, 1, [][]byte{{11}, {12}}, 13)
 		require.False(t, types.BatchIDEqual(baf1, baf2))
-		baf2 = types.NewSimpleBatchAttestationFragment(1, 111, 3, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		baf2 = types.NewSimpleBatchAttestationFragment(1, 111, 3, []byte{4, 5, 6, 7}, 9, 1, [][]byte{{11}, {12}}, 13)
 		require.False(t, types.BatchIDEqual(baf1, baf2))
-		baf2 = types.NewSimpleBatchAttestationFragment(1, 2, 111, []byte{4, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		baf2 = types.NewSimpleBatchAttestationFragment(1, 2, 111, []byte{4, 5, 6, 7}, 9, 1, [][]byte{{11}, {12}}, 13)
 		require.False(t, types.BatchIDEqual(baf1, baf2))
-		baf2 = types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{111, 5, 6, 7}, 9, nil, 1, [][]byte{{11}, {12}}, 13)
+		baf2 = types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{111, 5, 6, 7}, 9, 1, [][]byte{{11}, {12}}, 13)
 		require.False(t, types.BatchIDEqual(baf1, baf2))
 	})
 }

--- a/node/batcher/batcher.go
+++ b/node/batcher/batcher.go
@@ -404,7 +404,7 @@ func CreateComplaint(signer Signer, id types.PartyID, shard types.ShardID, term 
 }
 
 func CreateBAF(signer Signer, id types.PartyID, shard types.ShardID, digest []byte, primary types.PartyID, seq types.BatchSequence) (types.BatchAttestationFragment, error) {
-	baf := types.NewSimpleBatchAttestationFragment(shard, primary, seq, digest, id, nil, 0, nil, 0)
+	baf := types.NewSimpleBatchAttestationFragment(shard, primary, seq, digest, id, 0, nil, 0)
 	sig, err := signer.Sign(baf.ToBeSigned())
 	if err != nil {
 		return nil, err

--- a/node/batcher/batcher_role_old_test.go
+++ b/node/batcher/batcher_role_old_test.go
@@ -207,7 +207,7 @@ func createBenchBatcher(b *testing.B, shardID arma_types.ShardID, nodeID arma_ty
 
 	bafCreator := &mocks.FakeBAFCreator{}
 	bafCreator.CreateBAFCalls(func(seq arma_types.BatchSequence, primary arma_types.PartyID, si arma_types.ShardID, digest []byte) arma_types.BatchAttestationFragment {
-		return arma_types.NewSimpleBatchAttestationFragment(shardID, primary, seq, digest, nodeID, nil, 0, nil, 0)
+		return arma_types.NewSimpleBatchAttestationFragment(shardID, primary, seq, digest, nodeID, 0, nil, 0)
 	})
 
 	batcher := &batcher.BatcherRole{
@@ -350,7 +350,7 @@ func createTestBatcher(t *testing.T, shardID arma_types.ShardID, nodeID arma_typ
 
 	bafCreator := &mocks.FakeBAFCreator{}
 	bafCreator.CreateBAFCalls(func(seq arma_types.BatchSequence, primary arma_types.PartyID, si arma_types.ShardID, digest []byte) arma_types.BatchAttestationFragment {
-		return arma_types.NewSimpleBatchAttestationFragment(shardID, primary, seq, digest, nodeID, nil, 0, nil, 0)
+		return arma_types.NewSimpleBatchAttestationFragment(shardID, primary, seq, digest, nodeID, 0, nil, 0)
 	})
 
 	b := &batcher.BatcherRole{

--- a/node/batcher/batcher_role_test.go
+++ b/node/batcher/batcher_role_test.go
@@ -631,9 +631,9 @@ func TestResubmitPending(t *testing.T) {
 
 	ledger.RetrieveBatchByNumberReturns(batch)
 
-	myBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID), nil, 0, nil, 0)
-	notMyBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID+1), nil, 0, nil, 0)
-	myBAFWithOtherPrimary := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary()+1, batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID), nil, 0, nil, 0)
+	myBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID), 0, nil, 0)
+	notMyBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID+1), 0, nil, 0)
+	myBAFWithOtherPrimary := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary()+1, batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID), 0, nil, 0)
 
 	stateChan <- &state.State{
 		Shards: []state.ShardTerm{
@@ -751,7 +751,7 @@ func TestVerifyBatch(t *testing.T) {
 func createBatcher(batcherID arma_types.PartyID, shardID arma_types.ShardID, batchers []arma_types.PartyID, N uint16, logger arma_types.Logger) *batcher.BatcherRole {
 	bafCreator := &mocks.FakeBAFCreator{}
 	bafCreator.CreateBAFCalls(func(seq arma_types.BatchSequence, primary arma_types.PartyID, si arma_types.ShardID, digest []byte) arma_types.BatchAttestationFragment {
-		return arma_types.NewSimpleBatchAttestationFragment(shardID, primary, seq, digest, batcherID, nil, 0, nil, 0)
+		return arma_types.NewSimpleBatchAttestationFragment(shardID, primary, seq, digest, batcherID, 0, nil, 0)
 	})
 
 	batcher := &batcher.BatcherRole{

--- a/node/consensus/consenter_test.go
+++ b/node/consensus/consenter_test.go
@@ -33,7 +33,8 @@ func TestConsenter(t *testing.T) {
 	db := &mocks.FakeBatchAttestationDB{}
 	consenter.DB = db
 
-	ba := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(2), []uint8{1}, 0, [][]uint8{}, 0)
+	ba := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(2), nil, 0, [][]uint8{}, 0)
+	ba.SetSignature([]uint8{1})
 	events := [][]byte{(&state.ControlEvent{BAF: ba}).Bytes()}
 
 	// Test with an event that should be filtered out
@@ -57,7 +58,8 @@ func TestConsenter(t *testing.T) {
 	assert.Zero(t, db.PutCallCount())
 
 	// Test valid events meeting the threshold
-	ba2 := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(3), []uint8{1}, 0, [][]uint8{}, 0)
+	ba2 := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(3), nil, 0, [][]uint8{}, 0)
+	ba2.SetSignature([]byte{1})
 	events = append(events, (&state.ControlEvent{BAF: ba2}).Bytes())
 
 	newState, batchAttestations = consenter.SimulateStateTransition(s, events)

--- a/node/consensus/consenter_test.go
+++ b/node/consensus/consenter_test.go
@@ -33,7 +33,7 @@ func TestConsenter(t *testing.T) {
 	db := &mocks.FakeBatchAttestationDB{}
 	consenter.DB = db
 
-	ba := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(2), nil, 0, [][]uint8{}, 0)
+	ba := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(2), 0, [][]uint8{}, 0)
 	ba.SetSignature([]uint8{1})
 	events := [][]byte{(&state.ControlEvent{BAF: ba}).Bytes()}
 
@@ -58,7 +58,7 @@ func TestConsenter(t *testing.T) {
 	assert.Zero(t, db.PutCallCount())
 
 	// Test valid events meeting the threshold
-	ba2 := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(3), nil, 0, [][]uint8{}, 0)
+	ba2 := arma_types.NewSimpleBatchAttestationFragment(arma_types.ShardID(1), arma_types.PartyID(1), arma_types.BatchSequence(1), []byte{3}, arma_types.PartyID(3), 0, [][]uint8{}, 0)
 	ba2.SetSignature([]byte{1})
 	events = append(events, (&state.ControlEvent{BAF: ba2}).Bytes())
 

--- a/node/consensus/state/state_test.go
+++ b/node/consensus/state/state_test.go
@@ -104,7 +104,7 @@ func TestControlEventSerialization(t *testing.T) {
 	assert.Equal(t, ce, ce2)
 
 	// Serialization and deserialization of ControlEvent with BAF
-	baf := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), nil, 0, [][]uint8{}, 0)
+	baf := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), 0, [][]uint8{}, 0)
 	baf.SetSignature([]byte{4})
 	ce = consensus_state.ControlEvent{BAF: baf}
 
@@ -169,7 +169,7 @@ func TestCollectAndDeduplicateEvents(t *testing.T) {
 	assert.Equal(t, state, expectedState)
 
 	// Update state with a valid BAF
-	baf := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), nil, 0, [][]uint8{}, 0)
+	baf := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), 0, [][]uint8{}, 0)
 	baf.SetSignature([]byte{4})
 	ce = consensus_state.ControlEvent{BAF: baf}
 	expectedState.Pending = append(expectedState.Pending, baf)
@@ -182,7 +182,7 @@ func TestCollectAndDeduplicateEvents(t *testing.T) {
 	assert.Equal(t, state, expectedState)
 
 	// Handle BAF with invalid Shard
-	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(2), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(3), nil, 0, [][]uint8{}, 0)
+	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(2), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(3), 0, [][]uint8{}, 0)
 	baf2.SetSignature([]byte{4})
 	ce = consensus_state.ControlEvent{BAF: baf2}
 
@@ -236,7 +236,7 @@ func TestCleanupOldAttestations(t *testing.T) {
 	state := initialState
 
 	// Test condition where the threshold is not met
-	baf1 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{1, 2}, types.PartyID(2), nil, 1, [][]byte{{1, 2}, {3, 4}}, 0)
+	baf1 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{1, 2}, types.PartyID(2), 1, [][]byte{{1, 2}, {3, 4}}, 0)
 	baf1.SetSignature([]byte{1})
 	logger := testutil.CreateLogger(t, 0)
 
@@ -246,7 +246,7 @@ func TestCleanupOldAttestations(t *testing.T) {
 	assert.Len(t, state.Pending, 1)
 
 	// Test condition where the threshold is met
-	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3, 4}, types.PartyID(3), nil, 1, [][]byte{{3, 4}}, 0)
+	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3, 4}, types.PartyID(3), 1, [][]byte{{3, 4}}, 0)
 	baf2.SetSignature([]byte{1})
 
 	state.Pending = append(state.Pending, baf2)

--- a/node/consensus/state/state_test.go
+++ b/node/consensus/state/state_test.go
@@ -33,8 +33,6 @@ var (
 		Signer:    3,
 		Signature: []byte{4},
 	}
-
-	baf = types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), []uint8{4}, 0, [][]uint8{}, 0)
 )
 
 func TestStateSerializeDeserialize(t *testing.T) {
@@ -106,7 +104,9 @@ func TestControlEventSerialization(t *testing.T) {
 	assert.Equal(t, ce, ce2)
 
 	// Serialization and deserialization of ControlEvent with BAF
-	ce = consensus_state.ControlEvent{baf, nil}
+	baf := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), nil, 0, [][]uint8{}, 0)
+	baf.SetSignature([]byte{4})
+	ce = consensus_state.ControlEvent{BAF: baf}
 
 	bafd := consensus_state.BAFDeserialize{}
 
@@ -169,7 +169,9 @@ func TestCollectAndDeduplicateEvents(t *testing.T) {
 	assert.Equal(t, state, expectedState)
 
 	// Update state with a valid BAF
-	ce = consensus_state.ControlEvent{baf, nil}
+	baf := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(2), nil, 0, [][]uint8{}, 0)
+	baf.SetSignature([]byte{4})
+	ce = consensus_state.ControlEvent{BAF: baf}
 	expectedState.Pending = append(expectedState.Pending, baf)
 
 	consensus_state.CollectAndDeduplicateEvents(&state, logger, ce)
@@ -180,8 +182,9 @@ func TestCollectAndDeduplicateEvents(t *testing.T) {
 	assert.Equal(t, state, expectedState)
 
 	// Handle BAF with invalid Shard
-	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(2), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(3), []uint8{4}, 0, [][]uint8{}, 0)
-	ce = consensus_state.ControlEvent{baf2, nil}
+	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(2), types.PartyID(1), types.BatchSequence(1), []byte{3}, types.PartyID(3), nil, 0, [][]uint8{}, 0)
+	baf2.SetSignature([]byte{4})
+	ce = consensus_state.ControlEvent{BAF: baf2}
 
 	consensus_state.CollectAndDeduplicateEvents(&state, logger, ce)
 	assert.Equal(t, state, expectedState)
@@ -233,7 +236,8 @@ func TestCleanupOldAttestations(t *testing.T) {
 	state := initialState
 
 	// Test condition where the threshold is not met
-	baf1 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{1, 2}, types.PartyID(2), []byte{}, 1, [][]byte{{1, 2}, {3, 4}}, 0)
+	baf1 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{1, 2}, types.PartyID(2), nil, 1, [][]byte{{1, 2}, {3, 4}}, 0)
+	baf1.SetSignature([]byte{1})
 	logger := testutil.CreateLogger(t, 0)
 
 	state.Pending = append(state.Pending, baf1)
@@ -242,7 +246,8 @@ func TestCleanupOldAttestations(t *testing.T) {
 	assert.Len(t, state.Pending, 1)
 
 	// Test condition where the threshold is met
-	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3, 4}, types.PartyID(3), []byte{}, 1, [][]byte{{3, 4}}, 0)
+	baf2 := types.NewSimpleBatchAttestationFragment(types.ShardID(1), types.PartyID(1), types.BatchSequence(1), []byte{3, 4}, types.PartyID(3), nil, 1, [][]byte{{3, 4}}, 0)
+	baf2.SetSignature([]byte{1})
 
 	state.Pending = append(state.Pending, baf2)
 	consensus_state.CleanupOldAttestations(&state, logger)


### PR DESCRIPTION
Remove the sig bytes from the constructor of the BAF, as in real workflows it is always nil.

Add some tests.

Issue #208 