### PR TITLE
fix armageddon to support assembler crashes

### DIFF
--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -689,11 +689,9 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 		os.Exit(3)
 	}
 
-	var stream ab.AtomicBroadcast_DeliverClient
-	var gRPCAssemblerClientConn *grpc.ClientConn
 	endpointToPullFrom := userConfig.AssemblerEndpoints[pullFromPartyId-1]
 
-	gRPCAssemblerClientConn, err = gRPCAssemblerClient.Dial(endpointToPullFrom)
+	gRPCAssemblerClientConn, err := gRPCAssemblerClient.Dial(endpointToPullFrom)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create a gRPC client connection to assembler %d: %v", pullFromPartyId, err)
 		os.Exit(3)
@@ -702,7 +700,7 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 	abc := ab.NewAtomicBroadcastClient(gRPCAssemblerClientConn)
 
 	// create a deliver stream
-	stream, err = abc.Deliver(context.TODO())
+	stream, err := abc.Deliver(context.TODO())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create a deliver stream to assembler %d: %v", pullFromPartyId, err)
 		os.Exit(3)
@@ -735,7 +733,7 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 		waitToFinish.Done()
 	}()
 
-	// every second read the statistics and send it to the manageStatistics
+	// every second read the statistics and send it to manageStatistics
 	go func() {
 		ticker := time.NewTicker(timeIntervalToSampleStat)
 		defer ticker.Stop()
@@ -752,21 +750,64 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 		}
 	}()
 
-	// pull blocks from the assembler
-	// if a flag is given, stop when finish receiving all txs
+	// pull blocks from the assembler with reconnect logic on failure
 	go func() {
 		logger.Infof("starting pulling blocks from the assembler")
 		var txsTotal int
+		var lastBlockNum uint64 = 0
+
 		for {
-			block, err := pullBlock(stream, endpointToPullFrom, gRPCAssemblerClientConn)
+			block, err := pullBlock(stream, endpointToPullFrom)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to pull block from assembler %d: %v", pullFromPartyId, err)
-				os.Exit(3)
+				// Assembler is down — log and retry, do NOT exit
+				logger.Warnf("lost connection to assembler %d: %v — will retry in 1s", pullFromPartyId, err)
+
+				_ = stream.CloseSend()
+				_ = gRPCAssemblerClientConn.Close()
+
+				// Keep retrying until reconnect succeeds
+				for {
+					time.Sleep(1 * time.Second)
+
+					gRPCAssemblerClientConn, err = gRPCAssemblerClient.Dial(endpointToPullFrom)
+					if err != nil {
+						logger.Warnf("reconnect to assembler %d failed: %v — retrying", pullFromPartyId, err)
+						continue
+					}
+
+					abc := ab.NewAtomicBroadcastClient(gRPCAssemblerClientConn)
+					stream, err = abc.Deliver(context.TODO())
+					if err != nil {
+						logger.Warnf("failed to create deliver stream to assembler %d: %v — retrying", pullFromPartyId, err)
+						_ = gRPCAssemblerClientConn.Close()
+						continue
+					}
+
+					requestEnvelope, err = createRequestEnvelopeForUserFromSeq(userConfig, lastBlockNum+1)
+					if err != nil {
+						logger.Warnf("failed to recreate request envelope: %v — retrying", err)
+						_ = gRPCAssemblerClientConn.Close()
+						continue
+					}
+
+					err = stream.Send(requestEnvelope)
+					if err != nil {
+						logger.Warnf("failed to send request envelope to assembler %d: %v — retrying", pullFromPartyId, err)
+						_ = gRPCAssemblerClientConn.Close()
+						continue
+					}
+
+					logger.Infof("reconnected to assembler %d successfully, resuming from block %d", pullFromPartyId, lastBlockNum+1)
+					break
+				}
+				continue
 			}
 
 			if block.Header.Number == 0 {
 				continue
 			}
+
+			lastBlockNum = block.Header.Number
 
 			blockWithTime := BlockWithTime{
 				block:        block,
@@ -779,6 +820,8 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 
 			if expectedNumOfTxs > 0 && expectedNumOfTxs <= txsTotal {
 				logger.Infof("overall %d txs were received, finished pulling", txsTotal)
+				_ = stream.CloseSend()
+				_ = gRPCAssemblerClientConn.Close()
 				waitToFinish.Done()
 				return
 			}
@@ -831,33 +874,30 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 	logger.Debugf("exit pulling blocks from the assembler")
 }
 
-func calculateDelayOfTx(data []byte, acceptedTime time.Time) time.Duration {
-	sendTime := tx.ExtractTimestampFromTx(data)
-	delayTime := acceptedTime.Sub(sendTime)
-	return delayTime
-}
-
-func pullBlock(stream ab.AtomicBroadcast_DeliverClient, endpointToPullFrom string, gRPCAssemblerClientConn *grpc.ClientConn) (*common.Block, error) {
+// pullBlock no longer closes the connection internally — the caller manages reconnection
+func pullBlock(stream ab.AtomicBroadcast_DeliverClient, endpointToPullFrom string) (*common.Block, error) {
 	resp, err := stream.Recv()
 	if err != nil {
-		return nil, fmt.Errorf("failed to receive a deliver response from %s", endpointToPullFrom)
+		return nil, fmt.Errorf("failed to receive a deliver response from %s: %w", endpointToPullFrom, err)
 	}
 
 	block := resp.GetBlock()
 
 	if block == nil {
-		stream.CloseSend()
-		gRPCAssemblerClientConn.Close()
-		return nil, fmt.Errorf("received a non block message from %s: %v", endpointToPullFrom, resp)
+		return nil, fmt.Errorf("received a non-block message from %s: %v", endpointToPullFrom, resp)
 	}
 
 	if block.Data == nil || len(block.Data.Data) == 0 {
-		stream.CloseSend()
-		gRPCAssemblerClientConn.Close()
 		return nil, fmt.Errorf("received empty block from %s", endpointToPullFrom)
 	}
 
 	return block, nil
+}
+
+func calculateDelayOfTx(data []byte, acceptedTime time.Time) time.Duration {
+	sendTime := tx.ExtractTimestampFromTx(data)
+	delayTime := acceptedTime.Sub(sendTime)
+	return delayTime
 }
 
 func sendTx(txsMap *protectedMap, streams []ab.AtomicBroadcast_BroadcastClient, i int, txSize int, sessionNumber []byte) {
@@ -891,7 +931,7 @@ func reportLoadResults(transactions int, elapsed time.Duration, txSize int) {
 
 // manageStatistics manages a statistics queue and every hour writes the queue to a CSV file
 func manageStatistics(receiveOutputDir string, statisticChan <-chan Statistics, stopChan <-chan bool, startTime float64, expectedTxs int, pullFrom int, timeIntervalToSampleStat time.Duration) {
-	filePath := path.Join(receiveOutputDir, "statistics.csv")
+	filePath := path.Join(receiveOutputDir, fmt.Sprintf("statistics_%s.csv", time.Now().Format("2006-01-02_15:04:05")))
 	logger.Infof("Statistics are written to: %v\n", filePath)
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
@@ -973,6 +1013,10 @@ func writeStatisticsToCSV(file *os.File, statistic Statistics, timeIntervalToSam
 }
 
 func createRequestEnvelopeForUser(userConfig *UserConfig) (*common.Envelope, error) {
+	return createRequestEnvelopeForUserFromSeq(userConfig, 0)
+}
+
+func createRequestEnvelopeForUserFromSeq(userConfig *UserConfig, startSeq uint64) (*common.Envelope, error) {
 	signer, err := signutil.CreateSignerForUser(userConfig.MSPDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create signer for user: %v", err)
@@ -991,7 +1035,7 @@ func createRequestEnvelopeForUser(userConfig *UserConfig) (*common.Envelope, err
 		common.HeaderType_DELIVER_SEEK_INFO,
 		"arma",
 		signer,
-		nextSeekInfo(0),
+		nextSeekInfo(startSeq),
 		int32(0),
 		uint64(0),
 		tlsCertHash,
@@ -1000,6 +1044,9 @@ func createRequestEnvelopeForUser(userConfig *UserConfig) (*common.Envelope, err
 	return requestEnvelope, err
 }
 
+// receiveResponseFromAssembler is used by the submit command, which is a short-lived operation.
+// Unlike pullBlocksFromAssemblerAndCollectStatistics, no reconnect logic is needed here —
+// if the assembler goes down during a submit run, it is correct to fail fast.
 func receiveResponseFromAssembler(userConfig *UserConfig, txsMap *protectedMap, expectedNumOfTxs int) (int, float64) {
 	// arbitrarily choose the first assembler to pull blocks from
 	pullFromPartyId := 1
@@ -1059,7 +1106,7 @@ func receiveResponseFromAssembler(userConfig *UserConfig, txsMap *protectedMap, 
 	numOfTxsCalculated := 0
 	var sumOfDelayTimes float64
 	for {
-		block, err := pullBlock(stream, endpointToPullFrom, gRPCAssemblerClientConn)
+		block, err := pullBlock(stream, endpointToPullFrom)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to pull block from assembler %d: %v", pullFromPartyId, err)
 			os.Exit(3)

--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -683,7 +683,7 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 		DialTimeout: time.Second * 5,
 	}
 
-	requestEnvelope, err := createRequestEnvelopeForUser(userConfig)
+	requestEnvelope, err := createDeliverRequestWithSeekInfo(userConfig, 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create a request envelope: %v", err)
 		os.Exit(3)
@@ -783,7 +783,7 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 						continue
 					}
 
-					requestEnvelope, err = createRequestEnvelopeForUserFromSeq(userConfig, lastBlockNum+1)
+					requestEnvelope, err = createDeliverRequestWithSeekInfo(userConfig, lastBlockNum+1)
 					if err != nil {
 						logger.Warnf("failed to recreate request envelope: %v — retrying", err)
 						_ = gRPCAssemblerClientConn.Close()
@@ -874,7 +874,6 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 	logger.Debugf("exit pulling blocks from the assembler")
 }
 
-// pullBlock no longer closes the connection internally — the caller manages reconnection
 func pullBlock(stream ab.AtomicBroadcast_DeliverClient, endpointToPullFrom string) (*common.Block, error) {
 	resp, err := stream.Recv()
 	if err != nil {
@@ -1012,11 +1011,7 @@ func writeStatisticsToCSV(file *os.File, statistic Statistics, timeIntervalToSam
 	}
 }
 
-func createRequestEnvelopeForUser(userConfig *UserConfig) (*common.Envelope, error) {
-	return createRequestEnvelopeForUserFromSeq(userConfig, 0)
-}
-
-func createRequestEnvelopeForUserFromSeq(userConfig *UserConfig, startSeq uint64) (*common.Envelope, error) {
+func createDeliverRequestWithSeekInfo(userConfig *UserConfig, startSeq uint64) (*common.Envelope, error) {
 	signer, err := signutil.CreateSignerForUser(userConfig.MSPDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create signer for user: %v", err)
@@ -1045,8 +1040,7 @@ func createRequestEnvelopeForUserFromSeq(userConfig *UserConfig, startSeq uint64
 }
 
 // receiveResponseFromAssembler is used by the submit command, which is a short-lived operation.
-// Unlike pullBlocksFromAssemblerAndCollectStatistics, no reconnect logic is needed here —
-// if the assembler goes down during a submit run, it is correct to fail fast.
+// Unlike pullBlocksFromAssemblerAndCollectStatistics, no reconnect logic is supported.
 func receiveResponseFromAssembler(userConfig *UserConfig, txsMap *protectedMap, expectedNumOfTxs int) (int, float64) {
 	// arbitrarily choose the first assembler to pull blocks from
 	pullFromPartyId := 1
@@ -1069,7 +1063,7 @@ func receiveResponseFromAssembler(userConfig *UserConfig, txsMap *protectedMap, 
 		DialTimeout: time.Second * 5,
 	}
 
-	requestEnvelope, err := createRequestEnvelopeForUser(userConfig)
+	requestEnvelope, err := createDeliverRequestWithSeekInfo(userConfig, 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create a request envelope: %v", err)
 		os.Exit(3)
@@ -1109,6 +1103,8 @@ func receiveResponseFromAssembler(userConfig *UserConfig, txsMap *protectedMap, 
 		block, err := pullBlock(stream, endpointToPullFrom)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to pull block from assembler %d: %v", pullFromPartyId, err)
+			_ = stream.CloseSend()
+			_ = gRPCAssemblerClientConn.Close()
 			os.Exit(3)
 		}
 

--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -570,9 +570,9 @@ func receive(userConfigFile **os.File, pullFromPartyId *int, receiveOutputDir *s
 		os.Exit(-1)
 	}
 
-	// pull blocks from the assembler and report statistics to statistics.csv file
+	// pull blocks from the assembler and report statistics to a timestamped CSV file
 	pullBlocksFromAssemblerAndCollectStatistics(userConfig, *pullFromPartyId, *receiveOutputDir, *expectedNumOfTxs)
-	logger.Infof("Receive command finished, statistics can be found in: %v\n", path.Join(*receiveOutputDir, "statistics.csv"))
+	logger.Infof("Receive command finished, statistics can be found in the output directory: %v\n", *receiveOutputDir)
 }
 
 func nextSeekInfo(startSeq uint64) *ab.SeekInfo {
@@ -786,6 +786,7 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 					requestEnvelope, err = createDeliverRequestWithSeekInfo(userConfig, lastBlockNum+1)
 					if err != nil {
 						logger.Warnf("failed to recreate request envelope: %v — retrying", err)
+						_ = stream.CloseSend()
 						_ = gRPCAssemblerClientConn.Close()
 						continue
 					}
@@ -793,6 +794,7 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 					err = stream.Send(requestEnvelope)
 					if err != nil {
 						logger.Warnf("failed to send request envelope to assembler %d: %v — retrying", pullFromPartyId, err)
+						_ = stream.CloseSend()
 						_ = gRPCAssemblerClientConn.Close()
 						continue
 					}
@@ -928,9 +930,9 @@ func reportLoadResults(transactions int, elapsed time.Duration, txSize int) {
 	logger.Infof("Load command finished, sent %d TXs in %v seconds, TX size %d, avg. tx sending rate: %.2f\n", transactions, elapsed, txSize, avgTxSendingRate)
 }
 
-// manageStatistics manages a statistics queue and every hour writes the queue to a CSV file
+// manageStatistics manages a statistics queue and writes statistics to a timestamped CSV file for this run
 func manageStatistics(receiveOutputDir string, statisticChan <-chan Statistics, stopChan <-chan bool, startTime float64, expectedTxs int, pullFrom int, timeIntervalToSampleStat time.Duration) {
-	filePath := path.Join(receiveOutputDir, fmt.Sprintf("statistics_%s.csv", time.Now().Format("2006-01-02_15:04:05")))
+	filePath := path.Join(receiveOutputDir, fmt.Sprintf("statistics_%s.csv", time.Now().Format("2006-01-02_150405")))
 	logger.Infof("Statistics are written to: %v\n", filePath)
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {

--- a/common/tools/armageddon/armageddon_test.go
+++ b/common/tools/armageddon/armageddon_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/csv"
 	"fmt"
 	"os"
 	"os/exec"
@@ -796,6 +797,175 @@ func checkCryptoDir(outputDir string) error {
 	}
 
 	return nil
+}
+
+// Scenario:
+//  1. Create a config YAML file to be an input to armageddon
+//  2. Run armageddon generate command to create config files in a folder structure
+//  3. Run arma with the generated config files to run each of the nodes for a single party
+//  4. Run armageddon receive command to pull blocks from the assembler and report results (in a go routine)
+//  5. Run armageddon load command to send txs to all routers at a specified rate (in a go routine)
+//  6. Wait 30 seconds with assembler running, verify assembler is up and CSV has non-zero rows
+//  7. Shutdown the assembler (simulating a crash)
+//  8. Wait 30 seconds with assembler down, verify assembler is down and CSV has zero rows
+//  9. Restart the assembler
+//
+// 10. Wait 30 seconds with assembler running, verify assembler is up and CSV has non-zero rows again
+// 11. Wait for the txs to be received by the assembler
+func TestLoadAndReceive_AssemblerFailsAndRecovers(t *testing.T) {
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// 1. Create network configuration with 1 party and 1 shard (simpler test)
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, 1, 1, "TLS", "TLS")
+	defer netInfo.CleanUp()
+
+	// 2. Generate config files and crypto material
+	armageddon := armageddon.NewCLI()
+	sampleConfigPath := fabric.GetDevConfigDir()
+	armageddon.Run([]string{"generate", "--config", configPath, "--output", dir, "--sampleConfigPath", sampleConfigPath})
+
+	// 3. Compile arma
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	// run arma nodes
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	readyChan := make(chan string, 20)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, 4, 10) // Wait for 4 nodes: consenter, assembler, router, 1 batcher
+
+	// 4. + 5. Start sending and receiving transactions in parallel
+	userConfigPath := path.Join(dir, "config", "party1", "user_config.yaml")
+	rate := "100"      // 100 tx/second
+	totalTxs := "9000" // 90 seconds * 100 tx/s = 9000 total
+	txSize := "128"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Start receiving blocks (this creates the CSV file)
+	go func() {
+		defer wg.Done()
+		armageddon.Run([]string{"receive", "--config", userConfigPath, "--pullFromPartyId", "1", "--expectedTxs", totalTxs, "--output", dir})
+	}()
+
+	// Start sending transactions
+	go func() {
+		defer wg.Done()
+		armageddon.Run([]string{"load", "--config", userConfigPath, "--transactions", totalTxs, "--rate", rate, "--txSize", txSize})
+	}()
+
+	// 6. Wait 30 seconds, then check assembler is up and CSV has non-zero rows
+	time.Sleep(30 * time.Second)
+	t.Log("Phase 1: Checking assembler is UP and processing blocks")
+	assembler := armaNetwork.GetAssembler(t, 1)
+	require.NotNil(t, assembler.RunInfo.Session, "Assembler process should be running")
+	checkCSVHasNonZeroRows(t, dir, 3) // Check at least 3 rows with non-zero values
+
+	// 7. Stop the assembler
+	t.Log("Phase 2: Stopping assembler to simulate crash")
+	assembler.StopArmaNode()
+
+	// 8. Wait 30 seconds, then check assembler is down and CSV has zero rows
+	time.Sleep(30 * time.Second)
+	t.Log("Phase 2: Verifying assembler is DOWN and no blocks are being received")
+	checkCSVHasZeroRows(t, dir, 3) // Check at least 3 rows with zero values
+
+	// 9. Restart the assembler
+	t.Log("Phase 3: Restarting assembler to simulate recovery")
+	assembler.RestartArmaNode(t, readyChan)
+	testutil.WaitReady(t, readyChan, 1, 10)
+
+	// 10. Wait 30 seconds, then check assembler is up and CSV has non-zero rows again
+	time.Sleep(30 * time.Second)
+	t.Log("Phase 3: Verifying assembler is UP again and processing blocks")
+	require.NotNil(t, assembler.RunInfo.Session, "Assembler process should be running after restart")
+	checkCSVHasNonZeroRows(t, dir, 3) // Check at least 3 more rows with non-zero values
+
+	// 11. Wait for all goroutines to finish
+	wg.Wait()
+}
+
+// checkCSVHasNonZeroRows verifies that the statistics CSV file has at least minRows rows
+// with non-zero values for number of transactions and number of blocks.
+// This indicates the assembler is processing blocks normally.
+func checkCSVHasNonZeroRows(t *testing.T, dir string, minRows int) {
+	// Find the CSV file (it has timestamp in name: statistics_YYYY-MM-DD_HH:MM:SS.csv)
+	files, err := filepath.Glob(filepath.Join(dir, "statistics_*.csv"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "Statistics CSV file should exist")
+
+	// Read CSV file
+	file, err := os.Open(files[0])
+	require.NoError(t, err)
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1 // Allow variable number of fields per record
+
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Skip header rows (first 3 rows: description, empty line, column headers)
+	require.Greater(t, len(records), 3, "CSV should have header rows")
+	dataRows := records[3:]
+
+	// Count rows with non-zero txs and blocks
+	nonZeroCount := 0
+	for _, row := range dataRows {
+		if len(row) >= 3 {
+			numTxs := row[1]    // Column: "Number of txs"
+			numBlocks := row[2] // Column: "Number of blocks"
+			if numTxs != "0" && numBlocks != "0" {
+				nonZeroCount++
+			}
+		}
+	}
+
+	require.GreaterOrEqual(t, nonZeroCount, minRows, "Expected at least %d rows with non-zero values (assembler processing blocks)", minRows)
+}
+
+// checkCSVHasZeroRows verifies that the statistics CSV file has at least minRows rows
+// with zero values for number of transactions and number of blocks.
+// This indicates the assembler is down and not processing blocks.
+func checkCSVHasZeroRows(t *testing.T, dir string, minRows int) {
+	files, err := filepath.Glob(filepath.Join(dir, "statistics_*.csv"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "Statistics CSV file should exist")
+
+	file, err := os.Open(files[0])
+	require.NoError(t, err)
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1 // Allow variable number of fields per record
+
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Skip header rows
+	require.Greater(t, len(records), 3, "CSV should have header rows")
+	dataRows := records[3:]
+
+	// Count rows with zero txs and blocks (but non-zero timestamp)
+	zeroCount := 0
+	for _, row := range dataRows {
+		if len(row) >= 3 {
+			numTxs := row[1]    // Column: "Number of txs"
+			numBlocks := row[2] // Column: "Number of blocks"
+			if numTxs == "0" && numBlocks == "0" {
+				zeroCount++
+			}
+		}
+	}
+
+	require.GreaterOrEqual(t, zeroCount, minRows, "Expected at least %d rows with zero values (assembler down)", minRows)
 }
 
 func fileExists(path string) bool {

--- a/common/tools/armageddon/armageddon_test.go
+++ b/common/tools/armageddon/armageddon_test.go
@@ -805,12 +805,12 @@ func checkCryptoDir(outputDir string) error {
 //  3. Run arma with the generated config files to run each of the nodes for a single party
 //  4. Run armageddon receive command to pull blocks from the assembler and report results (in a go routine)
 //  5. Run armageddon load command to send txs to all routers at a specified rate (in a go routine)
-//  6. Wait 30 seconds with assembler running, verify assembler is up and CSV has non-zero rows
+//  6. Wait 30 seconds with assembler running, Verifying that the assembler is operational and processing blocks
 //  7. Shutdown the assembler (simulating a crash)
-//  8. Wait 30 seconds with assembler down, verify assembler is down and CSV has zero rows
+//  8. Wait 30 seconds with assembler down, Verifying that the assembler is not operantinal and not processing blocks
 //  9. Restart the assembler
 //
-// 10. Wait 30 seconds with assembler running, verify assembler is up and CSV has non-zero rows again
+// 10. Wait 30 seconds with assembler running, Verifying that the assembler is operational again and processing blocks as if it was not down at all
 // 11. Wait for the txs to be received by the assembler
 func TestLoadAndReceive_AssemblerFailsAndRecovers(t *testing.T) {
 	dir, err := os.MkdirTemp("", t.Name())
@@ -861,111 +861,115 @@ func TestLoadAndReceive_AssemblerFailsAndRecovers(t *testing.T) {
 		armageddon.Run([]string{"load", "--config", userConfigPath, "--transactions", totalTxs, "--rate", rate, "--txSize", txSize})
 	}()
 
-	// 6. Wait 30 seconds, then check assembler is up and CSV has non-zero rows
-	time.Sleep(30 * time.Second)
-	t.Log("Phase 1: Checking assembler is UP and processing blocks")
+	// 6. Wait 30 seconds for assembler to process blocks, then verify
+	t.Log("Phase 1: Waiting 30 seconds with assembler UP and processing blocks")
 	assembler := armaNetwork.GetAssembler(t, 1)
+	time.Sleep(30 * time.Second)
+
+	t.Log("Phase 1: Verifying assembler processed blocks")
 	require.NotNil(t, assembler.RunInfo.Session, "Assembler process should be running")
-	checkCSVHasNonZeroRows(t, dir, 3) // Check at least 3 rows with non-zero values
+	// CSV writes every 1 second, so after 30 seconds we expect at least 25 non-zero rows (allowing some margin)
+	// Check that the last 25 rows have non-zero values (assembler was processing)
+	files, err := filepath.Glob(filepath.Join(dir, "statistics_*.csv"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "Statistics CSV file should exist")
+
+	file, err := os.Open(files[0])
+	require.NoError(t, err)
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+	records, err := reader.ReadAll()
+	file.Close()
+	require.NoError(t, err)
+	require.Greater(t, len(records), 3, "CSV should have header rows")
+
+	dataRows := records[3:]
+	require.GreaterOrEqual(t, len(dataRows), 25, "Should have at least 25 data rows after 30 seconds")
+
+	// Check last 25 rows are non-zero (assembler was processing)
+	nonZeroCount := 0
+	startIdx := len(dataRows) - 25
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	for i := startIdx; i < len(dataRows); i++ {
+		row := dataRows[i]
+		if len(row) >= 3 && row[1] != "0" && row[2] != "0" {
+			nonZeroCount++
+		}
+	}
+	require.GreaterOrEqual(t, nonZeroCount, 20, "Expected at least 20 of the last 25 rows to have non-zero values (assembler processing)")
 
 	// 7. Stop the assembler
 	t.Log("Phase 2: Stopping assembler to simulate crash")
 	assembler.StopArmaNode()
 
-	// 8. Wait 30 seconds, then check assembler is down and CSV has zero rows
+	// 8. Wait 30 seconds with assembler down, then verify CSV shows zeros
+	t.Log("Phase 2: Waiting 30 seconds with assembler DOWN")
 	time.Sleep(30 * time.Second)
-	t.Log("Phase 2: Verifying assembler is DOWN and no blocks are being received")
-	checkCSVHasZeroRows(t, dir, 3) // Check at least 3 rows with zero values
+
+	t.Log("Phase 2: Verifying assembler is DOWN and CSV shows zero rows")
+	// After 30 seconds down, the last ~25 rows should be zeros
+	file, err = os.Open(files[0])
+	require.NoError(t, err)
+	reader = csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+	records, err = reader.ReadAll()
+	file.Close()
+	require.NoError(t, err)
+
+	dataRows = records[3:]
+	// Check last 25 rows are zeros (assembler was down)
+	zeroCount := 0
+	startIdx = len(dataRows) - 25
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	for i := startIdx; i < len(dataRows); i++ {
+		row := dataRows[i]
+		if len(row) >= 3 && row[1] == "0" && row[2] == "0" {
+			zeroCount++
+		}
+	}
+	require.GreaterOrEqual(t, zeroCount, 20, "Expected at least 20 of the last 25 rows to have zero values (assembler down)")
 
 	// 9. Restart the assembler
 	t.Log("Phase 3: Restarting assembler to simulate recovery")
 	assembler.RestartArmaNode(t, readyChan)
 	testutil.WaitReady(t, readyChan, 1, 10)
 
-	// 10. Wait 30 seconds, then check assembler is up and CSV has non-zero rows again
+	// 10. Wait 30 seconds with assembler back up, then verify CSV shows non-zeros again
+	t.Log("Phase 3: Waiting 30 seconds with assembler UP again")
 	time.Sleep(30 * time.Second)
-	t.Log("Phase 3: Verifying assembler is UP again and processing blocks")
+
+	t.Log("Phase 3: Verifying assembler is UP and processing blocks again")
 	require.NotNil(t, assembler.RunInfo.Session, "Assembler process should be running after restart")
-	checkCSVHasNonZeroRows(t, dir, 3) // Check at least 3 more rows with non-zero values
+	// After 30 seconds up again, the last ~25 rows should be non-zeros
+	file, err = os.Open(files[0])
+	require.NoError(t, err)
+	reader = csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+	records, err = reader.ReadAll()
+	file.Close()
+	require.NoError(t, err)
+
+	dataRows = records[3:]
+	// Check last 25 rows are non-zeros (assembler recovered and processing)
+	nonZeroCount = 0
+	startIdx = len(dataRows) - 25
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	for i := startIdx; i < len(dataRows); i++ {
+		row := dataRows[i]
+		if len(row) >= 3 && row[1] != "0" && row[2] != "0" {
+			nonZeroCount++
+		}
+	}
+	require.GreaterOrEqual(t, nonZeroCount, 20, "Expected at least 20 of the last 25 rows to have non-zero values (assembler recovered)")
 
 	// 11. Wait for all goroutines to finish
 	wg.Wait()
-}
-
-// checkCSVHasNonZeroRows verifies that the statistics CSV file has at least minRows rows
-// with non-zero values for number of transactions and number of blocks.
-// This indicates the assembler is processing blocks normally.
-func checkCSVHasNonZeroRows(t *testing.T, dir string, minRows int) {
-	// Find the CSV file (it has timestamp in name: statistics_YYYY-MM-DD_HH:MM:SS.csv)
-	files, err := filepath.Glob(filepath.Join(dir, "statistics_*.csv"))
-	require.NoError(t, err)
-	require.NotEmpty(t, files, "Statistics CSV file should exist")
-
-	// Read CSV file
-	file, err := os.Open(files[0])
-	require.NoError(t, err)
-	defer file.Close()
-
-	reader := csv.NewReader(file)
-	reader.FieldsPerRecord = -1 // Allow variable number of fields per record
-
-	records, err := reader.ReadAll()
-	require.NoError(t, err)
-
-	// Skip header rows (first 3 rows: description, empty line, column headers)
-	require.Greater(t, len(records), 3, "CSV should have header rows")
-	dataRows := records[3:]
-
-	// Count rows with non-zero txs and blocks
-	nonZeroCount := 0
-	for _, row := range dataRows {
-		if len(row) >= 3 {
-			numTxs := row[1]    // Column: "Number of txs"
-			numBlocks := row[2] // Column: "Number of blocks"
-			if numTxs != "0" && numBlocks != "0" {
-				nonZeroCount++
-			}
-		}
-	}
-
-	require.GreaterOrEqual(t, nonZeroCount, minRows, "Expected at least %d rows with non-zero values (assembler processing blocks)", minRows)
-}
-
-// checkCSVHasZeroRows verifies that the statistics CSV file has at least minRows rows
-// with zero values for number of transactions and number of blocks.
-// This indicates the assembler is down and not processing blocks.
-func checkCSVHasZeroRows(t *testing.T, dir string, minRows int) {
-	files, err := filepath.Glob(filepath.Join(dir, "statistics_*.csv"))
-	require.NoError(t, err)
-	require.NotEmpty(t, files, "Statistics CSV file should exist")
-
-	file, err := os.Open(files[0])
-	require.NoError(t, err)
-	defer file.Close()
-
-	reader := csv.NewReader(file)
-	reader.FieldsPerRecord = -1 // Allow variable number of fields per record
-
-	records, err := reader.ReadAll()
-	require.NoError(t, err)
-
-	// Skip header rows
-	require.Greater(t, len(records), 3, "CSV should have header rows")
-	dataRows := records[3:]
-
-	// Count rows with zero txs and blocks (but non-zero timestamp)
-	zeroCount := 0
-	for _, row := range dataRows {
-		if len(row) >= 3 {
-			numTxs := row[1]    // Column: "Number of txs"
-			numBlocks := row[2] // Column: "Number of blocks"
-			if numTxs == "0" && numBlocks == "0" {
-				zeroCount++
-			}
-		}
-	}
-
-	require.GreaterOrEqual(t, zeroCount, minRows, "Expected at least %d rows with zero values (assembler down)", minRows)
 }
 
 func fileExists(path string) bool {


### PR DESCRIPTION
as part of #591 

as well as the chos run support that will be later added in the CI/CD part this PR fixes the armageddon.go file to support the fact that if the assembler crashes, the armageddon will just keep writing it's statsitics regullary and will return back to write more data once the assembler is fully up.