### PR TITLE
Change the way we verify block sigs in integration tests

### DIFF
--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -722,17 +722,10 @@ func pullFromAssembler(t *testing.T, userConfig *armageddon.UserConfig, partyID 
 				if err != nil {
 					return fmt.Errorf("failed unmarshalling identifier header for block %d: %v", block.Header.GetNumber(), err)
 				}
-				lastConfigBlockNum := uint64(0) // TODO set last config block num
-				if protoutil.IsConfigBlock(block) {
-					lastConfigBlockNum = block.Header.Number
-				}
 				msg := &state.MessageToSign{
-					IdentifierHeader: metadataSignature.IdentifierHeader,
-					BlockHeader:      protoutil.BlockHeaderBytes(bhdr),
-					OrdererBlockMetadata: protoutil.MarshalOrPanic(&common.OrdererBlockMetadata{
-						LastConfig:        &common.LastConfig{Index: lastConfigBlockNum},
-						ConsenterMetadata: block.Metadata.Metadata[common.BlockMetadataIndex_ORDERER],
-					}),
+					IdentifierHeader:     metadataSignature.IdentifierHeader,
+					BlockHeader:          protoutil.BlockHeaderBytes(bhdr),
+					OrdererBlockMetadata: md.GetValue(),
 				}
 				if err = sigVerifier.VerifySignature(types.PartyID(identifierHeader.Identifier), types.ShardIDConsensus, msg.AsBytes(), metadataSignature.GetSignature()); err != nil {
 					t.Logf("failed verifying signature for block %d: %v", block.Header.GetNumber(), err)


### PR DESCRIPTION
Issue  #769