### PR TITLE
change default values in bft params

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -44,6 +44,8 @@ var DefaultArmaBFTConfig = func() smartbft_types.Configuration {
 	config.RequestForwardTimeout = time.Second * 10
 	config.DecisionsPerLeader = 0
 	config.LeaderRotation = false
+	config.IncomingMessageBufferSize = 10000
+	config.RequestPoolSize = 50000
 
 	return config
 }

--- a/config/sample/test-sample/bootstrap/shared_config.yaml
+++ b/config/sample/test-sample/bootstrap/shared_config.yaml
@@ -126,8 +126,8 @@ Consensus:
     requestbatchmaxcount: 100
     requestbatchmaxbytes: 10485760
     requestbatchmaxinterval: 500ms
-    incomingmessagebuffersize: 200
-    requestpoolsize: 400
+    incomingmessagebuffersize: 10000
+    requestpoolsize: 50000
     requestforwardtimeout: 10s
     requestcomplaintimeout: 20s
     requestautoremovetimeout: 3m0s


### PR DESCRIPTION
Increase the memory pool in the Consenter node by setting higher default parameter values.