### PR TITLE
fix flake eventually submit to batcher

### DIFF
--- a/node/batcher/batcher_reconfig_test.go
+++ b/node/batcher/batcher_reconfig_test.go
@@ -120,9 +120,10 @@ func TestBatcherReceivesConfigBlockFromConsensusAndApplyConfig_ChangeBatchTimeou
 
 	// submit request
 	req := tx.CreateStructuredRequestWithConfigSeq([]byte{2}, 1)
-	resp, err := primaryBatcher.Submit(context.Background(), req)
-	require.NoError(t, err)
-	require.Empty(t, resp.Error)
+	require.Eventually(t, func() bool {
+		resp, err := primaryBatcher.Submit(context.Background(), req)
+		return err == nil && resp.Error == ""
+	}, 60*time.Second, 10*time.Millisecond)
 
 	// make sure request was batched
 	for _, b := range batchers {


### PR DESCRIPTION
`
2026-03-31T07:43:56.5038598Z --- FAIL: TestBatcherReceivesConfigBlockFromConsensusAndApplyConfig_ChangeBatchTimeoutsParam (5.82s)
2026-03-31T07:43:56.5039205Z     batcher_reconfig_test.go:125: 
2026-03-31T07:43:56.5039974Z         	Error Trace:	/home/runner/work/fabric-x-orderer/fabric-x-orderer/node/batcher/batcher_reconfig_test.go:125
2026-03-31T07:43:56.5040991Z         	Error:      	Should be empty, but was pool halted or closed, request rejected
2026-03-31T07:43:56.5041816Z         	Test:       	TestBatcherReceivesConfigBlockFromConsensusAndApplyConfig_ChangeBatchTimeoutsParam
`