### PR TITLE
shared port-allocator

### DIFF
--- a/node/consensus/consensus_real_reconfig_test.go
+++ b/node/consensus/consensus_real_reconfig_test.go
@@ -57,7 +57,7 @@ func TestConsensusWithRealConfigUpdate(t *testing.T) {
 
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, len(parties), numOfShards, "TLS", "none")
+	netInfo := testutil.CreateNetworkWithPortAllocator(t, configPath, len(parties), numOfShards, "TLS", "none", testutil.SharedTestPortAllocator())
 	require.NotNil(t, netInfo)
 
 	nodesIPs := testutil.GetNodesIPsFromNetInfo(netInfo)
@@ -65,7 +65,7 @@ func TestConsensusWithRealConfigUpdate(t *testing.T) {
 
 	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
 
-	updateFileStorePath(t, dir, parties)
+	updateFileStoreAndMonitoringPort(t, dir, netInfo)
 
 	netInfo.CleanUp()
 	consensusNodes, servers, _ := createConsensusNodesAndGRPCServers(t, dir, parties)

--- a/node/consensus/setup_real_test.go
+++ b/node/consensus/setup_real_test.go
@@ -8,6 +8,7 @@ package consensus_test
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,7 +18,6 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/common/policy"
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
-	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/config"
 	"github.com/hyperledger/fabric-x-orderer/node/comm"
 	consensus_node "github.com/hyperledger/fabric-x-orderer/node/consensus"
@@ -32,12 +32,12 @@ import (
 
 func createTestSetupReal(t *testing.T, dir string, parties []types.PartyID, numOfShards int) (*common.Block, consensusTestSetup) {
 	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, len(parties), numOfShards, "TLS", "none")
+	netInfo := testutil.CreateNetworkWithPortAllocator(t, configPath, len(parties), numOfShards, "TLS", "none", testutil.SharedTestPortAllocator())
 	require.NotNil(t, netInfo)
 
 	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
 
-	updateFileStorePath(t, dir, parties)
+	updateFileStoreAndMonitoringPort(t, dir, netInfo)
 
 	netInfo.CleanUp()
 	consensusNodes, servers, genesisBlock := createConsensusNodesAndGRPCServers(t, dir, parties)
@@ -149,24 +149,19 @@ func startConsensusNodesAndRegisterGRPCServers(t *testing.T, parties []types.Par
 	return ledgerListeners
 }
 
-func updateFileStorePath(t *testing.T, dir string, parties []types.PartyID) {
-	for _, i := range parties {
-		fileStoreDir := t.TempDir()
-		nodeConfigPath := filepath.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_consenter.yaml")
-		localConfig, _, err := config.LoadLocalConfig(nodeConfigPath)
-		require.NoError(t, err)
-		localConfig.NodeLocalConfig.FileStore.Path = fileStoreDir
-		err = utils.WriteToYAML(localConfig.NodeLocalConfig, nodeConfigPath)
-		require.NoError(t, err)
-	}
-
-	for _, i := range parties {
-		fileStoreDir := t.TempDir()
-		nodeConfigPath := filepath.Join(dir, "config", fmt.Sprintf("party%d", i), "local_config_batcher1.yaml")
-		localConfig, _, err := config.LoadLocalConfig(nodeConfigPath)
-		require.NoError(t, err)
-		localConfig.NodeLocalConfig.FileStore.Path = fileStoreDir
-		err = utils.WriteToYAML(localConfig.NodeLocalConfig, nodeConfigPath)
-		require.NoError(t, err)
+func updateFileStoreAndMonitoringPort(t *testing.T, dir string, netInfo testutil.ArmaNodesInfoMap) {
+	for _, nodeInfo := range netInfo {
+		var nodeConfigPath string
+		switch nodeInfo.NodeType {
+		case testutil.Consensus:
+			nodeConfigPath = filepath.Join(dir, "config", fmt.Sprintf("party%d", nodeInfo.PartyId), "local_config_consenter.yaml")
+		case testutil.Batcher:
+			nodeConfigPath = filepath.Join(dir, "config", fmt.Sprintf("party%d", nodeInfo.PartyId), fmt.Sprintf("local_config_batcher%d.yaml", nodeInfo.ShardId))
+		default:
+			continue
+		}
+		storagePath := t.TempDir()
+		monitoringPort := uint32(nodeInfo.MonitoringListener.Addr().(*net.TCPAddr).Port)
+		testutil.EditDirectoryInNodeConfigYAML(t, nodeConfigPath, storagePath, nodeInfo.ConfigBlockPath, monitoringPort)
 	}
 }

--- a/testutil/port_allocator.go
+++ b/testutil/port_allocator.go
@@ -1,0 +1,100 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testutil
+
+import (
+	"net"
+	"sync"
+	"testing"
+)
+
+// PortAllocator allocates a TCP port and returns both its numeric string and
+// the listener that currently holds it.
+type PortAllocator interface {
+	Allocate(t *testing.T) (port string, ll net.Listener)
+}
+
+// DefaultPortAllocator preserves the current behavior by delegating every
+// allocation to GetAvailablePort.
+type DefaultPortAllocator struct{}
+
+func (a *DefaultPortAllocator) Allocate(t *testing.T) (string, net.Listener) {
+	return GetAvailablePort(t)
+}
+
+// TestScopedPortAllocator tracks allocated ports by test name and prevents
+// assigning the same port to multiple tests in the same process.
+type TestScopedPortAllocator struct {
+	lock          sync.Mutex
+	portsByTest   map[string][]string
+	ownerByPort   map[string]string
+	cleanupByTest map[string]bool
+	allocatePort  func(t *testing.T) (string, net.Listener)
+	retryAttempts int
+}
+
+func NewTestScopedPortAllocator() *TestScopedPortAllocator {
+	return &TestScopedPortAllocator{
+		portsByTest:   make(map[string][]string),
+		ownerByPort:   make(map[string]string),
+		cleanupByTest: make(map[string]bool),
+		allocatePort:  GetAvailablePort,
+		retryAttempts: 32,
+	}
+}
+
+func (a *TestScopedPortAllocator) Allocate(t *testing.T) (string, net.Listener) {
+	testName := t.Name()
+
+	a.lock.Lock()
+	if !a.cleanupByTest[testName] {
+		a.cleanupByTest[testName] = true
+		t.Cleanup(func() {
+			a.releaseTest(testName)
+		})
+	}
+	a.lock.Unlock()
+
+	for attempt := 0; attempt < a.retryAttempts; attempt++ {
+		port, ll := a.allocatePort(t)
+
+		a.lock.Lock()
+		_, exists := a.ownerByPort[port]
+		if !exists {
+			a.ownerByPort[port] = testName
+			a.portsByTest[testName] = append(a.portsByTest[testName], port)
+			a.lock.Unlock()
+			return port, ll
+		}
+		a.lock.Unlock()
+
+		_ = ll.Close()
+	}
+
+	t.Fatalf("failed allocating a unique port for test %s after %d attempts", testName, a.retryAttempts)
+	return "", nil
+}
+
+func (a *TestScopedPortAllocator) releaseTest(testName string) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	ports := a.portsByTest[testName]
+	for _, port := range ports {
+		if owner, exists := a.ownerByPort[port]; exists && owner == testName {
+			delete(a.ownerByPort, port)
+		}
+	}
+	delete(a.portsByTest, testName)
+	delete(a.cleanupByTest, testName)
+}
+
+var sharedTestPortAllocator = NewTestScopedPortAllocator()
+
+func SharedTestPortAllocator() *TestScopedPortAllocator {
+	return sharedTestPortAllocator
+}

--- a/testutil/port_allocator_test.go
+++ b/testutil/port_allocator_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testutil
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testListener struct {
+	closed atomic.Bool
+}
+
+func (l *testListener) Accept() (net.Conn, error) {
+	return nil, errors.New("test listener does not accept")
+}
+
+func (l *testListener) Close() error {
+	l.closed.Store(true)
+	return nil
+}
+
+func (l *testListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}
+}
+
+type allocationResult struct {
+	port     string
+	listener *testListener
+}
+
+func scriptedAllocator(t *testing.T, results []allocationResult) func(t *testing.T) (string, net.Listener) {
+	t.Helper()
+
+	var lock sync.Mutex
+	idx := 0
+
+	return func(t *testing.T) (string, net.Listener) {
+		t.Helper()
+
+		lock.Lock()
+		defer lock.Unlock()
+
+		require.Less(t, idx, len(results), "scripted allocator exhausted")
+		result := results[idx]
+		idx++
+		return result.port, result.listener
+	}
+}
+
+// Scenario: two allocations in the same test receive a duplicate candidate port (41000),
+// so the allocator retries and returns a different unique port.
+func TestScopedPortAllocator_RetriesOnDuplicatePort(t *testing.T) {
+	allocator := NewTestScopedPortAllocator()
+	results := []allocationResult{
+		{port: "41000", listener: &testListener{}},
+		{port: "41000", listener: &testListener{}},
+		{port: "41001", listener: &testListener{}},
+	}
+	allocator.allocatePort = scriptedAllocator(t, results)
+
+	port1, ll1 := allocator.Allocate(t)
+	require.Equal(t, "41000", port1)
+	require.NoError(t, ll1.Close())
+
+	port2, ll2 := allocator.Allocate(t)
+	require.Equal(t, "41001", port2)
+	require.NoError(t, ll2.Close())
+
+	require.True(t, results[1].listener.closed.Load(), "duplicate candidate listener should be closed")
+	require.Equal(t, t.Name(), allocator.ownerByPort["41000"])
+	require.Equal(t, t.Name(), allocator.ownerByPort["41001"])
+}
+
+// Scenario: a child test allocates a port and exits, and cleanup must release
+// all ownership state for that child test.
+func TestScopedPortAllocator_ReleasesPortsOnCleanup(t *testing.T) {
+	allocator := NewTestScopedPortAllocator()
+	results := []allocationResult{{port: "42000", listener: &testListener{}}}
+	allocator.allocatePort = scriptedAllocator(t, results)
+
+	var childName string
+	var childPort string
+	t.Run("child", func(t *testing.T) {
+		childName = t.Name()
+
+		port, ll := allocator.Allocate(t)
+		childPort = port
+		require.Equal(t, "42000", port)
+		require.NoError(t, ll.Close())
+
+		require.Equal(t, childName, allocator.ownerByPort[childPort])
+		require.Equal(t, []string{childPort}, allocator.portsByTest[childName])
+		require.True(t, allocator.cleanupByTest[childName])
+	})
+
+	require.NotContains(t, allocator.ownerByPort, childPort)
+	require.NotContains(t, allocator.portsByTest, childName)
+	require.NotContains(t, allocator.cleanupByTest, childName)
+}
+
+// Scenario: two coordinated parallel subtests contend on the same first
+// candidate port (43000) and must end up with different allocated ports.
+func TestScopedPortAllocator_ParallelSubtestsDoNotSharePort(t *testing.T) {
+	allocator := NewTestScopedPortAllocator()
+	results := []allocationResult{
+		{port: "43000", listener: &testListener{}},
+		{port: "43000", listener: &testListener{}},
+		{port: "43001", listener: &testListener{}},
+	}
+	allocator.allocatePort = scriptedAllocator(t, results)
+
+	ready := make(chan struct{})
+	release := make(chan struct{})
+	ports := make(chan string, 2)
+
+	t.Run("parallel", func(t *testing.T) {
+		t.Run("holder", func(t *testing.T) {
+			t.Parallel()
+
+			port, ll := allocator.Allocate(t)
+			require.NoError(t, ll.Close())
+			ports <- port
+			close(ready)
+			<-release
+		})
+
+		t.Run("contender", func(t *testing.T) {
+			t.Parallel()
+
+			<-ready
+			port, ll := allocator.Allocate(t)
+			require.NoError(t, ll.Close())
+			ports <- port
+			close(release)
+		})
+	})
+
+	portA := <-ports
+	portB := <-ports
+	require.NotEqual(t, portA, portB, "parallel subtests should receive different ports")
+	require.True(t, results[0].listener.closed.Load(), "first candidate listener should be closed")
+	require.True(t, results[1].listener.closed.Load(), "duplicate candidate listener should be closed")
+}

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -90,27 +90,41 @@ func ReadNodeConfigFromYaml(t *testing.T, path string) *config.NodeLocalConfig {
 	return &config
 }
 
+var defaultPortAllocator PortAllocator = &DefaultPortAllocator{}
+
+func allocatePort(t *testing.T, allocator PortAllocator) (string, net.Listener) {
+	if allocator == nil {
+		allocator = defaultPortAllocator
+	}
+	return allocator.Allocate(t)
+}
+
 // CreateNetwork creates a config.yaml file with the network configuration. This file is the input for armageddon generate command.
 func CreateNetwork(t *testing.T, configPath string, numOfParties int, numOfBatcherShards int, useTLSRouter string, useTLSAssembler string) ArmaNodesInfoMap {
+	return CreateNetworkWithPortAllocator(t, configPath, numOfParties, numOfBatcherShards, useTLSRouter, useTLSAssembler, defaultPortAllocator)
+}
+
+// CreateNetworkWithPortAllocator creates a config.yaml file with a caller-provided port allocator.
+func CreateNetworkWithPortAllocator(t *testing.T, configPath string, numOfParties int, numOfBatcherShards int, useTLSRouter string, useTLSAssembler string, allocator PortAllocator) ArmaNodesInfoMap {
 	var parties []genconfig.Party
 	netInfo := *NewArmaNodesInfoMap()
 	var maxPartyID types.PartyID
 
 	for i := range numOfParties {
-		assemblerPort, lla := GetAvailablePort(t)
-		_, llam := GetAvailablePort(t)
-		consenterPort, llc := GetAvailablePort(t)
-		_, llcm := GetAvailablePort(t)
-		routerPort, llr := GetAvailablePort(t)
-		_, llrm := GetAvailablePort(t)
-		var llbs []net.Listener
-		var llbms []net.Listener
+		assemblerPort, assemblerListener := allocatePort(t, allocator)
+		_, assemblerMonitoringListener := allocatePort(t, allocator)
+		consenterPort, consenterListener := allocatePort(t, allocator)
+		_, consenterMonitoringListener := allocatePort(t, allocator)
+		routerPort, routerListener := allocatePort(t, allocator)
+		_, routerMonitoringListener := allocatePort(t, allocator)
+		var batchersListenersInShard []net.Listener
+		var batchersMonitoringListenersInShard []net.Listener
 		var batchersEndpoints []string
 		for range numOfBatcherShards {
-			batcherPort, llb := GetAvailablePort(t)
-			_, llbm := GetAvailablePort(t)
-			llbs = append(llbs, llb)
-			llbms = append(llbms, llbm)
+			batcherPort, batcherListener := allocatePort(t, allocator)
+			_, batcherMonitoringListener := allocatePort(t, allocator)
+			batchersListenersInShard = append(batchersListenersInShard, batcherListener)
+			batchersMonitoringListenersInShard = append(batchersMonitoringListenersInShard, batcherMonitoringListener)
 			batchersEndpoints = append(batchersEndpoints, "127.0.0.1:"+batcherPort)
 		}
 
@@ -130,18 +144,18 @@ func CreateNetwork(t *testing.T, configPath string, numOfParties int, numOfBatch
 		}
 
 		nodeName := NodeName{PartyID: types.PartyID(i + 1), NodeType: Router}
-		netInfo[nodeName] = &ArmaNodeInfo{Listener: llr, NodeType: Router, PartyId: types.PartyID(i + 1), MonitoringListener: llrm}
+		netInfo[nodeName] = &ArmaNodeInfo{Listener: routerListener, NodeType: Router, PartyId: types.PartyID(i + 1), MonitoringListener: routerMonitoringListener}
 
-		for j, b := range llbs {
+		for j, b := range batchersListenersInShard {
 			nodeName = NodeName{PartyID: types.PartyID(i + 1), NodeType: Batcher, ShardID: types.ShardID(j + 1)}
-			netInfo[nodeName] = &ArmaNodeInfo{Listener: b, NodeType: Batcher, PartyId: types.PartyID(i + 1), ShardId: types.ShardID(j + 1), MonitoringListener: llbms[j]}
+			netInfo[nodeName] = &ArmaNodeInfo{Listener: b, NodeType: Batcher, PartyId: types.PartyID(i + 1), ShardId: types.ShardID(j + 1), MonitoringListener: batchersMonitoringListenersInShard[j]}
 		}
 
 		nodeName = NodeName{PartyID: types.PartyID(i + 1), NodeType: Consensus}
-		netInfo[nodeName] = &ArmaNodeInfo{Listener: llc, NodeType: Consensus, PartyId: types.PartyID(i + 1), MonitoringListener: llcm}
+		netInfo[nodeName] = &ArmaNodeInfo{Listener: consenterListener, NodeType: Consensus, PartyId: types.PartyID(i + 1), MonitoringListener: consenterMonitoringListener}
 
 		nodeName = NodeName{PartyID: types.PartyID(i + 1), NodeType: Assembler}
-		netInfo[nodeName] = &ArmaNodeInfo{Listener: lla, NodeType: Assembler, PartyId: types.PartyID(i + 1), MonitoringListener: llam}
+		netInfo[nodeName] = &ArmaNodeInfo{Listener: assemblerListener, NodeType: Assembler, PartyId: types.PartyID(i + 1), MonitoringListener: assemblerMonitoringListener}
 	}
 
 	network := genconfig.Network{
@@ -166,6 +180,11 @@ type NodeName struct {
 // ExtendNetwork extends an existing network configuration by adding a party to it.
 // It updates the config file with the new party and returns the new party's information and config only
 func ExtendNetwork(t *testing.T, configPath string) (ArmaNodesInfoMap, *genconfig.Network) {
+	return ExtendNetworkWithPortAllocator(t, configPath, defaultPortAllocator)
+}
+
+// ExtendNetworkWithPortAllocator extends the network and uses a caller-provided allocator for new ports.
+func ExtendNetworkWithPortAllocator(t *testing.T, configPath string, allocator PortAllocator) (ArmaNodesInfoMap, *genconfig.Network) {
 	netInfo := *NewArmaNodesInfoMap()
 
 	networkConfig := genconfig.Network{}
@@ -176,21 +195,21 @@ func ExtendNetwork(t *testing.T, configPath string) (ArmaNodesInfoMap, *genconfi
 
 	numOfBatcherShards := len(networkConfig.Parties[0].BatchersEndpoints)
 
-	assemblerPort, lla := GetAvailablePort(t)
-	_, llam := GetAvailablePort(t)
-	consenterPort, llc := GetAvailablePort(t)
-	_, llcm := GetAvailablePort(t)
-	routerPort, llr := GetAvailablePort(t)
-	_, llrm := GetAvailablePort(t)
-	var llbs []net.Listener
-	var llbms []net.Listener
+	assemblerPort, assemblerListener := allocatePort(t, allocator)
+	_, assemblerMonitoringListener := allocatePort(t, allocator)
+	consenterPort, consenterListener := allocatePort(t, allocator)
+	_, consenterMonitoringListener := allocatePort(t, allocator)
+	routerPort, routerListener := allocatePort(t, allocator)
+	_, routerMonitoringListener := allocatePort(t, allocator)
+	var batchersListenersInShard []net.Listener
+	var batchersMonitoringListenersInShard []net.Listener
 	var batchersEndpoints []string
 
 	for range numOfBatcherShards {
-		batcherPort, llb := GetAvailablePort(t)
-		_, llbm := GetAvailablePort(t)
-		llbs = append(llbs, llb)
-		llbms = append(llbms, llbm)
+		batcherPort, batcherListener := allocatePort(t, allocator)
+		_, batcherMonitoringListener := allocatePort(t, allocator)
+		batchersListenersInShard = append(batchersListenersInShard, batcherListener)
+		batchersMonitoringListenersInShard = append(batchersMonitoringListenersInShard, batcherMonitoringListener)
 		batchersEndpoints = append(batchersEndpoints, "127.0.0.1:"+batcherPort)
 	}
 
@@ -205,17 +224,17 @@ func ExtendNetwork(t *testing.T, configPath string) (ArmaNodesInfoMap, *genconfi
 	networkConfig.Parties = append(networkConfig.Parties, newPartyConfig)
 
 	nodeName := NodeName{PartyID: networkConfig.MaxPartyID, NodeType: Router}
-	netInfo[nodeName] = &ArmaNodeInfo{Listener: llr, NodeType: Router, PartyId: types.PartyID(networkConfig.MaxPartyID), MonitoringListener: llrm}
+	netInfo[nodeName] = &ArmaNodeInfo{Listener: routerListener, NodeType: Router, PartyId: types.PartyID(networkConfig.MaxPartyID), MonitoringListener: routerMonitoringListener}
 
-	for j, b := range llbs {
+	for j, b := range batchersListenersInShard {
 		nodeName = NodeName{PartyID: networkConfig.MaxPartyID, NodeType: Batcher, ShardID: types.ShardID(j + 1)}
-		netInfo[nodeName] = &ArmaNodeInfo{Listener: b, NodeType: Batcher, PartyId: types.PartyID(networkConfig.MaxPartyID), ShardId: types.ShardID(j + 1), MonitoringListener: llbms[j]}
+		netInfo[nodeName] = &ArmaNodeInfo{Listener: b, NodeType: Batcher, PartyId: types.PartyID(networkConfig.MaxPartyID), ShardId: types.ShardID(j + 1), MonitoringListener: batchersMonitoringListenersInShard[j]}
 	}
 
 	nodeName = NodeName{PartyID: networkConfig.MaxPartyID, NodeType: Consensus}
-	netInfo[nodeName] = &ArmaNodeInfo{Listener: llc, NodeType: Consensus, PartyId: types.PartyID(networkConfig.MaxPartyID), MonitoringListener: llcm}
+	netInfo[nodeName] = &ArmaNodeInfo{Listener: consenterListener, NodeType: Consensus, PartyId: types.PartyID(networkConfig.MaxPartyID), MonitoringListener: consenterMonitoringListener}
 	nodeName = NodeName{PartyID: networkConfig.MaxPartyID, NodeType: Assembler}
-	netInfo[nodeName] = &ArmaNodeInfo{Listener: lla, NodeType: Assembler, PartyId: types.PartyID(networkConfig.MaxPartyID), MonitoringListener: llam}
+	netInfo[nodeName] = &ArmaNodeInfo{Listener: assemblerListener, NodeType: Assembler, PartyId: types.PartyID(networkConfig.MaxPartyID), MonitoringListener: assemblerMonitoringListener}
 
 	err = utils.WriteToYAML(networkConfig, configPath)
 	require.NoError(t, err)


### PR DESCRIPTION
Add port allocator interface
Implement a shared port allocator, that tracks ports by test name.
Add to some tests in consensus with ports leakage (#791).