### PR TITLE
config submitter part 3

### DIFF
--- a/node/router/config_submitter.go
+++ b/node/router/config_submitter.go
@@ -8,6 +8,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,7 +22,7 @@ type ConfigurationSubmitter interface {
 	Start()
 	Stop()
 	// Update() // TODO implement a thread-safe update method for config submitter
-	Forward(tr *TrackedRequest) error
+	Forward(tr *TrackedRequest)
 }
 
 type configSubmitter struct {
@@ -102,6 +103,11 @@ func (cs *configSubmitter) forwardRequest(tr *TrackedRequest) error {
 		feedback.SubmitResponse = resp
 		if err != nil {
 			feedback.err = fmt.Errorf("error forwarding config request to consenter: %v", err)
+		} else {
+			feedback.SubmitResponse = resp
+			if resp.Error != "" {
+				feedback.err = errors.New(resp.Error)
+			}
 		}
 	}
 

--- a/node/router/config_submitter_test.go
+++ b/node/router/config_submitter_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type configSubmitTestSetup struct {
-	stubConsenter   *stubConsenter
+	stubConsenter   *StubConsenter
 	configSubmitter *configSubmitter
 }
 
@@ -38,7 +38,7 @@ func createconfigSubmitTestSetup(t *testing.T) configSubmitTestSetup {
 	ca, err := tlsgen.NewCA()
 	require.NoError(t, err)
 
-	stubConsenter := NewStubConsenter(t, ca, types.PartyID(1), logger)
+	stubConsenter := NewStubConsenter(t, ca, types.PartyID(1))
 
 	ckp, err := ca.NewServerCertKeyPair("127.0.0.1")
 	require.NoError(t, err)

--- a/node/router/router.go
+++ b/node/router/router.go
@@ -45,7 +45,7 @@ type Router struct {
 	verifier         *requestfilter.RulesVerifier
 	stopChan         chan struct{}
 	configStore      *configstore.Store
-	configSubmitter  *configSubmitter
+	configSubmitter  ConfigurationSubmitter
 }
 
 func NewRouter(config *nodeconfig.RouterNodeConfig, logger types.Logger) *Router {
@@ -184,7 +184,7 @@ func (r *Router) Deliver(server orderer.AtomicBroadcast_DeliverServer) error {
 	return fmt.Errorf("not implemented")
 }
 
-func createRouter(shardIDs []types.ShardID, batcherEndpoints map[types.ShardID]string, batcherRootCAs map[types.ShardID][][]byte, rconfig *nodeconfig.RouterNodeConfig, logger types.Logger, verifier *requestfilter.RulesVerifier, configSubmitter *configSubmitter) *Router {
+func createRouter(shardIDs []types.ShardID, batcherEndpoints map[types.ShardID]string, batcherRootCAs map[types.ShardID][][]byte, rconfig *nodeconfig.RouterNodeConfig, logger types.Logger, verifier *requestfilter.RulesVerifier, configSubmitter ConfigurationSubmitter) *Router {
 	if rconfig.NumOfConnectionsForBatcher == 0 {
 		rconfig.NumOfConnectionsForBatcher = config.DefaultRouterParams.NumberOfConnectionsPerBatcher
 	}

--- a/node/router/router_test.go
+++ b/node/router/router_test.go
@@ -41,6 +41,7 @@ func init() {
 type routerTestSetup struct {
 	ca         tlsgen.CA
 	batchers   []*stubBatcher
+	consenter  *router.StubConsenter
 	clientConn *grpc.ClientConn
 	router     *router.Router
 }
@@ -57,6 +58,8 @@ func (r *routerTestSetup) Close() {
 	for _, batcher := range r.batchers {
 		batcher.server.Stop()
 	}
+
+	r.consenter.Stop()
 }
 
 func (r *routerTestSetup) isReconnectComplete() bool {
@@ -83,14 +86,18 @@ func createRouterTestSetup(t *testing.T, partyID types.PartyID, numOfShards int,
 	for _, batcher := range batchers {
 		batcher.Start()
 	}
+	// create and start stub-consenter
+	stubConsenter := router.NewStubConsenter(t, ca, partyID)
+	stubConsenter.Start()
 
 	// create and start router
-	router := createAndStartRouter(t, partyID, ca, batchers, useTLS, clientAuthRequired)
+	router := createAndStartRouter(t, partyID, ca, batchers, &stubConsenter, useTLS, clientAuthRequired)
 
 	return &routerTestSetup{
-		ca:       ca,
-		batchers: batchers,
-		router:   router,
+		ca:        ca,
+		batchers:  batchers,
+		consenter: &stubConsenter,
+		router:    router,
 	}
 }
 
@@ -428,6 +435,81 @@ func TestRequestFilters(t *testing.T) {
 	// 5) send request with invalid signature. Not implemented
 }
 
+// Scenario:
+// 1) Start a client, router and stub consenter
+// 2) Send valid config request, expect response from stub consenter
+func TestConfigSubmitter(t *testing.T) {
+	testSetup := createRouterTestSetup(t, types.PartyID(1), 1, true, false)
+	err := createServerTLSClientConnection(testSetup, testSetup.ca)
+	require.NoError(t, err)
+	require.NotNil(t, testSetup.clientConn)
+
+	defer testSetup.Close()
+
+	err = submitConfigRequest(t, testSetup.clientConn)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return testSetup.consenter.ReceivedMessageCount() == uint32(1)
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestConfigSubmitterConsenterDown(t *testing.T) {
+	testSetup := createRouterTestSetup(t, types.PartyID(1), 1, true, false)
+	err := createServerTLSClientConnection(testSetup, testSetup.ca)
+	require.NoError(t, err)
+	require.NotNil(t, testSetup.clientConn)
+
+	defer testSetup.Close()
+
+	// submit one request, and wait for the response
+	err = submitConfigRequest(t, testSetup.clientConn)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return testSetup.consenter.ReceivedMessageCount() == uint32(1)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// stop the consenter and wait until it is down
+	testSetup.consenter.Stop()
+	time.Sleep(250 * time.Millisecond)
+
+	// wait and restart the consenter
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		testSetup.consenter.Restart()
+	}()
+
+	// meanwhile, forward another request
+	err = submitConfigRequest(t, testSetup.clientConn)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return testSetup.consenter.ReceivedMessageCount() == uint32(2)
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func submitConfigRequest(t *testing.T, conn *grpc.ClientConn) error {
+	cl := ab.NewAtomicBroadcastClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	stream, err := cl.Broadcast(ctx)
+	require.NoError(t, err)
+
+	env := tx.CreateStructuredConfigEnvelope([]byte("123"))
+	err = stream.Send(env)
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, common.Status_INTERNAL_SERVER_ERROR, resp.Status)
+	require.Equal(t, "dummy submit config", resp.Info)
+
+	return nil
+}
+
 func createServerTLSClientConnection(testSetup *routerTestSetup, ca tlsgen.CA) error {
 	cc := comm.ClientConfig{
 		SecOpts: comm.SecureOptions{
@@ -585,7 +667,7 @@ func submitRequest(conn *grpc.ClientConn) error {
 	return nil
 }
 
-func createAndStartRouter(t *testing.T, partyID types.PartyID, ca tlsgen.CA, batchers []*stubBatcher, useTLS bool, clientAuthRequired bool) *router.Router {
+func createAndStartRouter(t *testing.T, partyID types.PartyID, ca tlsgen.CA, batchers []*stubBatcher, consenter *router.StubConsenter, useTLS bool, clientAuthRequired bool) *router.Router {
 	ckp, err := ca.NewServerCertKeyPair("127.0.0.1")
 	require.NoError(t, err)
 
@@ -602,6 +684,8 @@ func createAndStartRouter(t *testing.T, partyID types.PartyID, ca tlsgen.CA, bat
 	configtxValidator.ChannelIDReturns("arma")
 	bundle.ConfigtxValidatorReturns(configtxValidator)
 
+	stubConsenterInfo := config.ConsenterInfo{PartyID: partyID, Endpoint: consenter.GetConsenterEndpoint(), TLSCACerts: []config.RawBytes{ca.CertBytes()}}
+
 	conf := &config.RouterNodeConfig{
 		PartyID:                             partyID,
 		TLSCertificateFile:                  ckp.Cert,
@@ -611,6 +695,7 @@ func createAndStartRouter(t *testing.T, partyID types.PartyID, ca tlsgen.CA, bat
 		ConfigStorePath:                     t.TempDir(),
 		ClientAuthRequired:                  clientAuthRequired,
 		Shards:                              shards,
+		Consenter:                           stubConsenterInfo,
 		RequestMaxBytes:                     1 << 10,
 		ClientSignatureVerificationRequired: false,
 		Bundle:                              bundle,

--- a/node/router/shard_router.go
+++ b/node/router/shard_router.go
@@ -71,7 +71,7 @@ type ShardRouter struct {
 	reconnectRequests            chan reconnectReq
 	closeReconnect               chan bool
 	verifier                     *requestfilter.RulesVerifier
-	configSubmitter              *configSubmitter
+	configSubmitter              ConfigurationSubmitter
 }
 
 func NewShardRouter(l types.Logger,
@@ -82,7 +82,7 @@ func NewShardRouter(l types.Logger,
 	numOfConnectionsForBatcher int,
 	numOfgRPCStreamsPerConnection int,
 	verifier *requestfilter.RulesVerifier,
-	configSubmitter *configSubmitter,
+	configSubmitter ConfigurationSubmitter,
 ) *ShardRouter {
 	cc := comm.ClientConfig{
 		AsyncConnect: false,

--- a/testutil/tx/tx_utils.go
+++ b/testutil/tx/tx_utils.go
@@ -34,8 +34,8 @@ func createPayloadHeader(ch *common.ChannelHeader, sh *common.SignatureHeader) *
 	}
 }
 
-func createStructuredPayload(data []byte) *common.Payload {
-	payloadChannelHeader := createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)
+func createStructuredPayload(data []byte, requestType common.HeaderType) *common.Payload {
+	payloadChannelHeader := createChannelHeader(requestType, 0, "channelID", 0)
 	payloadSignatureHeader := &common.SignatureHeader{
 		Creator: []byte("creator"),
 		Nonce:   []byte("nonce"),
@@ -56,7 +56,16 @@ func deterministicMarshall(msg proto.Message) []byte {
 }
 
 func CreateStructuredEnvelope(data []byte) *common.Envelope {
-	payload := createStructuredPayload(data)
+	payload := createStructuredPayload(data, common.HeaderType_MESSAGE)
+	payloadBytes := deterministicMarshall(payload)
+	return &common.Envelope{
+		Payload:   payloadBytes,
+		Signature: []byte("signature"),
+	}
+}
+
+func CreateStructuredConfigEnvelope(data []byte) *common.Envelope {
+	payload := createStructuredPayload(data, common.HeaderType_CONFIG_UPDATE)
 	payloadBytes := deterministicMarshall(payload)
 	return &common.Envelope{
 		Payload:   payloadBytes,
@@ -65,7 +74,7 @@ func CreateStructuredEnvelope(data []byte) *common.Envelope {
 }
 
 func CreateStructuredRequest(data []byte) *protos.Request {
-	payload := createStructuredPayload(data)
+	payload := createStructuredPayload(data, common.HeaderType_MESSAGE)
 	payloadBytes := deterministicMarshall(payload)
 	return &protos.Request{
 		Payload:   payloadBytes,


### PR DESCRIPTION
- check request type in stream, and then forward to batcher or config-submitter
- add config submitter tests to router
- fix some other tests

issue: https://github.com/hyperledger/fabric-x-orderer/issues/192