### PR TITLE
Test configuration update - Remove several parties

### DIFF
--- a/test/send_config_update_test.go
+++ b/test/send_config_update_test.go
@@ -157,6 +157,9 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 	// Wait for Arma nodes to stop
 	testutil.WaitSoftStopped(t, netInfo)
 
+	// Wait for assemblers to relaunch
+	testutil.WaitForRelaunchByType(t, netInfo, []testutil.NodeType{testutil.Assembler}, 1)
+
 	// Pull blocks to verify all transactions are included
 	userBlockHandler := &verifyRouterEndpointUpdate{updatedParty: partyToUpdate, routerIP: routerIP, newPort: newPort}
 	PullFromAssemblers(t, &BlockPullerOptions{


### PR DESCRIPTION
Push the configuration update and verify it was applied successfully.
Remove several parties to reduce F (maximum number of Byzantine nodes)

issue #247