### PR TITLE
Remove global endpoints from deliver client

### DIFF
--- a/common/deliverclient/blocksprovider/bft_deliverer.go
+++ b/common/deliverclient/blocksprovider/bft_deliverer.go
@@ -117,12 +117,12 @@ func (d *BFTDeliverer) Initialize(channelConfig *common.Config, selfEndpoint str
 
 	osLogger := flogging.MustGetLogger("peer.orderers")
 	ordererSource := d.OrderersSourceFactory.CreateConnectionSource(osLogger, selfEndpoint)
-	globalAddresses, orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
+	orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
 	if err != nil {
 		// The bundle was created prior to calling this function, so it should not fail when we recreate it here.
 		d.Logger.Panicf("Bundle creation should not have failed: %s", err)
 	}
-	ordererSource.Update(globalAddresses, orgAddresses)
+	ordererSource.Update(orgAddresses)
 	d.orderers = ordererSource
 }
 
@@ -403,13 +403,13 @@ func (d *BFTDeliverer) onBlockProcessingSuccess(blockNum uint64, channelConfig *
 	d.lastBlockTime = time.Now()
 
 	if channelConfig != nil {
-		globalAddresses, orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
+		orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
 		if err != nil {
 			// The bundle was created prior to calling this function, so it should not fail when we recreate it here.
 			d.Logger.Panicf("Bundle creation should not have failed: %s", err)
 		}
-		d.Logger.Debugf("Extracted orderer addresses: global %v, orgs: %v", globalAddresses, orgAddresses)
-		d.orderers.Update(globalAddresses, orgAddresses)
+		d.Logger.Debugf("Extracted orderer addresses: %+v", orgAddresses)
+		d.orderers.Update(orgAddresses)
 		d.Logger.Debugf("Updated OrdererConnectionSource")
 	}
 

--- a/common/deliverclient/blocksprovider/deliverer.go
+++ b/common/deliverclient/blocksprovider/deliverer.go
@@ -121,12 +121,12 @@ func (d *Deliverer) Initialize(channelConfig *cb.Config) {
 
 	osLogger := flogging.MustGetLogger("peer.orderers")
 	ordererSource := d.OrderersSourceFactory.CreateConnectionSource(osLogger, "")
-	globalAddresses, orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
+	orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
 	if err != nil {
 		// The bundle was created prior to calling this function, so it should not fail when we recreate it here.
 		d.Logger.Panicf("Bundle creation should not have failed: %s", err)
 	}
-	ordererSource.Update(globalAddresses, orgAddresses)
+	ordererSource.Update(orgAddresses)
 	d.orderers = ordererSource
 }
 
@@ -213,12 +213,12 @@ func (d *Deliverer) DeliverBlocks() {
 			totalDuration = time.Duration(0)
 
 			if channelConfig != nil {
-				globalAddresses, orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
+				orgAddresses, err := extractAddresses(d.ChannelID, channelConfig, d.CryptoProvider)
 				if err != nil {
 					// The bundle was created prior to calling this function, so it should not fail when we recreate it here.
 					d.Logger.Panicf("Bundle creation should not have failed: %s", err)
 				}
-				d.orderers.Update(globalAddresses, orgAddresses)
+				d.orderers.Update(orgAddresses)
 			}
 		}
 		if err := blockReceiver.ProcessIncoming(onSuccess); err != nil {

--- a/common/deliverclient/blocksprovider/deliverer_test.go
+++ b/common/deliverclient/blocksprovider/deliverer_test.go
@@ -711,8 +711,7 @@ var _ = ginkgo.Describe("CFT-Deliverer", func() {
 
 		ginkgo.It("updates the orderer connection source", func() {
 			gomega.Eventually(fakeOrdererConnectionSource.UpdateCallCount, eventuallyTO).Should(gomega.Equal(1))
-			globalAddresses, orgsAddresses := fakeOrdererConnectionSource.UpdateArgsForCall(0)
-			gomega.Expect(globalAddresses).To(gomega.BeNil())
+			orgsAddresses := fakeOrdererConnectionSource.UpdateArgsForCall(0)
 			gomega.Expect(orgsAddresses).ToNot(gomega.BeNil())
 			gomega.Expect(orgsAddresses).To(gomega.HaveLen(1))
 			orgAddr, ok := orgsAddresses["SampleOrg"]

--- a/common/deliverclient/blocksprovider/fake/orderer_connection_source.go
+++ b/common/deliverclient/blocksprovider/fake/orderer_connection_source.go
@@ -31,11 +31,10 @@ type OrdererConnectionSource struct {
 	shuffledEndpointsReturnsOnCall map[int]struct {
 		result1 []*orderers.Endpoint
 	}
-	UpdateStub        func([]string, map[string]orderers.OrdererOrg)
+	UpdateStub        func(map[string]orderers.OrdererOrg)
 	updateMutex       sync.RWMutex
 	updateArgsForCall []struct {
-		arg1 []string
-		arg2 map[string]orderers.OrdererOrg
+		arg1 map[string]orderers.OrdererOrg
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -150,22 +149,16 @@ func (fake *OrdererConnectionSource) ShuffledEndpointsReturnsOnCall(i int, resul
 	}{result1}
 }
 
-func (fake *OrdererConnectionSource) Update(arg1 []string, arg2 map[string]orderers.OrdererOrg) {
-	var arg1Copy []string
-	if arg1 != nil {
-		arg1Copy = make([]string, len(arg1))
-		copy(arg1Copy, arg1)
-	}
+func (fake *OrdererConnectionSource) Update(arg1 map[string]orderers.OrdererOrg) {
 	fake.updateMutex.Lock()
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
-		arg1 []string
-		arg2 map[string]orderers.OrdererOrg
-	}{arg1Copy, arg2})
+		arg1 map[string]orderers.OrdererOrg
+	}{arg1})
 	stub := fake.UpdateStub
-	fake.recordInvocation("Update", []interface{}{arg1Copy, arg2})
+	fake.recordInvocation("Update", []interface{}{arg1})
 	fake.updateMutex.Unlock()
 	if stub != nil {
-		fake.UpdateStub(arg1, arg2)
+		fake.UpdateStub(arg1)
 	}
 }
 
@@ -175,17 +168,17 @@ func (fake *OrdererConnectionSource) UpdateCallCount() int {
 	return len(fake.updateArgsForCall)
 }
 
-func (fake *OrdererConnectionSource) UpdateCalls(stub func([]string, map[string]orderers.OrdererOrg)) {
+func (fake *OrdererConnectionSource) UpdateCalls(stub func(map[string]orderers.OrdererOrg)) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = stub
 }
 
-func (fake *OrdererConnectionSource) UpdateArgsForCall(i int) ([]string, map[string]orderers.OrdererOrg) {
+func (fake *OrdererConnectionSource) UpdateArgsForCall(i int) map[string]orderers.OrdererOrg {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	argsForCall := fake.updateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *OrdererConnectionSource) Invocations() map[string][][]interface{} {

--- a/common/deliverclient/blocksprovider/util.go
+++ b/common/deliverclient/blocksprovider/util.go
@@ -90,12 +90,12 @@ type timeNumber struct {
 	n uint64
 }
 
-func extractAddresses(channelID string, config *cb.Config, cryptoProvider bccsp.BCCSP) ([]string, map[string]orderers.OrdererOrg, error) {
+func extractAddresses(channelID string, config *cb.Config, cryptoProvider bccsp.BCCSP) (map[string]orderers.OrdererOrg, error) {
 	bundle, err := channelconfig.NewBundle(channelID, config, cryptoProvider)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	globalAddresses := bundle.ChannelConfig().OrdererAddresses()
+
 	orgAddresses := map[string]orderers.OrdererOrg{}
 	if ordererConfig, ok := bundle.OrdererConfig(); ok {
 		for orgName, org := range ordererConfig.Organizations() {
@@ -110,5 +110,5 @@ func extractAddresses(channelID string, config *cb.Config, cryptoProvider bccsp.
 		}
 	}
 
-	return globalAddresses, orgAddresses, nil
+	return orgAddresses, nil
 }

--- a/common/deliverclient/orderers/connection_factory.go
+++ b/common/deliverclient/orderers/connection_factory.go
@@ -13,7 +13,7 @@ import (
 type ConnectionSourcer interface {
 	RandomEndpoint() (*Endpoint, error)
 	ShuffledEndpoints() []*Endpoint
-	Update(globalAddrs []string, orgs map[string]OrdererOrg)
+	Update(orgs map[string]OrdererOrg)
 }
 
 type ConnectionSourceCreator interface {


### PR DESCRIPTION
Global endpoints are already deprecated in V3, and are not supported in fabric-x. 
We are only supporting org specific endpoint. 
Moreover, in future commits, we'll also be more specific and detail the endpoints by PartyID.

See #44 