### PR TITLE
Refactor net utils

### DIFF
--- a/common/utils/net.go
+++ b/common/utils/net.go
@@ -1,0 +1,86 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+func ExtractCertificateFromContext(ctx context.Context) *x509.Certificate {
+	pr, extracted := peer.FromContext(ctx)
+	if !extracted {
+		return nil
+	}
+
+	authInfo := pr.AuthInfo
+	if authInfo == nil {
+		return nil
+	}
+
+	tlsInfo, isTLSConn := authInfo.(credentials.TLSInfo)
+	if !isTLSConn {
+		return nil
+	}
+	certs := tlsInfo.State.PeerCertificates
+	if len(certs) == 0 {
+		return nil
+	}
+
+	if certs[0] == nil {
+		return nil
+	}
+
+	return certs[0]
+}
+
+func ExtractClientAddressFromContext(ctx context.Context) (string, error) {
+	peer, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("failed to extract peer from context")
+	}
+	if peer.Addr == net.Addr(nil) {
+		return "", fmt.Errorf("peer address is nil")
+	}
+	return peer.Addr.String(), nil
+}
+
+func CertificateToString(cert *x509.Certificate) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Certificate:\n")
+	fmt.Fprintf(&sb, "%4sVersion: %d\n", "", cert.Version)
+	fmt.Fprintf(&sb, "%4sSerial Number: %s\n", "", cert.SerialNumber.String())
+	fmt.Fprintf(&sb, "%4sSignature Algorithm: %s\n", "", cert.SignatureAlgorithm.String())
+	fmt.Fprintf(&sb, "%4sIssuer: %s\n", "", cert.Issuer.String())
+	fmt.Fprintf(&sb, "%4sValidity:\n", "")
+	fmt.Fprintf(&sb, "%8sNot Before: %s\n", "", cert.NotBefore.UTC().String())
+	fmt.Fprintf(&sb, "%8sNot After : %s\n", "", cert.NotAfter.UTC().String())
+	fmt.Fprintf(&sb, "%4sSubject: %s\n", "", cert.Subject.String())
+	fmt.Fprintf(&sb, "%4sPublic Key Algorithm: %s\n", "", cert.PublicKeyAlgorithm.String())
+
+	// Print DNS Names
+	if len(cert.DNSNames) > 0 {
+		fmt.Fprintf(&sb, "%4sDNS Names: %v\n", "", cert.DNSNames)
+	}
+	// Print SANs etc.
+	if len(cert.EmailAddresses) > 0 {
+		fmt.Fprintf(&sb, "%4sEmail Addresses: %v\n", "", cert.EmailAddresses)
+	}
+	if len(cert.IPAddresses) > 0 {
+		fmt.Fprintf(&sb, "%4sIP Addresses: %v\n", "", cert.IPAddresses)
+	}
+	// print raw PEM
+	// pem.Encode(&sb, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+
+	return sb.String()
+}

--- a/common/utils/net_test.go
+++ b/common/utils/net_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package node
+package utils
 
 import (
 	"context"

--- a/node/batcher/batcher.go
+++ b/node/batcher/batcher.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-orderer/common/configstore"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
-	"github.com/hyperledger/fabric-x-orderer/node"
+	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	node_config "github.com/hyperledger/fabric-x-orderer/node/config"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
 	node_ledger "github.com/hyperledger/fabric-x-orderer/node/ledger"
@@ -298,14 +298,14 @@ func (b *Batcher) sendResponses(stream protos.RequestTransmit_SubmitStreamServer
 }
 
 func (b *Batcher) extractBatcherFromContext(c context.Context) (types.PartyID, error) {
-	cert := node.ExtractCertificateFromContext(c)
+	cert := utils.ExtractCertificateFromContext(c)
 	if cert == nil {
 		return 0, errors.New("access denied; could not extract certificate from context")
 	}
 
 	from, exists := b.batcherCerts2IDs[string(cert.Raw)]
 	if !exists {
-		return 0, errors.Errorf("access denied; unknown certificate; %s", node.CertificateToString(cert))
+		return 0, errors.Errorf("access denied; unknown certificate; %s", utils.CertificateToString(cert))
 	}
 
 	return from, nil

--- a/node/consensus/consensus.go
+++ b/node/consensus/consensus.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/common/policy"
 	"github.com/hyperledger/fabric-x-orderer/common/requestfilter"
 	arma_types "github.com/hyperledger/fabric-x-orderer/common/types"
-	"github.com/hyperledger/fabric-x-orderer/node"
+	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/node/comm"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/badb"
@@ -656,7 +656,7 @@ func (c *Consensus) verifyCE(req []byte) (smartbft_types.RequestInfo, *state.Con
 
 func (c *Consensus) validateRouterFromContext(ctx context.Context) error {
 	// extract the client certificate from the context
-	cert := node.ExtractCertificateFromContext(ctx)
+	cert := utils.ExtractCertificateFromContext(ctx)
 	if cert == nil {
 		return errors.New("error: access denied; could not extract certificate from context")
 	}
@@ -670,7 +670,7 @@ func (c *Consensus) validateRouterFromContext(ctx context.Context) error {
 
 	// compare the two certificates
 	if !bytes.Equal(pemBlock.Bytes, cert.Raw) {
-		c.Logger.Errorf("error: access denied. The client certificate does not match the router's certificate. \n client's certificate: \n %s \n %x \n ", node.CertificateToString(cert), cert.Raw)
+		c.Logger.Errorf("error: access denied. The client certificate does not match the router's certificate. \n client's certificate: \n %s \n %x \n ", utils.CertificateToString(cert), cert.Raw)
 		return errors.New("error: access denied. The client certificate does not match the router's certificate")
 	}
 	return nil

--- a/node/router/router.go
+++ b/node/router/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/common/policy"
 	"github.com/hyperledger/fabric-x-orderer/common/requestfilter"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/config"
 	"github.com/hyperledger/fabric-x-orderer/node"
 	nodeconfig "github.com/hyperledger/fabric-x-orderer/node/config"
@@ -228,12 +229,12 @@ func (r *Router) SoftStop() error {
 }
 
 func (r *Router) Broadcast(stream orderer.AtomicBroadcast_BroadcastServer) error {
-	clientAddr, err := node.ExtractClientAddressFromContext(stream.Context())
+	clientAddr, err := utils.ExtractClientAddressFromContext(stream.Context())
 	if err == nil {
 		r.logger.Infof("Client connected: %s", clientAddr)
 	}
-	if clientCert := node.ExtractCertificateFromContext(stream.Context()); clientCert != nil {
-		r.logger.Infof("Client's certificate: \n%s", node.CertificateToString(clientCert))
+	if clientCert := utils.ExtractCertificateFromContext(stream.Context()); clientCert != nil {
+		r.logger.Infof("Client's certificate: \n%s", utils.CertificateToString(clientCert))
 	}
 
 	exit := make(chan struct{})

--- a/node/util.go
+++ b/node/util.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package node
 
 import (
-	"context"
-	"crypto/x509"
 	"fmt"
 	"net"
 	"os"
@@ -17,9 +15,6 @@ import (
 
 	"github.com/hyperledger/fabric-x-orderer/node/comm"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
-
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/peer"
 )
 
 const (
@@ -186,72 +181,4 @@ func CreateGRPCBatcher(conf *config.BatcherNodeConfig) *comm.GRPCServer {
 		os.Exit(1)
 	}
 	return srv
-}
-
-func ExtractCertificateFromContext(ctx context.Context) *x509.Certificate { // TODO add unit test
-	pr, extracted := peer.FromContext(ctx)
-	if !extracted {
-		return nil
-	}
-
-	authInfo := pr.AuthInfo
-	if authInfo == nil {
-		return nil
-	}
-
-	tlsInfo, isTLSConn := authInfo.(credentials.TLSInfo)
-	if !isTLSConn {
-		return nil
-	}
-	certs := tlsInfo.State.PeerCertificates
-	if len(certs) == 0 {
-		return nil
-	}
-
-	if certs[0] == nil {
-		return nil
-	}
-
-	return certs[0]
-}
-
-func ExtractClientAddressFromContext(ctx context.Context) (string, error) {
-	peer, ok := peer.FromContext(ctx)
-	if !ok {
-		return "", fmt.Errorf("failed to extract peer from context")
-	}
-	if peer.Addr == net.Addr(nil) {
-		return "", fmt.Errorf("peer address is nil")
-	}
-	return peer.Addr.String(), nil
-}
-
-func CertificateToString(cert *x509.Certificate) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "Certificate:\n")
-	fmt.Fprintf(&sb, "%4sVersion: %d\n", "", cert.Version)
-	fmt.Fprintf(&sb, "%4sSerial Number: %s\n", "", cert.SerialNumber.String())
-	fmt.Fprintf(&sb, "%4sSignature Algorithm: %s\n", "", cert.SignatureAlgorithm.String())
-	fmt.Fprintf(&sb, "%4sIssuer: %s\n", "", cert.Issuer.String())
-	fmt.Fprintf(&sb, "%4sValidity:\n", "")
-	fmt.Fprintf(&sb, "%8sNot Before: %s\n", "", cert.NotBefore.UTC().String())
-	fmt.Fprintf(&sb, "%8sNot After : %s\n", "", cert.NotAfter.UTC().String())
-	fmt.Fprintf(&sb, "%4sSubject: %s\n", "", cert.Subject.String())
-	fmt.Fprintf(&sb, "%4sPublic Key Algorithm: %s\n", "", cert.PublicKeyAlgorithm.String())
-
-	// Print DNS Names
-	if len(cert.DNSNames) > 0 {
-		fmt.Fprintf(&sb, "%4sDNS Names: %v\n", "", cert.DNSNames)
-	}
-	// Print SANs etc.
-	if len(cert.EmailAddresses) > 0 {
-		fmt.Fprintf(&sb, "%4sEmail Addresses: %v\n", "", cert.EmailAddresses)
-	}
-	if len(cert.IPAddresses) > 0 {
-		fmt.Fprintf(&sb, "%4sIP Addresses: %v\n", "", cert.IPAddresses)
-	}
-	// print raw PEM
-	// pem.Encode(&sb, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
-
-	return sb.String()
 }


### PR DESCRIPTION
Refactor net utilities to a leaf package because they will create a cycle in the next commit.

Move three methods from `node` package to `common/utils` package.