### PR TITLE
add delay in stubConsenter.Restart to fix port binding race

### DIFF
--- a/node/batcher/stub_consenter_test.go
+++ b/node/batcher/stub_consenter_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -100,15 +101,27 @@ func (sc *stubConsenter) StopNet() {
 func (sc *stubConsenter) Restart() {
 	sc.StopNet()
 	addr := sc.net.Address()
-	server, err := comm.NewGRPCServer(addr, comm.ServerConfig{
-		SecOpts: comm.SecureOptions{
-			UseTLS:      true,
-			Certificate: sc.certificate,
-			Key:         sc.key,
-		},
-	})
+
+	var server *comm.GRPCServer
+	var err error
+
+	// Retry up to 10 times with increasing delays
+	for i := range 10 {
+		server, err = comm.NewGRPCServer(addr, comm.ServerConfig{
+			SecOpts: comm.SecureOptions{
+				UseTLS:      true,
+				Certificate: sc.certificate,
+				Key:         sc.key,
+			},
+		})
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Duration(50*(i+1)) * time.Millisecond)
+	}
+
 	if err != nil {
-		panic(fmt.Sprintf("failed to restart gRPC server: %v", err))
+		panic(fmt.Sprintf("failed to restart gRPC server after retries: %v", err))
 	}
 
 	sc.net = server


### PR DESCRIPTION
```
2026-04-12T08:24:01.3718878Z --- FAIL: TestControlEventBroadcasterWaitsForQuorum (14.05s)
2026-04-12T08:24:01.3719441Z panic: failed to restart gRPC server: listen tcp 127.0.0.1:43945: bind: address already in use [recovered, repanicked]
2026-04-12T08:24:01.3719455Z 
2026-04-12T08:24:01.3719592Z goroutine 12605 [running]:
2026-04-12T08:24:01.3719801Z testing.tRunner.func1.2({0x19cd640, 0xc019f12f90})
2026-04-12T08:24:01.3720166Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1872 +0x419
2026-04-12T08:24:01.3720306Z testing.tRunner.func1()
2026-04-12T08:24:01.3720643Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1875 +0x683
2026-04-12T08:24:01.3720794Z panic({0x19cd640?, 0xc019f12f90?})
2026-04-12T08:24:01.3721123Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/panic.go:783 +0x132
2026-04-12T08:24:01.3721618Z github.com/hyperledger/fabric-x-orderer/node/batcher_test.(*stubConsenter).Restart(0xc0008298c0)
2026-04-12T08:24:01.3722158Z 	/home/runner/work/fabric-x-orderer/fabric-x-orderer/node/batcher/stub_consenter_test.go:111 +0x37c
2026-04-12T08:24:01.3722805Z github.com/hyperledger/fabric-x-orderer/node/batcher_test.TestControlEventBroadcasterWaitsForQuorum(0xc000b45dc0)
2026-04-12T08:24:01.3723317Z 	/home/runner/work/fabric-x-orderer/fabric-x-orderer/node/batcher/batcher_test.go:436 +0x1525
2026-04-12T08:24:01.3723479Z testing.tRunner(0xc000b45dc0, 0x1c8a098)
2026-04-12T08:24:01.3723827Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1934 +0x21d
2026-04-12T08:24:01.3723994Z created by testing.(*T).Run in goroutine 1
2026-04-12T08:24:01.3724331Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/testing/testing.go:1997 +0x9d3
2026-04-12T08:24:01.3724630Z FAIL	github.com/hyperledger/fabric-x-orderer/node/batcher	90.818s
```