### PR TITLE
Mempool update options during dynamic reconfig

### DIFF
--- a/node/batcher/batcher.go
+++ b/node/batcher/batcher.go
@@ -31,6 +31,7 @@ import (
 	node_ledger "github.com/hyperledger/fabric-x-orderer/node/ledger"
 	protos "github.com/hyperledger/fabric-x-orderer/node/protos/comm"
 	node_utils "github.com/hyperledger/fabric-x-orderer/node/utils"
+	"github.com/hyperledger/fabric-x-orderer/request"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 )
@@ -376,6 +377,17 @@ func (b *Batcher) stopAndReconfigure(newConfig *config.Configuration, lastBlock 
 	b.fullConfig = newConfig
 	b.configureBatcher(&ConsenterControlEventSenderFactory{}, b.batcher.MemPool, lastKnownDecisionNum)
 	newConfigSeq := newBatcherConfig.Bundle.ConfigtxValidator().Sequence()
+	poolOptions := request.PoolOptions{
+		MaxSize:               newBatcherConfig.MemPoolMaxSize,
+		BatchMaxSize:          newBatcherConfig.BatchMaxSize,
+		BatchMaxSizeBytes:     newBatcherConfig.BatchMaxBytes,
+		RequestMaxBytes:       newBatcherConfig.RequestMaxBytes,
+		SubmitTimeout:         newBatcherConfig.SubmitTimeout,
+		FirstStrikeThreshold:  newBatcherConfig.FirstStrikeThreshold,
+		SecondStrikeThreshold: newBatcherConfig.SecondStrikeThreshold,
+		AutoRemoveTimeout:     newBatcherConfig.AutoRemoveTimeout,
+	}
+	b.batcher.MemPool.UpdateOptions(poolOptions)
 	b.lock.Unlock()
 
 	// prune mempool

--- a/node/batcher/batcher_role.go
+++ b/node/batcher/batcher_role.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
+	"github.com/hyperledger/fabric-x-orderer/request"
 	"github.com/pkg/errors"
 )
 
@@ -37,6 +38,7 @@ type MemPool interface {
 	RequestCount() int64
 	Close()
 	Prune(predicate func([]byte) error)
+	UpdateOptions(options request.PoolOptions)
 }
 
 //go:generate counterfeiter -o mocks/state_provider.go . StateProvider

--- a/node/batcher/mocks/mem_pool.go
+++ b/node/batcher/mocks/mem_pool.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/hyperledger/fabric-x-orderer/node/batcher"
+	"github.com/hyperledger/fabric-x-orderer/request"
 )
 
 type FakeMemPool struct {
@@ -63,6 +64,11 @@ type FakeMemPool struct {
 	}
 	submitReturnsOnCall map[int]struct {
 		result1 error
+	}
+	UpdateOptionsStub        func(request.PoolOptions)
+	updateOptionsMutex       sync.RWMutex
+	updateOptionsArgsForCall []struct {
+		arg1 request.PoolOptions
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -384,6 +390,37 @@ func (fake *FakeMemPool) SubmitReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeMemPool) UpdateOptions(arg1 request.PoolOptions) {
+	fake.updateOptionsMutex.Lock()
+	fake.updateOptionsArgsForCall = append(fake.updateOptionsArgsForCall, struct {
+		arg1 request.PoolOptions
+	}{arg1})
+	fake.recordInvocation("UpdateOptions", []interface{}{arg1})
+	fake.updateOptionsMutex.Unlock()
+	if fake.UpdateOptionsStub != nil {
+		fake.UpdateOptionsStub(arg1)
+	}
+}
+
+func (fake *FakeMemPool) UpdateOptionsCallCount() int {
+	fake.updateOptionsMutex.RLock()
+	defer fake.updateOptionsMutex.RUnlock()
+	return len(fake.updateOptionsArgsForCall)
+}
+
+func (fake *FakeMemPool) UpdateOptionsCalls(stub func(request.PoolOptions)) {
+	fake.updateOptionsMutex.Lock()
+	defer fake.updateOptionsMutex.Unlock()
+	fake.UpdateOptionsStub = stub
+}
+
+func (fake *FakeMemPool) UpdateOptionsArgsForCall(i int) request.PoolOptions {
+	fake.updateOptionsMutex.RLock()
+	defer fake.updateOptionsMutex.RUnlock()
+	argsForCall := fake.updateOptionsArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeMemPool) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -403,6 +440,8 @@ func (fake *FakeMemPool) Invocations() map[string][][]interface{} {
 	defer fake.restartMutex.RUnlock()
 	fake.submitMutex.RLock()
 	defer fake.submitMutex.RUnlock()
+	fake.updateOptionsMutex.RLock()
+	defer fake.updateOptionsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/request/batchstore.go
+++ b/request/batchstore.go
@@ -202,3 +202,11 @@ func (bs *BatchStore) prepareBatch(readyBatch *batch) []interface{} {
 
 	return batch
 }
+
+func (bs *BatchStore) updateOptions(batchMaxSize uint32, batchMaxSizeBytes uint32) {
+	bs.lock.Lock()
+	defer bs.lock.Unlock()
+
+	bs.batchMaxSize = batchMaxSize
+	bs.batchMaxSizeBytes = batchMaxSizeBytes
+}

--- a/request/pending.go
+++ b/request/pending.go
@@ -377,3 +377,10 @@ func (ps *PendingStore) GetAllRequests(max uint64) [][]byte {
 
 	return requests
 }
+
+func (ps *PendingStore) updateOptions(firstStrikeThreshold, secondStrikeThreshold, autoRemoveTimeout time.Duration) {
+	ps.ReqIDGCInterval = autoRemoveTimeout / 4
+	ps.ReqIDLifetime = autoRemoveTimeout
+	ps.SecondStrikeThreshold = secondStrikeThreshold
+	ps.FirstStrikeThreshold = firstStrikeThreshold
+}

--- a/request/pool.go
+++ b/request/pool.go
@@ -377,3 +377,21 @@ func (rp *Pool) moveToBatchStore() {
 	rp.pending = nil
 	atomic.StoreInt64(&rp.size, int64(len(requests)))
 }
+
+// UpdateOptions updates only the pool options.
+// This method is expected to be called after the pool is halted.
+func (rp *Pool) UpdateOptions(options PoolOptions) {
+	rp.lock.Lock()
+	defer rp.lock.Unlock()
+
+	if rp.isClosed() {
+		return
+	}
+
+	rp.options = options
+	if rp.batchingEnabled {
+		rp.batchStore.updateOptions(rp.options.BatchMaxSize, rp.options.BatchMaxSizeBytes)
+	} else {
+		rp.pending.updateOptions(rp.options.FirstStrikeThreshold, rp.options.SecondStrikeThreshold, rp.options.AutoRemoveTimeout)
+	}
+}

--- a/test/send_config_update_test.go
+++ b/test/send_config_update_test.go
@@ -1940,7 +1940,6 @@ func (vt *verifySmartBFTParam) HandleBlock(t *testing.T, block *common.Block) er
 
 // TestUpdateBatchingParameters verifies that updating a party's batching parameters via a config update succeeds,
 // and that the party can continue processing transactions after the config update with the new batching parameters.
-// TODO: dynamic reconfig instead of stop and restart
 func TestUpdateBatchingParameters(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -1975,6 +1974,7 @@ func TestUpdateBatchingParameters(t *testing.T) {
 	require.NotNil(t, userConfig)
 
 	txNumber := 100
+
 	// rate limiter parameters
 	fillInterval := 10 * time.Millisecond
 	fillFrequency := 1000 / int(fillInterval.Milliseconds())
@@ -2012,18 +2012,10 @@ func TestUpdateBatchingParameters(t *testing.T) {
 
 	broadcastClient.Stop()
 
-	// Wait for Arma nodes to stop
-	testutil.WaitSoftStopped(t, netInfo)
+	t.Log("Wait for arma nodes to restart dynamically")
+	testutil.WaitForNetworkRelaunch(t, netInfo, 1)
 
-	// Restart Arma nodes
-	armaNetwork.Stop()
-
-	armaNetwork.Restart(t, readyChan)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
-
-	// Send transactions again and verify they are processed
+	// Send transactions and verify they are processed
 	broadcastClient = client.NewBroadcastTxClient(userConfig, 10*time.Second)
 
 	for i := range txNumber {

--- a/test/send_config_update_test.go
+++ b/test/send_config_update_test.go
@@ -82,11 +82,11 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 	require.NotNil(t, userConfig)
 
 	totalTxNumber := 100
+
 	// rate limiter parameters
 	fillInterval := 10 * time.Millisecond
 	fillFrequency := 1000 / int(fillInterval.Milliseconds())
 	rate := 500
-
 	capacity := rate / fillFrequency
 	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
 	if err != nil {
@@ -134,7 +134,7 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 	configUpdateBuilder, cleanUp := configutil.NewConfigUpdateBuilder(t, dir, filepath.Join(dir, "bootstrap", "bootstrap.block"))
 	defer cleanUp()
 
-	partyToUpdate := types.PartyID(submittingParty)
+	partyToUpdate := submittingParty
 	routerIP := strings.Split(userConfig.RouterEndpoints[partyToUpdate-1], ":")[0] // extract IP from the user config router endpoint
 	availablePort, newListener := testutil.GetAvailablePort(t)
 	newPort, err := strconv.Atoi(availablePort)
@@ -144,7 +144,7 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 
 	configUpdatePbData := configUpdateBuilder.UpdateRouterEndpoint(t, partyToUpdate, routerIP, newPort)
 
-	// Submit config update
+	// Create config tx
 	env := configutil.CreateConfigTX(t, dir, parties, int(submittingParty), configUpdatePbData)
 	require.NotNil(t, env)
 
@@ -154,8 +154,16 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 
 	broadcastClient.Stop()
 
-	// Wait for Arma nodes to stop
-	testutil.WaitSoftStopped(t, netInfo)
+	// Wait for the router to enter pending admin state and then stop it
+	t.Log("Wait for the router to enter pending admin state and then stop it")
+	testutil.WaitForPendingAdminByTypeAndParty(t, netInfo, []testutil.NodeType{testutil.Router}, []types.PartyID{partyToUpdate})
+	armaNetwork.GetRouter(t, partyToUpdate).StopArmaNode()
+
+	// Wait for arma nodes to restart dynamically
+	t.Log("Wait for arma nodes to restart dynamically")
+	testutil.WaitForRelaunchByType(t, netInfo, []testutil.NodeType{testutil.Consensus, testutil.Assembler, testutil.Batcher}, 1)
+	nonUpdatedRouterParties := []types.PartyID{2, 3, 4}
+	testutil.WaitForRelaunchByTypeAndParty(t, netInfo, []testutil.NodeType{testutil.Router}, nonUpdatedRouterParties, 1)
 
 	// Pull blocks to verify all transactions are included
 	userBlockHandler := &verifyRouterEndpointUpdate{updatedParty: partyToUpdate, routerIP: routerIP, newPort: newPort}
@@ -172,12 +180,8 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 
 	require.True(t, userBlockHandler.RouterEndpointUpdated.Load(), "Router endpoint was not updated in the config update")
 
-	// Restart Arma nodes
-	armaNetwork.Stop()
-
+	// Verify the config stored in the router's config store is updated
 	routerNodeConfigPath := filepath.Join(dir, "config", fmt.Sprintf("party%d", partyToUpdate), "local_config_router.yaml")
-
-	// Verify the router node config stored in the router ledger is updated
 	cfg, _, err := config.ReadConfig(routerNodeConfigPath, testutil.CreateLoggerForModule(t, "ReadConfigRouter", zap.DebugLevel))
 	require.NoError(t, err)
 	require.True(t, cfg.SharedConfig.GetPartiesConfig()[partyToUpdate-1].RouterConfig.Host == routerIP &&
@@ -190,17 +194,18 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 	localConfig.NodeLocalConfig.GeneralConfig.ListenPort = uint32(newPort)
 	utils.WriteToYAML(localConfig.NodeLocalConfig, routerNodeConfigPath)
 
-	armaNetwork.Restart(t, readyChan)
-	defer armaNetwork.Stop()
+	// Restart Router only
+	t.Log("Restart Router")
+	armaNetwork.GetRouter(t, partyToUpdate).RestartArmaNode(t, readyChan)
 
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
-
-	// Send transactions again and verify they are processed
+	testutil.WaitReady(t, readyChan, 1, 10)
 
 	// Update the user config with the new router endpoint
-	userConfig.RouterEndpoints[0] = fmt.Sprintf("%s:%d", routerIP, newPort)
+	userConfig.RouterEndpoints[partyToUpdate-1] = fmt.Sprintf("%s:%d", routerIP, newPort)
 	broadcastClient = client.NewBroadcastTxClient(userConfig, 10*time.Second)
 
+	// Send transactions again and verify they are processed
+	t.Log("Send transactions")
 	for i := range totalTxNumber {
 		status := rl.GetToken()
 		if !status {
@@ -229,6 +234,7 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 	})
 
 	require.True(t, userBlockHandler.RouterEndpointUpdated.Load(), "Router endpoint was not updated in the config update")
+	armaNetwork.Stop()
 }
 
 // Verify that the config update is applied by checking the router endpoint in the config update block
@@ -270,7 +276,7 @@ func TestRemovePartyRunAll(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	configPath := filepath.Join(dir, "config.yaml")
-	numOfParties := 4
+	numOfParties := 5
 	numOfShards := 2
 	submittingParty := types.PartyID(1)
 
@@ -312,6 +318,13 @@ func TestRemovePartyRunAll(t *testing.T) {
 		parties = append(parties, types.PartyID(i))
 	}
 
+	remainingParties := make([]types.PartyID, 0, numOfParties-1)
+	for i := 1; i <= numOfParties; i++ {
+		if types.PartyID(i) != partyToRemove {
+			parties = append(parties, types.PartyID(i))
+		}
+	}
+
 	// Submit config update
 	env := configutil.CreateConfigTX(t, dir, parties, int(submittingParty), configUpdatePbData)
 	require.NotNil(t, env)
@@ -320,9 +333,10 @@ func TestRemovePartyRunAll(t *testing.T) {
 	err = broadcastClient.SendTxTo(env, submittingParty)
 	require.NoError(t, err)
 
-	// Wait for Arma nodes to stop
+	// Wait for Arma nodes to soft stop
 	testutil.WaitSoftStopped(t, netInfo)
 
+	// Check that shared config of Router does not include the removed party
 	routerNodeConfigPath := filepath.Join(dir, "config", fmt.Sprintf("party%d", submittingParty), "local_config_router.yaml")
 	routerNodeConfig, _, err := config.ReadConfig(routerNodeConfigPath, testutil.CreateLoggerForModule(t, "ReadConfigRouter", zap.DebugLevel))
 	require.NoError(t, err)
@@ -332,38 +346,34 @@ func TestRemovePartyRunAll(t *testing.T) {
 		require.NotEqual(t, partyToRemove, partyConfig.PartyID, "Removed party still exists in the config")
 	}
 
-	// Stop Arma nodes
-	armaNetwork.Stop()
+	// Wait for the removed party to enter pending admin state and then stop the party
+	t.Log("Wait for the removed party to enter pending admin state and then stop the party")
+	testutil.WaitForPendingAdminByTypeAndParty(t, netInfo, []testutil.NodeType{testutil.Consensus, testutil.Assembler, testutil.Batcher, testutil.Router}, []types.PartyID{partyToRemove})
+	armaNetwork.StopParties([]types.PartyID{partyToRemove})
+
+	// Wait for arma nodes to restart dynamically
+	t.Log("Wait for arma nodes to restart dynamically")
+	testutil.WaitForRelaunchByTypeAndParty(t, netInfo, []testutil.NodeType{testutil.Consensus, testutil.Assembler, testutil.Batcher, testutil.Router}, remainingParties, 1)
 
 	numOfNodesPerParty := 3 + numOfShards
 	readyChan = make(chan string, (numOfParties-1)*numOfNodesPerParty)
 
 	// Try to restart the removed party nodes, expect them to fail to start
+	t.Log("Try to restart the removed party nodes, expect them to fail to start")
 	armaNetwork.RestartParties(t, []types.PartyID{partyToRemove}, readyChan)
 	defer armaNetwork.Stop()
-	// Expect the removed party nodes to fail to start
 	// TODO: improve the detection of failed nodes by checking specific exit codes,
 	// rather than relying on string matching in the output
 	// every node should report a panic during startup
 	testutil.WaitPanic(t, readyChan, numOfNodesPerParty-1, 10)
 
-	numOfArmaNodes = (numOfParties - 1) * numOfNodesPerParty
-	readyChan = make(chan string, numOfArmaNodes)
-	// Restart the remaining parties' nodes
-	remainingParties := []types.PartyID{}
-	for i := 1; i <= numOfParties; i++ {
-		if types.PartyID(i) != partyToRemove {
-			remainingParties = append(remainingParties, types.PartyID(i))
-		}
-	}
-	armaNetwork.RestartParties(t, remainingParties, readyChan)
-	// Expect the rest of the nodes to start successfully
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+	armaNetwork.StopParties(remainingParties)
 }
 
 // TestRemoveStoppedPartyThenRestart verifies that after removing a stopped party that via a config update
 // and stopping all Arma nodes, restarting the entire network results in all nodes starting successfully,
 // while the removed party's nodes fail to establish connections to the rest of the network.
+// TODO: dynamic reconfig instead of stop and restart
 func TestRemoveStoppedPartyThenRestart(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -528,7 +538,7 @@ func TestRemoveParty(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	configPath := filepath.Join(dir, "config.yaml")
-	numOfParties := 4
+	numOfParties := 5
 	numOfShards := 2
 	submittingParty := types.PartyID(1)
 
@@ -560,6 +570,7 @@ func TestRemoveParty(t *testing.T) {
 	require.NotNil(t, uc)
 
 	totalTxNumber := 10
+
 	// Send transactions to all parties to ensure network is operational before config update
 	signer, certBytes, err := testutil.LoadCryptoMaterialsFromDir(t, uc.MSPDir)
 	require.NoError(t, err)
@@ -572,8 +583,10 @@ func TestRemoveParty(t *testing.T) {
 		err = broadcastClient.SendTx(env)
 		require.NoError(t, err)
 	}
+
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 	statusUnknown := common.Status_UNKNOWN
+
 	// Pull blocks to verify all transactions are included
 	PullFromAssemblers(t, &BlockPullerOptions{
 		UserConfig:   uc,
@@ -602,11 +615,8 @@ func TestRemoveParty(t *testing.T) {
 
 	broadcastClient.Stop()
 
-	// Wait for Arma nodes to stop
+	// Wait for Arma nodes to soft stop
 	testutil.WaitSoftStopped(t, netInfo)
-
-	// Stop Arma nodes
-	armaNetwork.Stop()
 
 	// Verify that the party is removed by checking the router's shared config
 	var remainingParties []types.PartyID
@@ -617,31 +627,26 @@ func TestRemoveParty(t *testing.T) {
 		remainingParties = append(remainingParties, types.PartyID(i))
 	}
 
-	numOfParties--
-	numOfArmaNodes = numOfParties * (3 + numOfShards)
-
 	routerNodeConfigPath := filepath.Join(dir, "config", fmt.Sprintf("party%d", submittingParty), "local_config_router.yaml")
 	routerNodeConfig, _, err := config.ReadConfig(routerNodeConfigPath, testutil.CreateLoggerForModule(t, "ReadConfigRouter", zap.DebugLevel))
 	require.NoError(t, err)
-	require.Equal(t, numOfParties, len(routerNodeConfig.SharedConfig.GetPartiesConfig()), "Party was not removed from the config")
+	require.Equal(t, len(remainingParties), len(routerNodeConfig.SharedConfig.GetPartiesConfig()), "Party was not removed from the config")
 
 	for _, partyConfig := range routerNodeConfig.SharedConfig.GetPartiesConfig() {
 		require.NotEqual(t, partyToRemove, partyConfig.PartyID, "Removed party still exists in the config")
 	}
 
-	// Restart remaining Arma nodes
-	readyChan = make(chan string, numOfArmaNodes)
+	// Wait for the removed party to enter pending admin state and then stop the party
+	t.Log("Wait for the removed party to enter pending admin state and then stop the party")
+	testutil.WaitForPendingAdminByTypeAndParty(t, netInfo, []testutil.NodeType{testutil.Consensus, testutil.Assembler, testutil.Batcher, testutil.Router}, []types.PartyID{partyToRemove})
+	armaNetwork.StopParties([]types.PartyID{partyToRemove})
 
-	// Try to restart the remaining Arma nodes, removed party nodes will fail to start but the rest should start successfully
-	armaNetwork.RestartParties(t, remainingParties, readyChan)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+	// Wait for arma nodes to restart dynamically
+	t.Log("Wait for arma nodes to restart dynamically")
+	testutil.WaitForRelaunchByTypeAndParty(t, netInfo, []testutil.NodeType{testutil.Consensus, testutil.Assembler, testutil.Batcher, testutil.Router}, remainingParties, 1)
 
 	// Send transactions to remaining parties to verify they are processed
-
 	uc.RouterEndpoints = append(uc.RouterEndpoints[:partyToRemove-1], uc.RouterEndpoints[partyToRemove:]...)
-
 	broadcastClient = client.NewBroadcastTxClient(uc, 10*time.Second)
 
 	for i := range totalTxNumber {
@@ -654,6 +659,7 @@ func TestRemoveParty(t *testing.T) {
 	broadcastClient.Stop()
 
 	statusUnknown = common.Status_UNKNOWN
+
 	// Pull blocks to verify all transactions are included
 	PullFromAssemblers(t, &BlockPullerOptions{
 		UserConfig:   uc,
@@ -664,11 +670,14 @@ func TestRemoveParty(t *testing.T) {
 		Status:       &statusUnknown,
 		Signer:       signutil.CreateTestSigner(t, "org1", dir),
 	})
+
+	armaNetwork.StopParties(remainingParties)
 }
 
 // TestAddNewParty verifies that adding a party via a config update succeeds,
 // that the new party's config is included in the updated shared config,
 // and that the new party can join (start) and process transactions after the config update.
+// TODO: dynamic reconfig instead of stop and restart
 func TestAddNewParty(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -865,6 +874,7 @@ func TestAddNewParty(t *testing.T) {
 
 // TestChangePartyCertificates verifies that updating a party's certificates via a config update succeeds,
 // and that the party can continue processing transactions after the config update with the new certificates.
+// TODO: dynamic reconfig instead of stop and restart
 func TestChangePartyCertificates(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -1113,6 +1123,8 @@ func TestChangePartyCertificates(t *testing.T) {
 //  4. Restart again, extend client trust with the new TLS CA, and verify continued transaction submission and block pulling.
 //  5. Replace party crypto material on disk, update config to use only the new CA certs, and submit final config update.
 //  6. Restart once more and confirm the network remains operational by sending and pulling additional transactions.
+//
+// TODO: dynamic reconfig instead of stop and restart
 func TestChangePartyCACertificates(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -1578,6 +1590,7 @@ func uniqueFileName(path string) string {
 
 // TestUpdateTimeoutParameters verifies that updating a party's timeout parameters via a config update succeeds,
 // and that the party can continue processing transactions after the config update with the new timeout parameters.
+// TODO: dynamic reconfig instead of stop and restart
 func TestUpdateTimeoutParameters(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -1752,6 +1765,7 @@ func (vt *verifyTimeoutParam) HandleBlock(t *testing.T, block *common.Block) err
 
 // TestUpdateSmartBFTParameters verifies that updating SmartBFT parameters via a config update succeeds,
 // and that the network can continue processing transactions after the config update with the new parameters.
+// TODO: dynamic reconfig instead of stop and restart
 func TestUpdateSmartBFTParameters(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())
@@ -1926,6 +1940,7 @@ func (vt *verifySmartBFTParam) HandleBlock(t *testing.T, block *common.Block) er
 
 // TestUpdateBatchingParameters verifies that updating a party's batching parameters via a config update succeeds,
 // and that the party can continue processing transactions after the config update with the new batching parameters.
+// TODO: dynamic reconfig instead of stop and restart
 func TestUpdateBatchingParameters(t *testing.T) {
 	// Prepare Arma config and crypto and get the genesis block
 	dir, err := os.MkdirTemp("", t.Name())

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -535,9 +535,118 @@ func WaitForNetworkRelaunch(t *testing.T, netInfo map[NodeName]*ArmaNodeInfo, co
 	time.Sleep(time.Minute) // wait for consenters.
 }
 
+func WaitForRelaunchByTypeAndParty(t *testing.T, netInfo map[NodeName]*ArmaNodeInfo, nodeTypes []NodeType, parties []types.PartyID, configSeq uint64) {
+	errCh := make(chan error, len(netInfo))
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+
+		for _, n := range netInfo {
+			if !containsNodeType(nodeTypes, n.NodeType) {
+				continue
+			}
+			if !containsParty(n.PartyId, parties) {
+				continue
+			}
+			wg.Add(1)
+			go func(n *ArmaNodeInfo) {
+				defer wg.Done()
+				detectCh := n.RunInfo.Session.Err.Detect("started with new config sequence %d", configSeq)
+				defer n.RunInfo.Session.Err.CancelDetects()
+				select {
+				case <-detectCh:
+					return
+				case <-time.After(120 * time.Second):
+					errCh <- fmt.Errorf("timed out waiting for node %s_%d_%d to launch", n.NodeType.String(), n.PartyId, n.ShardId)
+				}
+			}(n)
+		}
+
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		select {
+		case err := <-errCh:
+			require.Fail(t, err.Error())
+		default:
+			return
+		}
+	case <-time.After(180 * time.Second):
+		select {
+		case err := <-errCh:
+			require.Fail(t, err.Error())
+		default:
+			require.Fail(t, "Timed out waiting for required nodes to launch")
+		}
+	}
+}
+
+func WaitForPendingAdminByTypeAndParty(t *testing.T, netInfo map[NodeName]*ArmaNodeInfo, nodeTypes []NodeType, parties []types.PartyID) {
+	errCh := make(chan error, len(netInfo))
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+
+		for _, n := range netInfo {
+			if !containsNodeType(nodeTypes, n.NodeType) {
+				continue
+			}
+			if !containsParty(n.PartyId, parties) {
+				continue
+			}
+			wg.Add(1)
+			go func(n *ArmaNodeInfo) {
+				defer wg.Done()
+				detectCh := n.RunInfo.Session.Err.Detect("Pending admin action to apply new config")
+				defer n.RunInfo.Session.Err.CancelDetects()
+				select {
+				case <-detectCh:
+					return
+				case <-time.After(120 * time.Second):
+					errCh <- fmt.Errorf("timed out waiting for node %s_%d_%d to enter pending admin state", n.NodeType.String(), n.PartyId, n.ShardId)
+				}
+			}(n)
+		}
+
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		select {
+		case err := <-errCh:
+			require.Fail(t, err.Error())
+		default:
+			return
+		}
+	case <-time.After(180 * time.Second):
+		select {
+		case err := <-errCh:
+			require.Fail(t, err.Error())
+		default:
+			require.Fail(t, "Timed out waiting for required nodes to enter pending admin state")
+		}
+	}
+}
+
 func containsNodeType(nodeTypes []NodeType, nodeType NodeType) bool {
 	for _, nt := range nodeTypes {
 		if nt == nodeType {
+			return true
+		}
+	}
+	return false
+}
+
+func containsParty(nodeParty types.PartyID, parties []types.PartyID) bool {
+	for _, p := range parties {
+		if p == nodeParty {
 			return true
 		}
 	}


### PR DESCRIPTION
During dynamic reconfiguration in the batcher, the batcher memory pool PoolOptions should be updated.
If not, after a config change of a batch param, a primary batcher might propose a batch with the old size, and then the secondary batcher rejects that batch, for example.

This PR updates `TestUpdateBatchingParameters` to a dynamic reconfig scenario, in which the batchMazSize parameter is updated, and nodes restart dynamically as a result.

issues: #799 #247 
