### PR TITLE
Batcher delivery service returns error for non-existing party ID

### DIFF
--- a/node/batcher/batcher_deliver_service.go
+++ b/node/batcher/batcher_deliver_service.go
@@ -96,8 +96,8 @@ func (c *chainManager) GetChain(chainID string) deliver.Chain {
 		c.logger.Errorf("Requested shard does not match this shard: requested=%d, this=%d", shardID, c.ledgerArray.ShardID())
 		return nil
 	}
-	// TODO ledger array should NOT panic if the party is not found
 	if ledger := c.ledgerArray.Part(partyID); ledger == nil {
+		c.logger.Errorf("Requested party ID %d does not exist in batch ledger array", partyID)
 		return nil
 	} else {
 		return &chainReader{ledger: ledger.Ledger()}

--- a/node/ledger/batch_ledger_array.go
+++ b/node/ledger/batch_ledger_array.go
@@ -118,7 +118,8 @@ func (bla *BatchLedgerArray) RetrieveBatchByNumber(partyID types.PartyID, seq ui
 func (bla *BatchLedgerArray) Part(partyID types.PartyID) *BatchLedgerPart {
 	part, ok := bla.ledgerParts[partyID]
 	if !ok {
-		bla.logger.Panicf("partyID does not exist: %d", partyID)
+		bla.logger.Debugf("partyID does not exist: %d", partyID)
+		return nil
 	}
 	return part
 }

--- a/node/ledger/batch_ledger_array_test.go
+++ b/node/ledger/batch_ledger_array_test.go
@@ -153,3 +153,30 @@ func TestBatchLedgerArrayPart(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchLedgerArrayMissingPartyID(t *testing.T) {
+	dir := t.TempDir()
+	logger := flogging.MustGetLogger("test")
+
+	parties := []types.PartyID{1, 2, 3, 4}
+	a, err := NewBatchLedgerArray(1, 1, parties, dir, logger)
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	missing := types.PartyID(99)
+
+	// Part should return nil for a non-existent party
+	part := a.Part(missing)
+	require.Nil(t, part)
+
+	// Height, Append and RetrieveBatchByNumber should panic for non-existent party
+	require.Panics(t, func() { _ = a.Height(missing) })
+
+	require.Panics(t, func() {
+		a.Append(missing, types.BatchSequence(0), 0, types.BatchedRequests{[]byte("x")})
+	})
+
+	require.Panics(t, func() { _ = a.RetrieveBatchByNumber(missing, 0) })
+
+	a.Close()
+}


### PR DESCRIPTION
The required behavior is that the batcher deliver service returns Status_NOT_FOUND when partyID does not exist.
issue #741 