### PR TITLE
add mainExitChan to stop net without kill the process consensus

### DIFF
--- a/node/consensus/consensus.go
+++ b/node/consensus/consensus.go
@@ -108,6 +108,7 @@ type Consensus struct {
 	BFT                          *smartbft_consensus.Consensus
 	Net                          NetStopper
 	BADB                         *badb.BatchAttestationDB
+	MainExitChan                 chan struct{}
 
 	synchronizerFactory bft_synch.SynchronizerFactory  // Builds a BFT synchronizer
 	bftSynchronizer     bft_synch.SynchronizerWithStop // The BFT synchronizer built by the factory
@@ -153,6 +154,8 @@ func (c *Consensus) Stop() {
 	c.Storage.Close()
 	c.Net.Stop()
 	c.status.SetState(node_utils.StateStopped)
+
+	close(c.MainExitChan)
 }
 
 func (c *Consensus) GetStatus() node_utils.NodeStatus {

--- a/node/consensus/consensus_builder.go
+++ b/node/consensus/consensus_builder.go
@@ -45,7 +45,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func CreateConsensus(conf *node_config.ConsenterNodeConfig, net NetStopper, lastConfigBlock *common.Block, logger *flogging.FabricLogger, signer Signer, configUpdateProposer policy.ConfigUpdateProposer) *Consensus {
+func CreateConsensus(conf *node_config.ConsenterNodeConfig, net NetStopper, lastConfigBlock *common.Block, logger *flogging.FabricLogger, mainExitChan chan struct{}, signer Signer, configUpdateProposer policy.ConfigUpdateProposer) *Consensus {
 	if lastConfigBlock == nil {
 		logger.Panicf("Error creating Consensus%d, last config block is nil", conf.PartyId)
 		return nil
@@ -113,6 +113,7 @@ func CreateConsensus(conf *node_config.ConsenterNodeConfig, net NetStopper, last
 		ConfigRulesVerifier: &verify.DefaultOrdererRules{},
 		txCount:             txCount,
 		PrevHash:            prevHash,
+		MainExitChan:        mainExitChan,
 		status:              node_utils.NodeStatus{},
 	}
 

--- a/node/consensus/consensus_real_reconfig_test.go
+++ b/node/consensus/consensus_real_reconfig_test.go
@@ -387,7 +387,7 @@ func createConsensusNodesAndGRPCServers(t *testing.T, dir string, parties []type
 		consenterLogger := testutil.CreateLogger(t, int(i))
 		server := node_utils.CreateGRPCConsensus(consenterConfig)
 		servers = append(servers, server)
-		consensus := consensus_node.CreateConsensus(consenterConfig, server, lastConfigBlock, consenterLogger, signer, &policy.DefaultConfigUpdateProposer{})
+		consensus := consensus_node.CreateConsensus(consenterConfig, server, lastConfigBlock, consenterLogger, make(chan struct{}), signer, &policy.DefaultConfigUpdateProposer{})
 		consensusNodes = append(consensusNodes, consensus)
 	}
 	return consensusNodes, servers

--- a/node/consensus/consensus_test.go
+++ b/node/consensus/consensus_test.go
@@ -312,6 +312,7 @@ func makeConsensusNode(t *testing.T, sk *ecdsa.PrivateKey, partyID arma_types.Pa
 		Net:          &consensus_mocks.FakeNetStopper{},
 		Synchronizer: &consensus_mocks.FakeSynchronizerStopper{},
 		Metrics:      node_consensus.NewConsensusMetrics(&consenterNodeConfig, ledger.Height(), 1, l),
+		MainExitChan: make(chan struct{}),
 	}
 
 	bftWAL, walInitState, err := wal.InitializeAndReadAll(l, dir, wal.DefaultOptions())

--- a/node/consensus/setup_test.go
+++ b/node/consensus/setup_test.go
@@ -175,7 +175,7 @@ func setupConsensusTest(t *testing.T, ca tlsgen.CA, numParties int, genesisBlock
 		mockConfigUpdateProposer := &policyMocks.FakeConfigUpdateProposer{}
 		mockConfigUpdateProposer.ProposeConfigUpdateReturns(nil, nil)
 
-		c := consensus.CreateConsensus(conf, consenterNodes[i].GRPCServer, genesisBlock, logger, signer, mockConfigUpdateProposer)
+		c := consensus.CreateConsensus(conf, consenterNodes[i].GRPCServer, genesisBlock, logger, make(chan struct{}), signer, mockConfigUpdateProposer)
 		grpcRegisterAndStart(c, consenterNodes[i])
 
 		listener := &storageListener{c: make(chan *common.Block, 100)}
@@ -270,7 +270,7 @@ func recoverNode(t *testing.T, setup consensusTestSetup, nodeIndex int, ca tlsge
 	mockConfigUpdateProposer := &policyMocks.FakeConfigUpdateProposer{}
 	mockConfigUpdateProposer.ProposeConfigUpdateReturns(nil, nil)
 
-	setup.consensusNodes[nodeIndex] = consensus.CreateConsensus(setup.configs[nodeIndex], newConsenterNode.GRPCServer, lastConfigBlock, setup.loggers[nodeIndex], signer, mockConfigUpdateProposer)
+	setup.consensusNodes[nodeIndex] = consensus.CreateConsensus(setup.configs[nodeIndex], newConsenterNode.GRPCServer, lastConfigBlock, setup.loggers[nodeIndex], make(chan struct{}), signer, mockConfigUpdateProposer)
 
 	grpcRegisterAndStart(setup.consensusNodes[nodeIndex], newConsenterNode)
 

--- a/node/server/arma.go
+++ b/node/server/arma.go
@@ -120,7 +120,7 @@ func launchConsensus(stop chan struct{}) func(configFile *os.File) {
 		}
 
 		srv := utils.CreateGRPCConsensus(conf)
-		consensus := consensus.CreateConsensus(conf, srv, lastConfigBlock, consenterLogger, signer, &policy.DefaultConfigUpdateProposer{})
+		consensus := consensus.CreateConsensus(conf, srv, lastConfigBlock, consenterLogger, stop, signer, &policy.DefaultConfigUpdateProposer{})
 
 		defer consensus.Start()
 
@@ -130,7 +130,6 @@ func launchConsensus(stop chan struct{}) func(configFile *os.File) {
 
 		go func() {
 			srv.Start()
-			close(stop)
 		}()
 
 		// TODO: move StopSignalListen to Consensus.Start and pass stopChan

--- a/node/server/arma_test.go
+++ b/node/server/arma_test.go
@@ -408,7 +408,7 @@ func TestLaunchArmaNode(t *testing.T) {
 		req := &protos.Request{}
 		mockConfigUpdateProposer.ProposeConfigUpdateReturns(req, nil)
 
-		consensus := consensus.CreateConsensus(conf, srv, genesisBlock, testLogger, signer, mockConfigUpdateProposer)
+		consensus := consensus.CreateConsensus(conf, srv, genesisBlock, testLogger, make(chan struct{}), signer, mockConfigUpdateProposer)
 		require.NotNil(t, consensus)
 		consensus.Storage.Close()
 

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -269,7 +269,7 @@ func createConsenters(t *testing.T, num int, consenterNodes []*node, consenterIn
 		mockConfigUpdateProposer := &policyMocks.FakeConfigUpdateProposer{}
 		mockConfigUpdateProposer.ProposeConfigUpdateReturns(nil, nil)
 
-		c := consensus.CreateConsensus(conf, net, genesisBlock, logger, signer, mockConfigUpdateProposer)
+		c := consensus.CreateConsensus(conf, net, genesisBlock, logger, make(chan struct{}), signer, mockConfigUpdateProposer)
 		mockConfigApplier := &consensusMocks.FakeConfigApplier{}
 		mockConfigApplier.ApplyConfigToStateCalls(func(s *state.State, request *state.ConfigRequest) (*state.State, error) {
 			return s, nil
@@ -487,7 +487,7 @@ func recoverConsenter(t *testing.T, ca tlsgen.CA, conf *node_config.ConsenterNod
 	mockConfigUpdateProposer := &policyMocks.FakeConfigUpdateProposer{}
 	mockConfigUpdateProposer.ProposeConfigUpdateReturns(nil, nil)
 
-	consenter := consensus.CreateConsensus(conf, newConsenterNode.GRPCServer, lastConfigBlock, logger, signer, mockConfigUpdateProposer)
+	consenter := consensus.CreateConsensus(conf, newConsenterNode.GRPCServer, lastConfigBlock, logger, make(chan struct{}), signer, mockConfigUpdateProposer)
 	mockConfigApplier := &consensusMocks.FakeConfigApplier{}
 	mockConfigApplier.ApplyConfigToStateCalls(func(s *state.State, request *state.ConfigRequest) (*state.State, error) {
 		return s, nil


### PR DESCRIPTION
issue #487 

Add mainExitChan to stop net without kill consensus process
The field is exported as it is used in consensus_test.