### PR TITLE
Generate shared config binary from a network definition

### DIFF
--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -154,6 +154,13 @@ type NodeName struct {
 // This function is used in testing only.
 func PrepareSharedConfigBinary(t *testing.T, dir string) (*config.SharedConfigYaml, string) {
 	networkConfig := GenerateNetworkConfig(t, "none", "none")
+	return PrepareSharedConfigBinaryFromNetwork(t, networkConfig, dir)
+}
+
+// PrepareSharedConfigBinaryFromNetwork generates a shared configuration from a network definition and writes the encoded configuration to a file.
+// The function returns the path to the file and the shared config in the yaml format.
+// This function is used in testing only.
+func PrepareSharedConfigBinaryFromNetwork(t *testing.T, networkConfig genconfig.Network, dir string) (*config.SharedConfigYaml, string) {
 	err := armageddon.GenerateCryptoConfig(&networkConfig, dir)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This allows to generate a config block for testing with arbitrary addresses and ports.

#44 