### PR TITLE
Router config store

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,8 @@ func ReadConfig(configFilePath string, logger types.Logger) (*Configuration, *co
 			}
 
 			if len(listBlockNumbers) > 0 {
-				lastBlockNumber := uint64(len(listBlockNumbers) - 1)
+				lastBlockNumberIdx := uint64(len(listBlockNumbers) - 1)
+				lastBlockNumber := listBlockNumbers[lastBlockNumberIdx]
 				lastConfigBlock, err = configStore.GetByNumber(lastBlockNumber)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to retrieve the last block from %s config store: %s", nodeRole, err)

--- a/config/generate/local_config_gen.go
+++ b/config/generate/local_config_gen.go
@@ -218,7 +218,7 @@ func NewRouterLocalConfig(routerGeneralParams GeneralConfigParams) *config.NodeL
 	return &config.NodeLocalConfig{
 		PartyID:       routerGeneralParams.partyID,
 		GeneralConfig: NewGeneralConfig(routerGeneralParams),
-		FileStore:     &config.FileStore{},
+		FileStore:     &config.FileStore{Path: "/var/dec-trust/production/orderer/store"},
 		RouterParams:  &params,
 	}
 }

--- a/config/local_config.go
+++ b/config/local_config.go
@@ -16,6 +16,13 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/node/comm"
 )
 
+const (
+	Router    = "Router"
+	Batcher   = "Batcher"
+	Consensus = "Consensus"
+	Assembler = "Assembler"
+)
+
 // NodeLocalConfig controls the local configuration of an Arma node.
 // The relevant information will be filled corresponding to the specific node type.
 // Every time a node starts, it is expected to load this file.
@@ -176,42 +183,77 @@ type Cluster struct {
 }
 
 // LoadLocalConfig reads the local config yaml and certs and returns the local configuration.
-func LoadLocalConfig(filePath string) (*LocalConfig, error) {
+func LoadLocalConfig(filePath string) (*LocalConfig, string, error) {
 	nodeLocalConfig, err := LoadLocalConfigYaml(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load local node configuration, failed reading config yaml, err: %s", err)
+		return nil, "", fmt.Errorf("cannot load local node configuration, failed reading config yaml, err: %s", err)
+	}
+
+	role, err := validateNodeLocalConfigParams(nodeLocalConfig)
+	if err != nil {
+		return nil, "", err
 	}
 
 	tlsConfig, err := loadTLSCryptoConfig(&nodeLocalConfig.GeneralConfig.TLSConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load local tls config, err: %s", err)
+		return nil, "", fmt.Errorf("cannot load local tls config, err: %s", err)
 	}
 
 	// load cluster crypto config return cluster config with empty fields except for the consenter node
 	var clusterConfig *Cluster
 	clusterConfig, err = loadClusterCryptoConfig(&nodeLocalConfig.GeneralConfig.Cluster)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load local cluster config for consenter, err: %s", err)
+		return nil, "", fmt.Errorf("cannot load local cluster config for consenter, err: %s", err)
 	}
 
 	return &LocalConfig{
 		NodeLocalConfig: nodeLocalConfig,
 		TLSConfig:       tlsConfig,
 		ClusterConfig:   clusterConfig,
-	}, nil
+	}, role, nil
 }
 
 func LoadLocalConfigYaml(filePath string) (*NodeLocalConfig, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("cannot load local node configuration, path: %s is empty", filePath)
 	}
-	nodeLocalConfig := NodeLocalConfig{}
-	err := utils.ReadFromYAML(&nodeLocalConfig, filePath)
+	nodeLocalConfig := &NodeLocalConfig{}
+	err := utils.ReadFromYAML(nodeLocalConfig, filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	return &nodeLocalConfig, nil
+	return nodeLocalConfig, nil
+}
+
+func validateNodeLocalConfigParams(nodeLocalConfig *NodeLocalConfig) (string, error) {
+	var nonNilRoles []string
+
+	if nodeLocalConfig.RouterParams != nil {
+		nonNilRoles = append(nonNilRoles, Router)
+	}
+
+	if nodeLocalConfig.BatcherParams != nil {
+		nonNilRoles = append(nonNilRoles, Batcher)
+	}
+
+	if nodeLocalConfig.ConsensusParams != nil {
+		nonNilRoles = append(nonNilRoles, Consensus)
+	}
+
+	if nodeLocalConfig.AssemblerParams != nil {
+		nonNilRoles = append(nonNilRoles, Assembler)
+	}
+
+	if len(nonNilRoles) == 0 {
+		return "", fmt.Errorf("node local config is not valid, node params are missing")
+	}
+
+	if len(nonNilRoles) > 1 {
+		return "", fmt.Errorf("node local config is not valid, multiple params were set %v", nonNilRoles)
+	}
+
+	return nonNilRoles[0], nil
 }
 
 func loadTLSCryptoConfig(tlsConfig *TLSConfigYaml) (*TLSConfig, error) {

--- a/config/local_config.go
+++ b/config/local_config.go
@@ -229,19 +229,19 @@ func LoadLocalConfigYaml(filePath string) (*NodeLocalConfig, error) {
 func validateNodeLocalConfigParams(nodeLocalConfig *NodeLocalConfig) (string, error) {
 	var nonNilRoles []string
 
-	if nodeLocalConfig.RouterParams != nil {
+	if nodeLocalConfig.RouterParams != nil && !isEmptyRouterParams(nodeLocalConfig.RouterParams) {
 		nonNilRoles = append(nonNilRoles, Router)
 	}
 
-	if nodeLocalConfig.BatcherParams != nil {
+	if nodeLocalConfig.BatcherParams != nil && !isEmptyBatcherParams(nodeLocalConfig.BatcherParams) {
 		nonNilRoles = append(nonNilRoles, Batcher)
 	}
 
-	if nodeLocalConfig.ConsensusParams != nil {
+	if nodeLocalConfig.ConsensusParams != nil && !isEmptyConsensusParams(nodeLocalConfig.ConsensusParams) {
 		nonNilRoles = append(nonNilRoles, Consensus)
 	}
 
-	if nodeLocalConfig.AssemblerParams != nil {
+	if nodeLocalConfig.AssemblerParams != nil && !isEmptyAssemblerParams(nodeLocalConfig.AssemblerParams) {
 		nonNilRoles = append(nonNilRoles, Assembler)
 	}
 
@@ -250,10 +250,26 @@ func validateNodeLocalConfigParams(nodeLocalConfig *NodeLocalConfig) (string, er
 	}
 
 	if len(nonNilRoles) > 1 {
-		return "", fmt.Errorf("node local config is not valid, multiple params were set %v", nonNilRoles)
+		return "", fmt.Errorf("node local config is not valid, multiple params were set: %v", nonNilRoles)
 	}
 
 	return nonNilRoles[0], nil
+}
+
+func isEmptyRouterParams(routerParams *RouterParams) bool {
+	return routerParams != nil && *routerParams == RouterParams{}
+}
+
+func isEmptyBatcherParams(batcherParams *BatcherParams) bool {
+	return batcherParams != nil && *batcherParams == BatcherParams{}
+}
+
+func isEmptyConsensusParams(consensusParams *ConsensusParams) bool {
+	return consensusParams != nil && *consensusParams == ConsensusParams{}
+}
+
+func isEmptyAssemblerParams(assemblerParams *AssemblerParams) bool {
+	return assemblerParams != nil && *assemblerParams == AssemblerParams{}
 }
 
 func loadTLSCryptoConfig(tlsConfig *TLSConfigYaml) (*TLSConfig, error) {

--- a/config/local_config_test.go
+++ b/config/local_config_test.go
@@ -52,7 +52,7 @@ func TestLoadARMALocalConfigAndCrypto(t *testing.T) {
 	// 3.
 	for i := 1; i <= len(networkLocalConfig.PartiesLocalConfig); i++ {
 		configPath := path.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_router.yaml")
-		routerLocalConfigLoaded, err := config.LoadLocalConfig(configPath)
+		routerLocalConfigLoaded, role, err := config.LoadLocalConfig(configPath)
 		require.NoError(t, err)
 		require.NotNil(t, routerLocalConfigLoaded)
 		require.NotNil(t, routerLocalConfigLoaded.NodeLocalConfig)
@@ -60,31 +60,35 @@ func TestLoadARMALocalConfigAndCrypto(t *testing.T) {
 		require.NotNil(t, routerLocalConfigLoaded.ClusterConfig)
 		require.Equal(t, routerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.Enabled, true)
 		require.Equal(t, routerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.ClientAuthRequired, true)
+		require.Equal(t, role, "Router")
 
 		for j := 1; j <= len(networkLocalConfig.PartiesLocalConfig[i-1].BatchersLocalConfig); j++ {
 			configPath = path.Join(dir, "config", fmt.Sprintf("party%d", i), fmt.Sprintf("local_config_batcher%d.yaml", j))
-			batcherLocalConfigLoaded, err := config.LoadLocalConfig(configPath)
+			batcherLocalConfigLoaded, role, err := config.LoadLocalConfig(configPath)
 			require.NoError(t, err)
 			require.NotNil(t, batcherLocalConfigLoaded.NodeLocalConfig)
 			require.NotNil(t, batcherLocalConfigLoaded.TLSConfig)
 			require.NotNil(t, batcherLocalConfigLoaded.ClusterConfig)
+			require.Equal(t, role, "Batcher")
 		}
 
 		configPath = path.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_consenter.yaml")
-		consenterLocalConfigLoaded, err := config.LoadLocalConfig(configPath)
+		consenterLocalConfigLoaded, role, err := config.LoadLocalConfig(configPath)
 		require.NoError(t, err)
 		require.NotNil(t, consenterLocalConfigLoaded.NodeLocalConfig)
 		require.NotNil(t, consenterLocalConfigLoaded.TLSConfig)
 		require.NotNil(t, consenterLocalConfigLoaded.ClusterConfig)
+		require.Equal(t, role, "Consensus")
 
 		configPath = path.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_assembler.yaml")
-		assemblerLocalConfigLoaded, err := config.LoadLocalConfig(configPath)
+		assemblerLocalConfigLoaded, role, err := config.LoadLocalConfig(configPath)
 		require.NoError(t, err)
 		require.NotNil(t, assemblerLocalConfigLoaded.NodeLocalConfig)
 		require.NotNil(t, assemblerLocalConfigLoaded.TLSConfig)
 		require.NotNil(t, assemblerLocalConfigLoaded.ClusterConfig)
 		require.Equal(t, assemblerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.Enabled, true)
 		require.Equal(t, assemblerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.ClientAuthRequired, true)
+		require.Equal(t, role, "Assembler")
 	}
 }
 

--- a/config/local_config_test.go
+++ b/config/local_config_test.go
@@ -8,14 +8,15 @@ package config_test
 
 import (
 	"fmt"
+	"path"
+	"testing"
+
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/config"
 	"github.com/hyperledger/fabric-x-orderer/config/generate"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/stretchr/testify/require"
-	"path"
-	"testing"
 )
 
 func TestLocalConfigLoadSingleYaml(t *testing.T) {
@@ -101,7 +102,7 @@ func TestLoadLocalConfigYaml_Errors(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoadLocalConfigYaml_MultipleRoles(t *testing.T) {
+func TestLoadLocalConfigYaml_MultipleOrMissingRoles(t *testing.T) {
 	dir := t.TempDir()
 	require.DirExists(t, dir)
 

--- a/config/local_config_test.go
+++ b/config/local_config_test.go
@@ -8,16 +8,14 @@ package config_test
 
 import (
 	"fmt"
-	"path"
-	"testing"
-
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/config"
 	"github.com/hyperledger/fabric-x-orderer/config/generate"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
-
 	"github.com/stretchr/testify/require"
+	"path"
+	"testing"
 )
 
 func TestLocalConfigLoadSingleYaml(t *testing.T) {
@@ -60,7 +58,7 @@ func TestLoadARMALocalConfigAndCrypto(t *testing.T) {
 		require.NotNil(t, routerLocalConfigLoaded.ClusterConfig)
 		require.Equal(t, routerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.Enabled, true)
 		require.Equal(t, routerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.ClientAuthRequired, true)
-		require.Equal(t, role, "Router")
+		require.Equal(t, role, config.Router)
 
 		for j := 1; j <= len(networkLocalConfig.PartiesLocalConfig[i-1].BatchersLocalConfig); j++ {
 			configPath = path.Join(dir, "config", fmt.Sprintf("party%d", i), fmt.Sprintf("local_config_batcher%d.yaml", j))
@@ -69,7 +67,7 @@ func TestLoadARMALocalConfigAndCrypto(t *testing.T) {
 			require.NotNil(t, batcherLocalConfigLoaded.NodeLocalConfig)
 			require.NotNil(t, batcherLocalConfigLoaded.TLSConfig)
 			require.NotNil(t, batcherLocalConfigLoaded.ClusterConfig)
-			require.Equal(t, role, "Batcher")
+			require.Equal(t, role, config.Batcher)
 		}
 
 		configPath = path.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_consenter.yaml")
@@ -78,7 +76,7 @@ func TestLoadARMALocalConfigAndCrypto(t *testing.T) {
 		require.NotNil(t, consenterLocalConfigLoaded.NodeLocalConfig)
 		require.NotNil(t, consenterLocalConfigLoaded.TLSConfig)
 		require.NotNil(t, consenterLocalConfigLoaded.ClusterConfig)
-		require.Equal(t, role, "Consensus")
+		require.Equal(t, role, config.Consensus)
 
 		configPath = path.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_assembler.yaml")
 		assemblerLocalConfigLoaded, role, err := config.LoadLocalConfig(configPath)
@@ -88,7 +86,7 @@ func TestLoadARMALocalConfigAndCrypto(t *testing.T) {
 		require.NotNil(t, assemblerLocalConfigLoaded.ClusterConfig)
 		require.Equal(t, assemblerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.Enabled, true)
 		require.Equal(t, assemblerLocalConfigLoaded.NodeLocalConfig.GeneralConfig.TLSConfig.ClientAuthRequired, true)
-		require.Equal(t, role, "Assembler")
+		require.Equal(t, role, config.Assembler)
 	}
 }
 
@@ -101,4 +99,64 @@ func TestLoadLocalConfigYaml_Errors(t *testing.T) {
 	require.Nil(t, res)
 	require.EqualError(t, err, "open File_not_exists: no such file or directory")
 	require.Error(t, err)
+}
+
+func TestLoadLocalConfigYaml_MultipleRoles(t *testing.T) {
+	dir := t.TempDir()
+	require.DirExists(t, dir)
+
+	// Create local config files
+	networkConfig := testutil.GenerateNetworkConfig(t, "mTLS", "mTLS")
+	err := armageddon.GenerateCryptoConfig(&networkConfig, dir)
+	require.NoError(t, err)
+
+	networkLocalConfig, err := generate.CreateArmaLocalConfig(networkConfig, dir, dir)
+	require.NoError(t, err)
+	require.NotNil(t, networkLocalConfig)
+
+	// Override consenter params - add router params
+	consenterLocalConfig := networkLocalConfig.PartiesLocalConfig[0].ConsenterLocalConfig
+	consenterLocalConfig.RouterParams = &config.RouterParams{
+		NumberOfConnectionsPerBatcher:       5,
+		NumberOfStreamsPerConnection:        5,
+		ClientSignatureVerificationRequired: false,
+	}
+
+	configPath := path.Join(dir, "config", "party1", "local_config_consenter.yaml")
+	err = utils.WriteToYAML(consenterLocalConfig, configPath)
+	require.NoError(t, err)
+
+	consenterLocalConfigLoaded, role, err := config.LoadLocalConfig(configPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "node local config is not valid, multiple params were set: [Router Consensus]")
+	require.Equal(t, role, "")
+	require.Nil(t, consenterLocalConfigLoaded)
+
+	// Override consenter params - clean router params and add empty consensus params
+	networkLocalConfig.PartiesLocalConfig[0].ConsenterLocalConfig.ConsensusParams = &config.ConsensusParams{}
+	networkLocalConfig.PartiesLocalConfig[0].ConsenterLocalConfig.RouterParams = nil
+
+	err = utils.WriteToYAML(consenterLocalConfig, configPath)
+	require.NoError(t, err)
+
+	consenterLocalConfigLoaded, role, err = config.LoadLocalConfig(configPath)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "node local config is not valid, node params are missing")
+	require.Equal(t, role, "")
+	require.Nil(t, consenterLocalConfigLoaded)
+
+	// Override consenter params - nil params
+	networkLocalConfig.PartiesLocalConfig[0].ConsenterLocalConfig.ConsensusParams = nil
+	networkLocalConfig.PartiesLocalConfig[0].ConsenterLocalConfig.RouterParams = nil
+
+	err = utils.WriteToYAML(consenterLocalConfig, configPath)
+	require.NoError(t, err)
+
+	consenterLocalConfigLoaded, role, err = config.LoadLocalConfig(configPath)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "node local config is not valid, node params are missing")
+	require.Equal(t, role, "")
+	require.Nil(t, consenterLocalConfigLoaded)
 }

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -71,6 +71,7 @@ type RouterNodeConfig struct {
 	TLSCertificateFile RawBytes
 	TLSPrivateKeyFile  RawBytes
 	ListenAddress      string
+	ConfigStorePath    string
 	// Shared config
 	Shards                              []ShardInfo
 	NumOfConnectionsForBatcher          int

--- a/node/router/router_test.go
+++ b/node/router/router_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -601,12 +602,16 @@ func createAndStartRouter(t *testing.T, partyID types.PartyID, ca tlsgen.CA, bat
 	configtxValidator.ChannelIDReturns("arma")
 	bundle.ConfigtxValidatorReturns(configtxValidator)
 
+	configStore, err := os.MkdirTemp("", fmt.Sprintf("config-store-router%d", partyID))
+	require.NoError(t, err)
+
 	conf := &config.RouterNodeConfig{
 		PartyID:                             partyID,
 		TLSCertificateFile:                  ckp.Cert,
 		UseTLS:                              useTLS,
 		TLSPrivateKeyFile:                   ckp.Key,
 		ListenAddress:                       "127.0.0.1:0",
+		ConfigStorePath:                     configStore,
 		ClientAuthRequired:                  clientAuthRequired,
 		Shards:                              shards,
 		RequestMaxBytes:                     1 << 10,

--- a/node/server/arma.go
+++ b/node/server/arma.go
@@ -79,7 +79,7 @@ func stopSignalListen(node NodeStopper, logger *flogging.FabricLogger, nodeAddr 
 
 func launchAssembler(stop chan struct{}) func(configFile *os.File) {
 	return func(configFile *os.File) {
-		configContent, genesisBlock, err := config.ReadConfig(configFile.Name())
+		configContent, genesisBlock, err := config.ReadConfig(configFile.Name(), flogging.MustGetLogger("ReadConfigAssembler"))
 		if err != nil {
 			panic(fmt.Sprintf("error launching assembler, err: %s", err))
 		}
@@ -110,7 +110,7 @@ func launchAssembler(stop chan struct{}) func(configFile *os.File) {
 
 func launchConsensus(stop chan struct{}) func(configFile *os.File) {
 	return func(configFile *os.File) {
-		configContent, genesisBlock, err := config.ReadConfig(configFile.Name())
+		configContent, genesisBlock, err := config.ReadConfig(configFile.Name(), flogging.MustGetLogger("ReadConfigConsensus"))
 		if err != nil {
 			panic(fmt.Sprintf("error launching consensus, err: %s", err))
 		}
@@ -152,7 +152,7 @@ func launchConsensus(stop chan struct{}) func(configFile *os.File) {
 
 func launchBatcher(stop chan struct{}) func(configFile *os.File) {
 	return func(configFile *os.File) {
-		config, _, err := config.ReadConfig(configFile.Name())
+		config, _, err := config.ReadConfig(configFile.Name(), flogging.MustGetLogger("ReadConfigBatcher"))
 		if err != nil {
 			panic(fmt.Sprintf("error launching batcher, err: %s", err))
 		}
@@ -194,7 +194,7 @@ func launchBatcher(stop chan struct{}) func(configFile *os.File) {
 
 func launchRouter(stop chan struct{}) func(configFile *os.File) {
 	return func(configFile *os.File) {
-		conf, lastConfigBlock, err := config.ReadConfig(configFile.Name())
+		conf, lastConfigBlock, err := config.ReadConfig(configFile.Name(), flogging.MustGetLogger("ReadConfigRouter"))
 		if err != nil {
 			panic(fmt.Sprintf("error launching router, err: %s", err))
 		}

--- a/node/server/arma.go
+++ b/node/server/arma.go
@@ -194,12 +194,12 @@ func launchBatcher(stop chan struct{}) func(configFile *os.File) {
 
 func launchRouter(stop chan struct{}) func(configFile *os.File) {
 	return func(configFile *os.File) {
-		conf, genesisBlock, err := config.ReadConfig(configFile.Name())
+		conf, lastConfigBlock, err := config.ReadConfig(configFile.Name())
 		if err != nil {
 			panic(fmt.Sprintf("error launching router, err: %s", err))
 		}
 
-		routerConf := conf.ExtractRouterConfig(genesisBlock)
+		routerConf := conf.ExtractRouterConfig(lastConfigBlock)
 
 		var routerLogger *flogging.FabricLogger
 		if testLogger != nil {

--- a/node/server/arma_test.go
+++ b/node/server/arma_test.go
@@ -194,9 +194,15 @@ func TestLaunchArmaNode(t *testing.T) {
 		testutil.EditLocalMSPDirForNode(t, configPath, mspPath)
 		err := editBatchersInSharedConfig(dir, 4, 2)
 		require.NoError(t, err)
+		testLogger = flogging.MustGetLogger("arma")
+
+		originalLogger := testLogger
+		defer func() {
+			testLogger = originalLogger
+		}()
 
 		// ReadConfig, expect for genesis block
-		_, genesisBlock, err := config.ReadConfig(configPath)
+		_, genesisBlock, err := config.ReadConfig(configPath, testLogger)
 		require.NoError(t, err)
 		require.NotNil(t, genesisBlock)
 
@@ -216,7 +222,7 @@ func TestLaunchArmaNode(t *testing.T) {
 		err = configStore.Add(newConfigBlock)
 		require.NoError(t, err)
 
-		_, lastConfigBlock, err := config.ReadConfig(configPath)
+		_, lastConfigBlock, err := config.ReadConfig(configPath, testLogger)
 		require.NoError(t, err)
 		require.NotNil(t, lastConfigBlock)
 

--- a/node/server/arma_test.go
+++ b/node/server/arma_test.go
@@ -215,10 +215,10 @@ func TestLaunchArmaNode(t *testing.T) {
 		require.Equal(t, genesisBlock.Header.Number, uint64(0))
 		require.Equal(t, listBlocks[0].Header.Number, uint64(0))
 
-		// Add a fake block to the config store
+		// Add a fake block with block number 5 to the config store
 		// ReadConfig again, expect for the fake block to be the last block
 		newConfigBlock := genesisBlock
-		newConfigBlock.Header.Number = 1
+		newConfigBlock.Header.Number = 5
 		err = configStore.Add(newConfigBlock)
 		require.NoError(t, err)
 
@@ -229,8 +229,8 @@ func TestLaunchArmaNode(t *testing.T) {
 		listBlocks, err = configStore.ListBlocks()
 		require.NoError(t, err)
 		require.Equal(t, len(listBlocks), 2)
-		require.Equal(t, genesisBlock.Header.Number, uint64(1))
-		require.Equal(t, listBlocks[1].Header.Number, uint64(1))
+		require.Equal(t, listBlocks[0].Header.Number, uint64(0))
+		require.Equal(t, listBlocks[1].Header.Number, uint64(5))
 	})
 }
 

--- a/test/sigverify_test.go
+++ b/test/sigverify_test.go
@@ -79,7 +79,7 @@ func TestSubmitReceiveAndVerifySignaturesAssemblerBlocks(t *testing.T) {
 	logger := testutil.CreateLogger(t, 0)
 
 	// 4.
-	conf, _, err := config.ReadConfig(filepath.Join(dir, "config/party1/local_config_consenter.yaml"))
+	conf, _, err := config.ReadConfig(filepath.Join(dir, "config/party1/local_config_consenter.yaml"), logger)
 	assert.NoError(t, err)
 	consenterInfos := conf.ExtractConsenters()
 

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -98,8 +98,12 @@ func createRouters(t *testing.T, num int, batcherInfos []nodeconfig.BatcherInfo,
 		configtxValidator.ChannelIDReturns("arma")
 		bundle.ConfigtxValidatorReturns(configtxValidator)
 
+		configStore, err := os.MkdirTemp("", fmt.Sprintf("config-store-router%d", i))
+		require.NoError(t, err)
+
 		config := &nodeconfig.RouterNodeConfig{
 			ListenAddress:      "0.0.0.0:0",
+			ConfigStorePath:    configStore,
 			TLSPrivateKeyFile:  kp.Key,
 			TLSCertificateFile: kp.Cert,
 			PartyID:            types.PartyID(i + 1),


### PR DESCRIPTION
issue #204 #205 

1. ReadConfig initializes the shared configuration for routers and batchers by loading the last block from the config store if it exists. If not, it initializes the shared configuration from the genesis block and adds the genesis block to the config store.
2. Test ReadConfig functionality
3. Init config store in router