### PR TITLE
Blocking GRPC dial issue fix

### DIFF
--- a/node/comm/config.go
+++ b/node/comm/config.go
@@ -131,6 +131,10 @@ func (cc ClientConfig) DialOptions() ([]grpc.DialOption, error) {
 			grpc.FailOnNonTempDialError(true),
 		)
 	}
+	// set dial timeout
+	if cc.DialTimeout > 0 {
+		dialOpts = append(dialOpts, grpc.WithTimeout(cc.DialTimeout))
+	}
 	// set send/recv message size to package defaults
 	maxRecvMsgSize := DefaultMaxRecvMsgSize
 	if cc.MaxRecvMsgSize != 0 {


### PR DESCRIPTION
The `DialTimeout` option was not translated into gRPC dial options, resulting in a blocking dial in the router when no batcher is running.