### PR TITLE
Flake in comm unit tests

### DIFF
--- a/node/comm/server_test.go
+++ b/node/comm/server_test.go
@@ -918,8 +918,6 @@ func runMutualAuth(t *testing.T, servers []testServer, trustedClients, unTrusted
 }
 
 func TestMutualAuth(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name             string
 		servers          []testServer


### PR DESCRIPTION
The t.parallel causes a flake on some systems.