### PR TITLE
Batcher start  add lock and add comment to lock in address

### DIFF
--- a/node/batcher/batcher.go
+++ b/node/batcher/batcher.go
@@ -97,6 +97,10 @@ func (b *Batcher) ConfigSequence() types.ConfigSequence {
 }
 
 func (b *Batcher) Address() string {
+	// TODO: move stopSignalListen again, and lock the method
+	// b.lock.Lock()
+	// defer b.lock.Unlock()
+
 	if b.Net == nil {
 		return ""
 	}


### PR DESCRIPTION
issue #504 

Calling `b.StartBatcherSevice` from within `b.Run` requires a significant change of the batcher's testing setup