### PR TITLE
Bft synch genesis fetcher

### DIFF
--- a/node/comm/deliver.go
+++ b/node/comm/deliver.go
@@ -136,6 +136,148 @@ func (p *BlockPuller) HeightsByEndpoints() (map[string]uint64, string, error) {
 	return res, myEndpoint, endpointsInfo.err
 }
 
+// GenesisByEndpoints fetches the genesis block (block #0) from all accessible endpoints.
+// Returns a map of endpoint addresses to their genesis blocks.
+// Returns an error if no endpoints are accessible.
+func (p *BlockPuller) GenesisByEndpoints() (map[string]*common.Block, error) {
+	genesisInfos := p.probeGenesisBlocks()
+
+	result := make(map[string]*common.Block)
+	for endpoint, info := range genesisInfos {
+		result[endpoint] = info.block
+		info.conn.Close()
+	}
+
+	if len(result) == 0 {
+		return nil, errors.New("failed to fetch genesis block from any endpoint")
+	}
+
+	p.Logger.Infof("Successfully fetched genesis block from %d endpoints", len(result))
+	return result, nil
+}
+
+// genesisBlockInfo holds information about a genesis block fetched from an endpoint
+type genesisBlockInfo struct {
+	endpoint string
+	block    *common.Block
+	conn     *grpc.ClientConn
+}
+
+// probeGenesisBlocks probes all endpoints in parallel to fetch their genesis blocks
+func (p *BlockPuller) probeGenesisBlocks() map[string]*genesisBlockInfo {
+	genesisInfoChan := make(chan *genesisBlockInfo, len(p.Endpoints))
+
+	var wg sync.WaitGroup
+	wg.Add(len(p.Endpoints))
+
+	for _, endpoint := range p.Endpoints {
+		go func(endpoint EndpointCriteria) {
+			defer wg.Done()
+			info, err := p.fetchGenesisFromEndpoint(endpoint)
+			if err != nil {
+				p.Logger.Warningf("Failed to fetch genesis from %s: %v",
+					endpoint.Endpoint, err)
+				return
+			}
+			genesisInfoChan <- info
+		}(endpoint)
+	}
+
+	wg.Wait()
+	close(genesisInfoChan)
+
+	result := make(map[string]*genesisBlockInfo)
+	for info := range genesisInfoChan {
+		if _, exists := result[info.endpoint]; exists {
+			p.Logger.Warningf("Duplicate endpoint found(%s), skipping it", info.endpoint)
+			info.conn.Close()
+			continue
+		}
+		result[info.endpoint] = info
+	}
+
+	return result
+}
+
+// fetchGenesisFromEndpoint fetches the genesis block from a single endpoint
+func (p *BlockPuller) fetchGenesisFromEndpoint(endpoint EndpointCriteria) (*genesisBlockInfo, error) {
+	// Establish connection
+	conn, err := p.Dialer.Dial(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to dial %s", endpoint.Endpoint)
+	}
+
+	// Create seek envelope for block 0
+	env, err := p.seekSpecificBlock(0)
+	if err != nil {
+		conn.Close()
+		return nil, errors.Wrap(err, "failed to create seek envelope")
+	}
+
+	// Request block
+	stream, err := p.requestBlocks(endpoint.Endpoint, NewImpatientStream(conn, p.FetchTimeout), env)
+	if err != nil {
+		conn.Close()
+		return nil, errors.Wrap(err, "failed to request block")
+	}
+	defer stream.abort()
+
+	// Receive block
+	resp, err := stream.Recv()
+	if err != nil {
+		conn.Close()
+		return nil, errors.Wrap(err, "failed to receive block")
+	}
+
+	// Extract and validate block
+	block, err := extractBlockFromResponse(resp)
+	if err != nil {
+		conn.Close()
+		return nil, errors.Wrap(err, "invalid block response")
+	}
+
+	blockNum := block.GetHeader().GetNumber()
+	if blockNum != 0 {
+		conn.Close()
+		return nil, errors.Errorf("expected block 0, got block %d", blockNum)
+	}
+	stream.CloseSend()
+
+	p.Logger.Infof("Successfully fetched genesis block from %s", endpoint.Endpoint)
+
+	return &genesisBlockInfo{
+		endpoint: endpoint.Endpoint,
+		block:    block,
+		conn:     conn,
+	}, nil
+}
+
+// seekSpecificBlock creates a seek envelope for a specific block number
+func (p *BlockPuller) seekSpecificBlock(blockNum uint64) (*common.Envelope, error) {
+	return protoutil.CreateSignedEnvelopeWithTLSBinding(
+		common.HeaderType_DELIVER_SEEK_INFO,
+		p.Channel,
+		p.Signer,
+		&orderer.SeekInfo{
+			Start: &orderer.SeekPosition{
+				Type: &orderer.SeekPosition_Specified{
+					Specified: &orderer.SeekSpecified{Number: blockNum},
+				},
+			},
+			Stop: &orderer.SeekPosition{
+				Type: &orderer.SeekPosition_Specified{
+					Specified: &orderer.SeekSpecified{Number: blockNum},
+				},
+			},
+			Behavior:      orderer.SeekInfo_BLOCK_UNTIL_READY,
+			ErrorResponse: orderer.SeekInfo_BEST_EFFORT,
+		},
+		int32(0),
+		uint64(0),
+		util.ComputeSHA256(p.TLSCert),
+	)
+}
+
 // UpdateEndpoints assigns the new endpoints and disconnects from the current one.
 func (p *BlockPuller) UpdateEndpoints(endpoints []EndpointCriteria) {
 	p.Logger.Debugf("Updating endpoints: %v", endpoints)

--- a/node/comm/deliver_genesis_fetcher_test.go
+++ b/node/comm/deliver_genesis_fetcher_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright IBM Corp. 2026 All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package comm_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockPullerGenesisByEndpointsHappyPath(t *testing.T) {
+	// Scenario: Three ordering nodes, all return genesis block successfully
+	osn1 := newClusterNode(t)
+	defer osn1.stop()
+
+	osn2 := newClusterNode(t)
+	defer osn2.stop()
+
+	osn3 := newClusterNode(t)
+	defer osn3.stop()
+
+	dialer := newCountingDialer()
+	bp := newBlockPuller(dialer, osn1.srv.Address(), osn2.srv.Address(), osn3.srv.Address())
+
+	// Each node expects a seek request for block 0
+	osn1.addExpectPullAssert(0)
+	osn2.addExpectPullAssert(0)
+	osn3.addExpectPullAssert(0)
+
+	// All nodes return genesis block
+	osn1.enqueueResponse(0)
+	osn2.enqueueResponse(0)
+	osn3.enqueueResponse(0)
+
+	genesisBlocks, err := bp.GenesisByEndpoints()
+	require.NoError(t, err)
+	require.Len(t, genesisBlocks, 3)
+
+	// Verify all blocks are genesis blocks (block 0)
+	for endpoint, block := range genesisBlocks {
+		require.NotNil(t, block, "block from %s should not be nil", endpoint)
+		require.Equal(t, uint64(0), block.GetHeader().GetNumber(), "block from %s should be genesis", endpoint)
+	}
+
+	bp.Close()
+	dialer.assertAllConnectionsClosed(t)
+}
+
+func TestBlockPullerGenesisByEndpointsPartialFailure(t *testing.T) {
+	// Scenario: Three ordering nodes, one offline, one returns error, one succeeds
+	osn1 := newClusterNode(t)
+	// osn1 will be stopped immediately (offline)
+
+	osn2 := newClusterNode(t)
+	defer osn2.stop()
+
+	osn3 := newClusterNode(t)
+	defer osn3.stop()
+
+	dialer := newCountingDialer()
+	bp := newBlockPuller(dialer, osn1.srv.Address(), osn2.srv.Address(), osn3.srv.Address())
+
+	// First node is offline
+	osn1.stop()
+
+	// Second node expects seek but returns forbidden
+	osn2.addExpectPullAssert(0)
+	osn2.blockResponses <- &orderer.DeliverResponse{
+		Type: &orderer.DeliverResponse_Status{Status: common.Status_FORBIDDEN},
+	}
+
+	// Third node succeeds
+	osn3.addExpectPullAssert(0)
+	osn3.enqueueResponse(0)
+
+	genesisBlocks, err := bp.GenesisByEndpoints()
+	require.NoError(t, err)
+	require.Len(t, genesisBlocks, 1)
+
+	// Only osn3 should be in the result
+	block, exists := genesisBlocks[osn3.srv.Address()]
+	require.True(t, exists)
+	require.NotNil(t, block)
+	require.Equal(t, uint64(0), block.GetHeader().GetNumber())
+
+	bp.Close()
+	dialer.assertAllConnectionsClosed(t)
+}
+
+func TestBlockPullerGenesisByEndpointsAllFail(t *testing.T) {
+	// Scenario: All ordering nodes fail to return genesis block
+	osn1 := newClusterNode(t)
+	defer osn1.stop()
+
+	osn2 := newClusterNode(t)
+	defer osn2.stop()
+
+	dialer := newCountingDialer()
+	bp := newBlockPuller(dialer, osn1.srv.Address(), osn2.srv.Address())
+
+	// Both nodes return errors
+	osn1.addExpectPullAssert(0)
+	osn1.blockResponses <- &orderer.DeliverResponse{
+		Type: &orderer.DeliverResponse_Status{Status: common.Status_FORBIDDEN},
+	}
+
+	osn2.addExpectPullAssert(0)
+	osn2.blockResponses <- &orderer.DeliverResponse{
+		Type: &orderer.DeliverResponse_Status{Status: common.Status_SERVICE_UNAVAILABLE},
+	}
+
+	genesisBlocks, err := bp.GenesisByEndpoints()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to fetch genesis block from any endpoint")
+	require.Nil(t, genesisBlocks)
+
+	bp.Close()
+	dialer.assertAllConnectionsClosed(t)
+}
+
+func TestBlockPullerGenesisByEndpointsWrongBlockNumber(t *testing.T) {
+	// Scenario: Node returns wrong block number (not genesis)
+	osn1 := newClusterNode(t)
+	defer osn1.stop()
+
+	osn2 := newClusterNode(t)
+	defer osn2.stop()
+
+	dialer := newCountingDialer()
+	bp := newBlockPuller(dialer, osn1.srv.Address(), osn2.srv.Address())
+
+	// First node returns block 5 instead of block 0
+	osn1.addExpectPullAssert(0)
+	osn1.enqueueResponse(5)
+
+	// Second node returns correct genesis block
+	osn2.addExpectPullAssert(0)
+	osn2.enqueueResponse(0)
+
+	genesisBlocks, err := bp.GenesisByEndpoints()
+	require.NoError(t, err)
+	require.Len(t, genesisBlocks, 1)
+
+	// Only osn2 should be in the result
+	block, exists := genesisBlocks[osn2.srv.Address()]
+	require.True(t, exists)
+	require.NotNil(t, block)
+	require.Equal(t, uint64(0), block.GetHeader().GetNumber())
+
+	bp.Close()
+	dialer.assertAllConnectionsClosed(t)
+}
+
+func TestBlockPullerGenesisByEndpointsDuplicateEndpoints(t *testing.T) {
+	// Scenario: Same endpoint appears twice in the list
+	osn := newClusterNode(t)
+	defer osn.stop()
+
+	dialer := newCountingDialer()
+	// Add the same endpoint twice
+	bp := newBlockPuller(dialer, osn.srv.Address(), osn.srv.Address())
+
+	// Expect two seek requests (one per duplicate)
+	osn.addExpectPullAssert(0)
+	osn.addExpectPullAssert(0)
+
+	// Return genesis block twice
+	osn.enqueueResponse(0)
+	osn.enqueueResponse(0)
+
+	genesisBlocks, err := bp.GenesisByEndpoints()
+	require.NoError(t, err)
+	// Should only have one entry (duplicates handled)
+	require.Len(t, genesisBlocks, 1)
+
+	block, exists := genesisBlocks[osn.srv.Address()]
+	require.True(t, exists)
+	require.NotNil(t, block)
+	require.Equal(t, uint64(0), block.GetHeader().GetNumber())
+
+	bp.Close()
+	dialer.assertAllConnectionsClosed(t)
+}


### PR DESCRIPTION
Add to the old block puller, which now functions as a target height detector, to fetch the genesis blocks of every target node. We will then find (at least) F+1 identical blocks to select a valid block in a BFT fashion. 

This allows a consenter node to join an existing cluster of consenters using only a join-block, and fetch the entire chain. 

#35 
#757 

