### PR TITLE
Improve assembler ledger API

### DIFF
--- a/node/assembler/assembler.go
+++ b/node/assembler/assembler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
+	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
 	"github.com/hyperledger/fabric-x-orderer/node/delivery"
 	node_ledger "github.com/hyperledger/fabric-x-orderer/node/ledger"
 
@@ -111,7 +112,13 @@ func NewDefaultAssembler(
 		if genesisBlock == nil {
 			logger.Panicf("Error creating Assembler%d, genesis block is nil", config.PartyId)
 		}
-		al.AppendConfig(genesisBlock, 0)
+		ordInfo := &state.OrderingInformation{
+			CommonBlock: genesisBlock,
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		}
+		al.AppendConfig(ordInfo)
 		logger.Infof("Appended genesis block, header digest: %s", hex.EncodeToString(protoutil.BlockHeaderHash(genesisBlock.GetHeader())))
 	}
 

--- a/node/assembler/collator.go
+++ b/node/assembler/collator.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
@@ -30,7 +29,7 @@ type AssemblerIndex interface {
 
 type AssemblerLedgerWriter interface {
 	Append(batch types.Batch, orderingInfo *state.OrderingInformation)
-	AppendConfig(configBlock *common.Block, decisionNum types.DecisionNum)
+	AppendConfig(orderingInfo *state.OrderingInformation)
 	Close()
 }
 
@@ -71,9 +70,8 @@ func (c *Collator) processOrderedBatchAttestations() {
 
 		if oba.BatchAttestation().Shard() == types.ShardIDConsensus {
 			orderingInfo := oba.OrderingInformation
-			c.Logger.Infof("Config decision: shard: %d, Ordering Info: %s", oba.BatchAttestation().Shard(), oba.OrderingInformation.String())
-			block := orderingInfo.CommonBlock
-			c.Ledger.AppendConfig(block, orderingInfo.DecisionNum)
+			c.Logger.Infof("Config decision: shard: %d, Ordering Info: %s", oba.BatchAttestation().Shard(), orderingInfo.String())
+			c.Ledger.AppendConfig(orderingInfo)
 
 			go c.AssemblerRestarter.SoftStop()
 			// TODO apply new config

--- a/node/assembler/collator_test.go
+++ b/node/assembler/collator_test.go
@@ -247,7 +247,12 @@ func createCollator(t *testing.T, shardCount int, AssemblerRestarter assembler.A
 
 	ledger.Metrics().NewAssemblerLedgerMetrics(monitoring.NewMonitor(monitoring.Endpoint{Host: "127.0.0.1", Port: 0}, t.Name()).Provider, "test_party", testutil.CreateLogger(t, 0))
 
-	ledger.AppendConfig(utils.EmptyGenesisBlock("test"), 0)
+	ledger.AppendConfig(&state.OrderingInformation{
+		CommonBlock: utils.EmptyGenesisBlock("test"),
+		DecisionNum: 0,
+		BatchIndex:  0,
+		BatchCount:  1,
+	})
 
 	ordBARep := make(naiveOrderedBatchAttestationReplicator)
 

--- a/node/ledger/assembler_ledger_test.go
+++ b/node/ledger/assembler_ledger_test.go
@@ -44,7 +44,12 @@ func TestAssemblerLedger_Append(t *testing.T) {
 		al := createAssemblerLedger(t, tmpDir, logger)
 		defer al.Close()
 
-		al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: utils.EmptyGenesisBlock("arma"),
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 		assert.Equal(t, uint64(1), al.GetTxCount())
 		assert.Equal(t, uint64(1), al.Ledger.Height())
 
@@ -70,7 +75,12 @@ func TestAssemblerLedger_Append(t *testing.T) {
 		al := createAssemblerLedger(t, tmpDir, logger)
 		defer al.Close()
 
-		al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: utils.EmptyGenesisBlock("arma"),
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 		assert.Equal(t, uint64(1), al.GetTxCount())
 		assert.Equal(t, uint64(1), al.Ledger.Height())
 
@@ -95,7 +105,12 @@ func TestAssemblerLedger_ReadAndParse(t *testing.T) {
 	al := createAssemblerLedger(t, tmpDir, logger)
 	defer al.Close()
 
-	al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+	al.AppendConfig(&state.OrderingInformation{
+		CommonBlock: utils.EmptyGenesisBlock("arma"),
+		DecisionNum: 0,
+		BatchIndex:  0,
+		BatchCount:  1,
+	})
 	assert.Equal(t, uint64(1), al.GetTxCount())
 	assert.Equal(t, uint64(1), al.Ledger.Height())
 
@@ -149,7 +164,12 @@ func TestAssemblerLedger_LastOrderingInfo(t *testing.T) {
 	al := createAssemblerLedger(t, tmpDir, logger)
 	defer al.Close()
 
-	al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+	al.AppendConfig(&state.OrderingInformation{
+		CommonBlock: utils.EmptyGenesisBlock("arma"),
+		DecisionNum: 0,
+		BatchIndex:  0,
+		BatchCount:  1,
+	})
 	ordInfo, err := al.LastOrderingInfo()
 	require.NoError(t, err)
 	require.NotNil(t, ordInfo)
@@ -179,7 +199,12 @@ func TestAssemblerLedger_BatchFrontier(t *testing.T) {
 		al := createAssemblerLedger(t, tmpDir, logger)
 		defer al.Close()
 
-		al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: utils.EmptyGenesisBlock("arma"),
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 
 		num := 128
 		batches, ordInfos := createBatchesAndOrdInfo(t, num)
@@ -209,7 +234,12 @@ func TestAssemblerLedger_BatchFrontier(t *testing.T) {
 		al := createAssemblerLedger(t, tmpDir, logger)
 		defer al.Close()
 
-		al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: utils.EmptyGenesisBlock("arma"),
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 
 		assert.Equal(t, uint64(1), al.GetTxCount())
 		assert.Equal(t, uint64(1), al.Ledger.Height())
@@ -226,7 +256,12 @@ func TestAssemblerLedger_BatchFrontier(t *testing.T) {
 		al := createAssemblerLedger(t, tmpDir, logger)
 		defer al.Close()
 
-		al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: utils.EmptyGenesisBlock("arma"),
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 
 		num := 8
 		batches, ordInfos := createBatchesAndOrdInfo(t, num)
@@ -254,7 +289,12 @@ func TestAssemblerLedger_BatchFrontier(t *testing.T) {
 		al := createAssemblerLedger(t, tmpDir, logger)
 		defer al.Close()
 
-		al.AppendConfig(utils.EmptyGenesisBlock("arma"), 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: utils.EmptyGenesisBlock("arma"),
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 
 		num := 10
 		batches, ordInfos := createBatchesAndOrdInfo(t, num)
@@ -282,20 +322,35 @@ func TestAssemblerLedger_LastConfig(t *testing.T) {
 		defer al.Close()
 
 		genBlock := utils.EmptyGenesisBlock("arma")
-		al.AppendConfig(genBlock, 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: genBlock,
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 
 		idx, err := node_ledger.GetLastConfigIndexFromAssemblerLedger(al)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), idx)
 
 		confBlock1 := prepareConfigBlock(1, genBlock)
-		al.AppendConfig(confBlock1, 1)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: confBlock1,
+			DecisionNum: 1,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 		idx, err = node_ledger.GetLastConfigIndexFromAssemblerLedger(al)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), idx)
 
 		confBlock2 := prepareConfigBlock(2, confBlock1)
-		al.AppendConfig(confBlock2, 2)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: confBlock2,
+			DecisionNum: 2,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 		idx, err = node_ledger.GetLastConfigIndexFromAssemblerLedger(al)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
@@ -309,7 +364,12 @@ func TestAssemblerLedger_LastConfig(t *testing.T) {
 		defer al.Close()
 
 		genBlock := utils.EmptyGenesisBlock("arma")
-		al.AppendConfig(genBlock, 0)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: genBlock,
+			DecisionNum: 0,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 
 		idx, err := node_ledger.GetLastConfigIndexFromAssemblerLedger(al)
 		require.NoError(t, err)
@@ -329,7 +389,12 @@ func TestAssemblerLedger_LastConfig(t *testing.T) {
 		require.Equal(t, uint64(0), idx)
 
 		confBlock1 := prepareConfigBlock(2, block1)
-		al.AppendConfig(confBlock1, 2)
+		al.AppendConfig(&state.OrderingInformation{
+			CommonBlock: confBlock1,
+			DecisionNum: 2,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 		idx, err = node_ledger.GetLastConfigIndexFromAssemblerLedger(al)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)

--- a/node/ledger/mocks/assembler_ledger.go
+++ b/node/ledger/mocks/assembler_ledger.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/blockledger"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
@@ -19,11 +18,10 @@ type FakeAssemblerLedgerReaderWriter struct {
 		arg1 types.Batch
 		arg2 *state.OrderingInformation
 	}
-	AppendConfigStub        func(*common.Block, types.DecisionNum)
+	AppendConfigStub        func(*state.OrderingInformation)
 	appendConfigMutex       sync.RWMutex
 	appendConfigArgsForCall []struct {
-		arg1 *common.Block
-		arg2 types.DecisionNum
+		arg1 *state.OrderingInformation
 	}
 	BatchFrontierStub        func([]types.ShardID, []types.PartyID, time.Duration) (ledger.BatchFrontier, error)
 	batchFrontierMutex       sync.RWMutex
@@ -123,17 +121,16 @@ func (fake *FakeAssemblerLedgerReaderWriter) AppendArgsForCall(i int) (types.Bat
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeAssemblerLedgerReaderWriter) AppendConfig(arg1 *common.Block, arg2 types.DecisionNum) {
+func (fake *FakeAssemblerLedgerReaderWriter) AppendConfig(arg1 *state.OrderingInformation) {
 	fake.appendConfigMutex.Lock()
 	fake.appendConfigArgsForCall = append(fake.appendConfigArgsForCall, struct {
-		arg1 *common.Block
-		arg2 types.DecisionNum
-	}{arg1, arg2})
+		arg1 *state.OrderingInformation
+	}{arg1})
 	stub := fake.AppendConfigStub
-	fake.recordInvocation("AppendConfig", []interface{}{arg1, arg2})
+	fake.recordInvocation("AppendConfig", []interface{}{arg1})
 	fake.appendConfigMutex.Unlock()
 	if stub != nil {
-		fake.AppendConfigStub(arg1, arg2)
+		fake.AppendConfigStub(arg1)
 	}
 }
 
@@ -143,17 +140,17 @@ func (fake *FakeAssemblerLedgerReaderWriter) AppendConfigCallCount() int {
 	return len(fake.appendConfigArgsForCall)
 }
 
-func (fake *FakeAssemblerLedgerReaderWriter) AppendConfigCalls(stub func(*common.Block, types.DecisionNum)) {
+func (fake *FakeAssemblerLedgerReaderWriter) AppendConfigCalls(stub func(*state.OrderingInformation)) {
 	fake.appendConfigMutex.Lock()
 	defer fake.appendConfigMutex.Unlock()
 	fake.AppendConfigStub = stub
 }
 
-func (fake *FakeAssemblerLedgerReaderWriter) AppendConfigArgsForCall(i int) (*common.Block, types.DecisionNum) {
+func (fake *FakeAssemblerLedgerReaderWriter) AppendConfigArgsForCall(i int) *state.OrderingInformation {
 	fake.appendConfigMutex.RLock()
 	defer fake.appendConfigMutex.RUnlock()
 	argsForCall := fake.appendConfigArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *FakeAssemblerLedgerReaderWriter) BatchFrontier(arg1 []types.ShardID, arg2 []types.PartyID, arg3 time.Duration) (ledger.BatchFrontier, error) {

--- a/node/server/arma_test.go
+++ b/node/server/arma_test.go
@@ -345,7 +345,12 @@ func TestLaunchArmaNode(t *testing.T) {
 		newConfigBlock.Metadata.Metadata[common.BlockMetadataIndex_LAST_CONFIG] = protoutil.MarshalOrPanic(&common.Metadata{
 			Value: protoutil.MarshalOrPanic(&common.LastConfig{Index: 1}),
 		})
-		assemblerLedger.AppendConfig(newConfigBlock, 1)
+		assemblerLedger.AppendConfig(&state.OrderingInformation{
+			CommonBlock: newConfigBlock,
+			DecisionNum: 1,
+			BatchIndex:  0,
+			BatchCount:  1,
+		})
 		assemblerLedger.Close()
 
 		_, lastConfigBlock, err := config.ReadConfig(configPath, testLogger)


### PR DESCRIPTION
AppendConfig only needs the OrderingInfo
AppendConfig organizes the signatures in the block metadata

#403 