### PR TITLE
add bundle and sig filter to batcher

### DIFF
--- a/node/batcher/batcher_test.go
+++ b/node/batcher/batcher_test.go
@@ -8,15 +8,14 @@ package batcher_test
 
 import (
 	"context"
-	"encoding/binary"
 	"testing"
 	"time"
 
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
-	protos "github.com/hyperledger/fabric-x-orderer/node/protos/comm"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/grpclog"
@@ -42,9 +41,7 @@ func TestBatcherRun(t *testing.T) {
 	batchers, loggers, configs, clean := createBatchers(t, numParties, shardID, batcherNodes, batchersInfo, consentersInfo, stubConsenters)
 	defer clean()
 
-	req := make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(1))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{1}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(1) == uint64(1) && batchers[1].Ledger.Height(1) == uint64(1)
@@ -58,9 +55,7 @@ func TestBatcherRun(t *testing.T) {
 	require.Equal(t, types.PartyID(1), ce.BAF.Primary())
 	require.Equal(t, types.BatchSequence(0), ce.BAF.Seq())
 
-	req2 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req2, uint64(2))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req2})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{2}))
 
 	require.Eventually(t, func() bool {
 		return batchers[2].Ledger.Height(1) == uint64(2) && batchers[3].Ledger.Height(1) == uint64(2)
@@ -98,9 +93,7 @@ func TestBatcherRun(t *testing.T) {
 	batchers[3] = recoverBatcher(t, ca, loggers[3], configs[3], batcherNodes[3], stubConsenters[3])
 	stubConsenters[3].UpdateState(termChangeState)
 
-	req3 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req3, uint64(3))
-	batchers[1].Submit(context.Background(), &protos.Request{Payload: req3})
+	batchers[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{3}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(2) == uint64(1) && batchers[1].Ledger.Height(2) == uint64(1)
@@ -124,9 +117,7 @@ func TestBatcherRun(t *testing.T) {
 	batchers[1] = recoverBatcher(t, ca, loggers[1], configs[1], batcherNodes[1], stubConsenters[1])
 	stubConsenters[1].UpdateState(termChangeState)
 
-	req4 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req4, uint64(4))
-	batchers[1].Submit(context.Background(), &protos.Request{Payload: req4})
+	batchers[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{4}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(2) == uint64(2) && batchers[1].Ledger.Height(2) == uint64(2) && batchers[3].Ledger.Height(2) == uint64(2)
@@ -143,9 +134,7 @@ func TestBatcherRun(t *testing.T) {
 	// stop secondary and recover after a batch
 	batchers[2].Stop()
 
-	req5 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req5, uint64(5))
-	batchers[1].Submit(context.Background(), &protos.Request{Payload: req5})
+	batchers[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{5}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(2) == uint64(3) && batchers[1].Ledger.Height(2) == uint64(3) && batchers[3].Ledger.Height(2) == uint64(3)
@@ -180,9 +169,7 @@ func TestBatcherRun(t *testing.T) {
 	require.Equal(t, uint64(0), batchers[2].Ledger.Height(3))
 	require.Equal(t, uint64(0), batchers[3].Ledger.Height(3))
 
-	req6 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req6, uint64(6))
-	batchers[2].Submit(context.Background(), &protos.Request{Payload: req6})
+	batchers[2].Submit(context.Background(), tx.CreateStructuredRequest([]byte{6}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(3) == uint64(1) && batchers[2].Ledger.Height(3) == uint64(1) && batchers[3].Ledger.Height(3) == uint64(1)
@@ -213,9 +200,7 @@ func TestBatcherComplainAndReqFwd(t *testing.T) {
 	batchers, loggers, configs, clean := createBatchers(t, numParties, shardID, batcherNodes, batchersInfo, consentersInfo, stubConsenters)
 	defer clean()
 
-	req := make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(1))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{1}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(1) == uint64(1) && batchers[1].Ledger.Height(1) == uint64(1)
@@ -236,10 +221,9 @@ func TestBatcherComplainAndReqFwd(t *testing.T) {
 	batchers[0].Stop()
 
 	// submit request to other batchers
-	req2 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req2, uint64(2))
-	batchers[1].Submit(context.Background(), &protos.Request{Payload: req2})
-	batchers[2].Submit(context.Background(), &protos.Request{Payload: req2})
+	req2 := tx.CreateStructuredRequest([]byte{2})
+	batchers[1].Submit(context.Background(), req2)
+	batchers[2].Submit(context.Background(), req2)
 
 	// wait for complaints
 	require.Eventually(t, func() bool {
@@ -267,7 +251,7 @@ func TestBatcherComplainAndReqFwd(t *testing.T) {
 
 	// make sure req2 did not disappear
 	require.Equal(t, 1, len(batchers[1].Ledger.RetrieveBatchByNumber(2, 0).Requests()))
-	rawReq, err := proto.Marshal(&protos.Request{Payload: req2})
+	rawReq, err := proto.Marshal(req2)
 	require.NoError(t, err)
 	require.Equal(t, rawReq, batchers[1].Ledger.RetrieveBatchByNumber(2, 0).Requests()[0])
 
@@ -283,9 +267,7 @@ func TestBatcherComplainAndReqFwd(t *testing.T) {
 	}
 
 	// submit another request only to a secondary
-	req3 := make([]byte, 8)
-	binary.BigEndian.PutUint64(req3, uint64(4))
-	batchers[2].Submit(context.Background(), &protos.Request{Payload: req3})
+	batchers[2].Submit(context.Background(), tx.CreateStructuredRequest([]byte{3}))
 
 	// after a timeout the request is forwarded
 	require.Eventually(t, func() bool {
@@ -316,9 +298,7 @@ func TestControlEventBroadcasterWaitsForQuorum(t *testing.T) {
 	defer clean()
 
 	// submit the first request and verify it was received
-	req := make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(1))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{1}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(1) == uint64(1) && batchers[1].Ledger.Height(1) == uint64(1)
@@ -332,9 +312,7 @@ func TestControlEventBroadcasterWaitsForQuorum(t *testing.T) {
 	stubConsenters[0].StopNet()
 
 	// submit the second request
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(2))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{2}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(1) == uint64(2) && batchers[1].Ledger.Height(1) == uint64(2)
@@ -348,9 +326,7 @@ func TestControlEventBroadcasterWaitsForQuorum(t *testing.T) {
 	stubConsenters[1].StopNet()
 
 	// submit another request, batch will be created but waiting for quorum
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(3))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{3}))
 
 	require.Eventually(t, func() bool {
 		return batchers[0].Ledger.Height(1) == uint64(3) && batchers[1].Ledger.Height(1) == uint64(3)
@@ -361,9 +337,7 @@ func TestControlEventBroadcasterWaitsForQuorum(t *testing.T) {
 	}, 30*time.Second, 10*time.Millisecond)
 
 	// submit a fourth request – batcher should wait until the previous batch reaches quorum
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(4))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{4}))
 
 	time.Sleep(5 * time.Second)
 

--- a/node/batcher/primary_connector_test.go
+++ b/node/batcher/primary_connector_test.go
@@ -8,7 +8,6 @@ package batcher_test
 
 import (
 	"context"
-	"encoding/binary"
 	"testing"
 	"time"
 
@@ -16,7 +15,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/node/batcher"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
-	protos "github.com/hyperledger/fabric-x-orderer/node/protos/comm"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
@@ -46,9 +45,7 @@ func TestPrimaryConnector(t *testing.T) {
 	connector.ConnectToPrimary()
 
 	// send request via normal submit
-	req := make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(1))
-	batchers[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{1}))
 
 	// make sure request was batched
 	require.Eventually(t, func() bool {
@@ -56,10 +53,8 @@ func TestPrimaryConnector(t *testing.T) {
 	}, 30*time.Second, 10*time.Millisecond)
 
 	// send request to primary via connector
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(2))
-	reqBytes, _ := proto.Marshal(&protos.Request{Payload: req})
-	connector.SendReq(reqBytes)
+	req2, _ := proto.Marshal(tx.CreateStructuredRequest([]byte{2}))
+	connector.SendReq(req2)
 
 	// make sure request was batched
 	require.Eventually(t, func() bool {
@@ -86,9 +81,7 @@ func TestPrimaryConnector(t *testing.T) {
 	connector.ConnectToNewPrimary(2)
 
 	// send request via normal submit
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(3))
-	batchers[1].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{3}))
 
 	// make sure request was batched
 	require.Eventually(t, func() bool {
@@ -96,10 +89,8 @@ func TestPrimaryConnector(t *testing.T) {
 	}, 30*time.Second, 10*time.Millisecond)
 
 	// send request via the connector to a new primary
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(4))
-	reqBytes, _ = proto.Marshal(&protos.Request{Payload: req})
-	connector.SendReq(reqBytes)
+	req4, _ := proto.Marshal(tx.CreateStructuredRequest([]byte{4}))
+	connector.SendReq(req4)
 
 	// make sure request was batched
 	require.Eventually(t, func() bool {

--- a/node/batcher/requests_inspector_verifier.go
+++ b/node/batcher/requests_inspector_verifier.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"runtime"
 
+	"github.com/hyperledger/fabric-x-common/common/policies"
 	"github.com/hyperledger/fabric-x-orderer/common/requestfilter"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
@@ -62,8 +63,7 @@ func createBatcherRulesVerifier(config *config.BatcherNodeConfig) *requestfilter
 	rv := requestfilter.NewRulesVerifier(nil)
 	rv.AddRule(requestfilter.PayloadNotEmptyRule{})
 	rv.AddRule(requestfilter.NewMaxSizeFilter(config))
-	// TODO - add policy and sig filter
-	// rv.AddRule(requestfilter.NewSigFilter(config, policies.ChannelWriters))
+	rv.AddRule(requestfilter.NewSigFilter(config, policies.ChannelWriters))
 	return rv
 }
 

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -128,6 +128,7 @@ type BatcherNodeConfig struct {
 	BatchCreationTimeout                time.Duration
 	BatchSequenceGap                    types.BatchSequence
 	ClientSignatureVerificationRequired bool
+	Bundle                              channelconfig.Resources
 	MetricsLogInterval                  time.Duration
 }
 

--- a/node/config/utils.go
+++ b/node/config/utils.go
@@ -33,11 +33,11 @@ func (c *BatcherNodeConfig) GetClientSignatureVerificationRequired() bool {
 }
 
 func (c *BatcherNodeConfig) GetChannelID() string {
-	return "" // TODO
+	return c.Bundle.ConfigtxValidator().ChannelID()
 }
 
 func (c *BatcherNodeConfig) GetPolicyManager() policies.Manager {
-	return nil // TODO
+	return c.Bundle.PolicyManager()
 }
 
 func (rfc *RouterNodeConfig) GetRequestMaxBytes() uint64 {

--- a/test/batcher_consenter_test.go
+++ b/test/batcher_consenter_test.go
@@ -8,7 +8,6 @@ package test
 
 import (
 	"context"
-	"encoding/binary"
 	"testing"
 	"time"
 
@@ -16,7 +15,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
-	protos "github.com/hyperledger/fabric-x-orderer/node/protos/comm"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 
 	"github.com/stretchr/testify/require"
 )
@@ -53,9 +52,7 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	}
 
 	// Submit request to primary in shard 0
-	req := make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(0))
-	batchers0[0].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers0[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{1}))
 
 	// Verify the batchers created a batch in shard 0
 	require.Eventually(t, func() bool {
@@ -63,9 +60,7 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// Submit a request to primary of shard 1
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint32(req, uint32(4))
-	batchers1[1].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers1[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{11}))
 
 	// Verify the batchers created a batch in shard 1
 	require.Eventually(t, func() bool {
@@ -81,10 +76,8 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	batchers0[0].Stop()
 
 	// Submit request to other batchers in shard 0
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(3))
-	batchers0[1].Submit(context.Background(), &protos.Request{Payload: req})
-	batchers0[2].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers0[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{22}))
+	batchers0[2].Submit(context.Background(), tx.CreateStructuredRequest([]byte{22}))
 
 	// Validate a term change occurred in shard 0
 	require.Eventually(t, func() bool {
@@ -97,9 +90,7 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// Submit a request to primary of shard 1
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(7))
-	batchers1[1].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers1[1].Submit(context.Background(), tx.CreateStructuredRequest([]byte{3}))
 
 	// Verify the batchers created a batch in shard 1
 	require.Eventually(t, func() bool {
@@ -119,13 +110,8 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	}
 
 	// Submit another request only to a secondary in shard 0 and shard 1
-	req = make([]byte, 8)
-	binary.BigEndian.PutUint64(req, uint64(8))
-	batchers0[2].Submit(context.Background(), &protos.Request{Payload: req})
-
-	req = make([]byte, 9)
-	binary.BigEndian.PutUint64(req, uint64(10))
-	batchers1[2].Submit(context.Background(), &protos.Request{Payload: req})
+	batchers0[2].Submit(context.Background(), tx.CreateStructuredRequest([]byte{9}))
+	batchers1[2].Submit(context.Background(), tx.CreateStructuredRequest([]byte{8}))
 
 	// Verify the batchers created batches in shard 0 and shard 1
 	require.Eventually(t, func() bool {

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -193,27 +193,34 @@ func createBatchersForShard(t *testing.T, num int, batcherNodes []*node, shards 
 		key, err := x509.MarshalPKCS8PrivateKey(batcherNodes[i].sk)
 		require.NoError(t, err)
 
+		bundle := &configMocks.FakeConfigResources{}
+		configtxValidator := &policyMocks.FakeConfigtxValidator{}
+		configtxValidator.ChannelIDReturns("arma")
+		bundle.ConfigtxValidatorReturns(configtxValidator)
+
 		batcherConf := &nodeconfig.BatcherNodeConfig{
-			ListenAddress:         "0.0.0.0:0",
-			Shards:                shards,
-			ShardId:               shardID,
-			ConfigStorePath:       t.TempDir(),
-			PartyId:               types.PartyID(i + 1),
-			Consenters:            consenterInfos,
-			TLSPrivateKeyFile:     batcherNodes[i].TLSKey,
-			TLSCertificateFile:    batcherNodes[i].TLSCert,
-			SigningPrivateKey:     nodeconfig.RawBytes(pem.EncodeToMemory(&pem.Block{Bytes: key})),
-			Directory:             dir,
-			MemPoolMaxSize:        1000000,
-			BatchMaxSize:          10000,
-			BatchMaxBytes:         1024 * 1024 * 10,
-			RequestMaxBytes:       1024 * 1024,
-			SubmitTimeout:         time.Millisecond * 500,
-			FirstStrikeThreshold:  time.Second * 10,
-			SecondStrikeThreshold: time.Second * 10,
-			AutoRemoveTimeout:     time.Second * 10,
-			BatchCreationTimeout:  time.Millisecond * 500,
-			BatchSequenceGap:      types.BatchSequence(10),
+			ListenAddress:                       "0.0.0.0:0",
+			Shards:                              shards,
+			ShardId:                             shardID,
+			ConfigStorePath:                     t.TempDir(),
+			PartyId:                             types.PartyID(i + 1),
+			Consenters:                          consenterInfos,
+			TLSPrivateKeyFile:                   batcherNodes[i].TLSKey,
+			TLSCertificateFile:                  batcherNodes[i].TLSCert,
+			SigningPrivateKey:                   nodeconfig.RawBytes(pem.EncodeToMemory(&pem.Block{Bytes: key})),
+			Directory:                           dir,
+			MemPoolMaxSize:                      1000000,
+			BatchMaxSize:                        10000,
+			BatchMaxBytes:                       1024 * 1024 * 10,
+			RequestMaxBytes:                     1024 * 1024,
+			SubmitTimeout:                       time.Millisecond * 500,
+			FirstStrikeThreshold:                time.Second * 10,
+			SecondStrikeThreshold:               time.Second * 10,
+			AutoRemoveTimeout:                   time.Second * 10,
+			BatchCreationTimeout:                time.Millisecond * 500,
+			BatchSequenceGap:                    types.BatchSequence(10),
+			ClientSignatureVerificationRequired: false,
+			Bundle:                              bundle,
 		}
 
 		configs = append(configs, batcherConf)


### PR DESCRIPTION
- add bundle to batcher node config
- add sig filter to request verifier in batcher
- fix tx-test-utils, so that payload bytes in created requests will be deterministic, and avoid shard-mapping discrepancy 
- fix related tests

related issue: #293 