### PR TITLE
add arma stop channel

### DIFF
--- a/node/router/router.go
+++ b/node/router/router.go
@@ -61,12 +61,13 @@ type Router struct {
 	stopOnce         sync.Once
 	drainChan        chan struct{}
 	drainOnce        sync.Once
+	armaStopChan     chan struct{}
 	feedbackWG       sync.WaitGroup
 	configSeq        uint32
 	wal              *wal.WriteAheadLogFile
 }
 
-func NewRouter(config *nodeconfig.RouterNodeConfig, logger *flogging.FabricLogger, signer identity.SignerSerializer, configUpdateProposer policy.ConfigUpdateProposer, configRulesVerifier verify.OrdererRules) *Router {
+func NewRouter(config *nodeconfig.RouterNodeConfig, logger *flogging.FabricLogger, armaStopChan chan struct{}, signer identity.SignerSerializer, configUpdateProposer policy.ConfigUpdateProposer, configRulesVerifier verify.OrdererRules) *Router {
 	// shardIDs is an array of all shard ids
 	var shardIDs []types.ShardID
 	// batcherEndpoints are the endpoints of all batchers from the router's party by shard id
@@ -119,7 +120,7 @@ func NewRouter(config *nodeconfig.RouterNodeConfig, logger *flogging.FabricLogge
 
 	metrics := NewRouterMetrics(config, logger)
 
-	r := createRouter(shardIDs, batcherEndpoints, tlsCAsOfBatchers, metrics, config, logger, verifier, configStore, configSubmitter, decisionPuller, routerWAL)
+	r := createRouter(shardIDs, batcherEndpoints, tlsCAsOfBatchers, metrics, config, logger, armaStopChan, verifier, configStore, configSubmitter, decisionPuller, routerWAL)
 	r.init()
 	r.metrics.Start()
 	return r
@@ -164,28 +165,26 @@ func getNextDecisionNumber(configStore *configstore.Store, walInitState [][]byte
 	return lastConfigBlockDecisionNumber + 1
 }
 
-func (r *Router) StartRouterService() <-chan struct{} {
+func (r *Router) StartRouterService() {
 	srv := node_utils.CreateGRPCRouter(r.routerNodeConfig)
 	r.net = srv
 
 	protos.RegisterRequestTransmitServer(srv.Server(), r)
 	orderer.RegisterAtomicBroadcastServer(srv.Server(), r)
 
-	stop := make(chan struct{})
-
 	go func() {
 		err := srv.Start()
 		if err != nil {
 			panic(err)
 		}
-		close(stop)
+		r.logger.Infof("Router network service was stopped")
 	}()
 
 	r.configSubmitter.Start()
 
-	go r.pullAndProcessDecisions()
+	node_utils.StopSignalListen(r.stopChan, r, r.logger, r.Address())
 
-	return stop
+	go r.pullAndProcessDecisions()
 }
 
 func (r *Router) MonitoringServiceAddress() string {
@@ -219,6 +218,8 @@ func (r *Router) Stop() {
 	for _, sr := range r.shardRouters {
 		sr.Stop()
 	}
+
+	close(r.armaStopChan)
 }
 
 func (r *Router) SoftStop() error {
@@ -313,7 +314,7 @@ func (r *Router) Deliver(server orderer.AtomicBroadcast_DeliverServer) error {
 	return fmt.Errorf("not implemented")
 }
 
-func createRouter(shardIDs []types.ShardID, batcherEndpoints map[types.ShardID]string, batcherRootCAs map[types.ShardID][][]byte, metrics *RouterMetrics, rconfig *nodeconfig.RouterNodeConfig, logger *flogging.FabricLogger, verifier *requestfilter.RulesVerifier, configStore *configstore.Store, configSubmitter ConfigurationSubmitter, decisionPuller DecisionPuller, routerWAL *wal.WriteAheadLogFile) *Router {
+func createRouter(shardIDs []types.ShardID, batcherEndpoints map[types.ShardID]string, batcherRootCAs map[types.ShardID][][]byte, metrics *RouterMetrics, rconfig *nodeconfig.RouterNodeConfig, logger *flogging.FabricLogger, armaStopChan chan struct{}, verifier *requestfilter.RulesVerifier, configStore *configstore.Store, configSubmitter ConfigurationSubmitter, decisionPuller DecisionPuller, routerWAL *wal.WriteAheadLogFile) *Router {
 	if rconfig.NumOfConnectionsForBatcher == 0 {
 		rconfig.NumOfConnectionsForBatcher = config.DefaultRouterParams.NumberOfConnectionsPerBatcher
 	}
@@ -337,6 +338,7 @@ func createRouter(shardIDs []types.ShardID, batcherEndpoints map[types.ShardID]s
 		decisionPuller:   decisionPuller,
 		stopChan:         make(chan struct{}),
 		drainChan:        make(chan struct{}),
+		armaStopChan:     armaStopChan,
 		metrics:          metrics,
 		configSeq:        uint32(rconfig.Bundle.ConfigtxValidator().Sequence()),
 		wal:              routerWAL,
@@ -583,9 +585,14 @@ func (r *Router) pullAndProcessDecisions() {
 
 			// TODO apply the config block
 
-			// initiate router restart to apply new config
+			// initiate router restart and apply new config
 			r.logger.Warnf("Soft stop")
-			go r.SoftStop()
+			go func() {
+				err := r.SoftStop()
+				if err != nil {
+					r.logger.Warnf("The router was not soft-stopped properly: %v.", err)
+				}
+			}()
 
 			// do not pull additional decisions, until the router is restarted.
 			r.logger.Infof("Stopping decisions pulling from consensus")

--- a/node/router/router_test.go
+++ b/node/router/router_test.go
@@ -989,7 +989,7 @@ func createAndStartRouter(t *testing.T, partyID types.PartyID, ca tlsgen.CA, bat
 	configRulesVerifier.ValidateNewConfigReturns(nil)
 	configRulesVerifier.ValidateTransitionReturns(nil)
 
-	r := router.NewRouter(conf, logger, fakeSigner, configUpdateProposer, configRulesVerifier)
+	r := router.NewRouter(conf, logger, make(chan struct{}), fakeSigner, configUpdateProposer, configRulesVerifier)
 	r.StartRouterService()
 
 	return r, conf

--- a/node/server/arma.go
+++ b/node/server/arma.go
@@ -219,16 +219,12 @@ func launchRouter(stop chan struct{}) func(configFile *os.File) {
 		} else {
 			routerLogger = flogging.MustGetLogger(fmt.Sprintf("Router%d", routerConf.PartyID))
 		}
-		r := router.NewRouter(routerConf, routerLogger, signer, &policy.DefaultConfigUpdateProposer{}, &verify.DefaultOrdererRules{})
-		ch := r.StartRouterService()
 
-		go func() {
-			<-ch
-			close(stop)
-		}()
+		// TODO - When the router restarts, a new router instance is created with same stop channel,
+		// since closing stop channel will kill the whole arma process.
+		r := router.NewRouter(routerConf, routerLogger, stop, signer, &policy.DefaultConfigUpdateProposer{}, &verify.DefaultOrdererRules{})
+		r.StartRouterService()
 
-		// TODO: move StopSignalListen to Router.Run and pass stopChan
-		utils.StopSignalListen(nil, r, routerLogger, r.Address())
 		routerLogger.Infof("Router listening on %s, PartyID: %d", r.Address(), routerConf.PartyID)
 	}
 }

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -155,7 +155,7 @@ func createRouters(t *testing.T, num int, batcherInfos []node_config.BatcherInfo
 		configRulesVerifier.ValidateNewConfigReturns(nil)
 		configRulesVerifier.ValidateTransitionReturns(nil)
 
-		router := router.NewRouter(config, l, fakeSigner, configUpdateProposer, configRulesVerifier)
+		router := router.NewRouter(config, l, make(chan struct{}), fakeSigner, configUpdateProposer, configRulesVerifier)
 		routers = append(routers, router)
 	}
 
@@ -546,7 +546,7 @@ func recoverRouter(conf *node_config.RouterNodeConfig, logger *flogging.FabricLo
 	configRulesVerifier.ValidateNewConfigReturns(nil)
 	configRulesVerifier.ValidateTransitionReturns(nil)
 
-	router := router.NewRouter(conf, logger, fakeSigner, configUpdateProposer, configRulesVerifier)
+	router := router.NewRouter(conf, logger, make(chan struct{}), fakeSigner, configUpdateProposer, configRulesVerifier)
 	router.StartRouterService()
 
 	return router


### PR DESCRIPTION
Currently, when starting a router, we create a channel that is closed when the router’s network server stops. This cascades and terminates the arma process.
However, when restarting the router, the arma process must remain running, and a new router instance should be created instead.

If accepted, this fix should be applied to all Arma nodes.

issue #442 