### PR TITLE
Split integration tests

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -55,8 +55,8 @@ jobs:
           go-version-file: go.mod
       - run: make unit-tests
         name: Run Unit Tests
-  integration-tests:
-    name: Integration Tests
+  integration-basic:
+    name: Integration Basic Tests
     needs: basic-checks
     runs-on: ${{ github.repository == 'hyperledger/fabric-x-orderer' && 'ubuntu-24.04' }}
     steps:
@@ -68,8 +68,38 @@ jobs:
         name: Install Go
         with:
           go-version-file: go.mod
-      - run: make integration-tests
-        name: Run Integration Tests
+      - run: make integration-basic
+        name: Run Integration Basic Tests
+  integration-faulttolerance:
+    name: Integration Fault Tolerance Tests
+    needs: basic-checks
+    runs-on: ${{ github.repository == 'hyperledger/fabric-x-orderer' && 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+        name: Checkout Fabric-X Code
+      - uses: actions/setup-go@v6
+        name: Install Go
+        with:
+          go-version-file: go.mod
+      - run: make integration-faulttolerance
+        name: Run Integration Fault Tolerance Tests
+  integration-reconfig:
+    name: Integration Reconfig Tests
+    needs: basic-checks
+    runs-on: ${{ github.repository == 'hyperledger/fabric-x-orderer' && 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+        name: Checkout Fabric-X Code
+      - uses: actions/setup-go@v6
+        name: Install Go
+        with:
+          go-version-file: go.mod
+      - run: make integration-reconfig
+        name: Run Integration Reconfig Tests
   sample-tests:
     name: Sample Tests
     needs: basic-checks

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,20 @@ check-protos:
 unit-tests:
 	go test -race -timeout 20m $$(go list ./... | grep -v /test)
 
+.PHONY: integration-basic
+integration-basic:
+	go test -race -timeout 30m ./test/basic/...
+
+.PHONY: integration-faulttolerance
+integration-faulttolerance:
+	go test -race -timeout 30m ./test/faulttolerance/...
+
+.PHONY: integration-reconfig
+integration-reconfig:
+	go test -race -timeout 30m ./test/reconfig/...
+
 .PHONY: integration-tests
-integration-tests:
-	go test -race -timeout 30m ./test/...
+integration-tests: integration-basic integration-faulttolerance integration-reconfig
 
 .PHONY: sample-tests
 sample-tests:

--- a/test/basic/abcr_test.go
+++ b/test/basic/abcr_test.go
@@ -4,20 +4,15 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// package test contains integration tests.
-package test
+package basic
 
 import (
-	"runtime"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/hyperledger/fabric-x-orderer/common/utils"
-	"github.com/hyperledger/fabric-x-orderer/node/assembler"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
-	"github.com/hyperledger/fabric-x-orderer/node/router"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 
 	_ "github.com/onsi/gomega/gexec"
@@ -32,8 +27,8 @@ func TestABCR(t *testing.T) {
 	require.NoError(t, err)
 	numParties := 4
 
-	batcherNodes, batcherInfos := createBatcherNodesAndInfo(t, ca, numParties)
-	consenterNodes, consenterInfos := createConsenterNodesAndInfo(t, ca, numParties)
+	batcherNodes, batcherInfos := test_utils.CreateBatcherNodesAndInfo(t, ca, numParties)
+	consenterNodes, consenterInfos := test_utils.CreateConsenterNodesAndInfo(t, ca, numParties)
 
 	for i := 0; i < numParties; i++ {
 		t.Logf("batcher: %v, %s", batcherInfos[i], batcherNodes[i].ToString())
@@ -43,17 +38,17 @@ func TestABCR(t *testing.T) {
 
 	genesisBlock := utils.EmptyGenesisBlock("arma")
 
-	_, _, _, cleanConsenters := createConsenters(t, numParties, consenterNodes, consenterInfos, shards, genesisBlock)
+	_, _, _, cleanConsenters := test_utils.CreateConsenters(t, numParties, consenterNodes, consenterInfos, shards, genesisBlock)
 
-	_, _, _, cleanBatchers := createBatchersForShard(t, numParties, batcherNodes, shards, consenterInfos, shards[0].ShardId, genesisBlock)
+	_, _, _, cleanBatchers := test_utils.CreateBatchersForShard(t, numParties, batcherNodes, shards, consenterInfos, shards[0].ShardId, genesisBlock)
 
-	routers, _, _, _ := createRouters(t, numParties, batcherInfos, ca, shards[0].ShardId, make([]string, numParties), genesisBlock)
+	routers, _, _, _ := test_utils.CreateRouters(t, numParties, batcherInfos, ca, shards[0].ShardId, make([]string, numParties), genesisBlock)
 
 	for i := range routers {
 		routers[i].StartRouterService()
 	}
 
-	assemblers, _, _, _, cleanAssemblers := createAssemblers(t, numParties, ca, shards, consenterInfos, genesisBlock)
+	assemblers, _, _, _, cleanAssemblers := test_utils.CreateAssemblers(t, numParties, ca, shards, consenterInfos, genesisBlock)
 
 	defer func() {
 		for i := range routers {
@@ -64,50 +59,7 @@ func TestABCR(t *testing.T) {
 		cleanAssemblers()
 	}()
 
-	sendTransactions(t, routers, assemblers[3])
-}
-
-func sendTransactions(t *testing.T, routers []*router.Router, assembler *assembler.Assembler) {
-	sendTxn(runtime.NumCPU()+1, 0, routers)
-
-	time.Sleep(time.Second)
-
-	var wg sync.WaitGroup
-	wg.Add(runtime.NumCPU())
-
-	workPerWorker := 100
-
-	initialCount := int(assembler.GetTxCount())
-
-	start := time.Now()
-
-	for workerID := 0; workerID < runtime.NumCPU(); workerID++ {
-		go func(workerID int) {
-			defer wg.Done()
-
-			for txNum := 0; txNum < workPerWorker; txNum++ {
-				sendTxn(workerID, initialCount+txNum, routers)
-			}
-		}(workerID)
-	}
-
-	wg.Wait()
-
-	totalTxn := workPerWorker * runtime.NumCPU()
-	expected := initialCount + totalTxn
-	t.Logf("Expecting %d TXs (%d to %d)", totalTxn, initialCount, expected)
-	require.Eventually(t, func() bool {
-		n := assembler.GetTxCount()
-		t.Logf("Received TXs: %d", n)
-		return int(n) >= expected
-	}, time.Minute, time.Second)
-
-	elapsed := int(time.Since(start).Seconds())
-	if elapsed == 0 {
-		elapsed = 1
-	}
-
-	t.Logf("%f (totalTxn / elapsed)\n", float32(totalTxn)/float32(elapsed))
+	test_utils.SendTransactions(t, routers, assemblers[3])
 }
 
 // func runPerf(t *testing.T, routerTLSCA, assemblerTLSCA [][]byte, routerEndpoints []string, assemblerEndpoint string, clientPath string) {

--- a/test/basic/assembler_basic_test.go
+++ b/test/basic/assembler_basic_test.go
@@ -4,10 +4,11 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package basic
 
 import (
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +25,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTxClientSend(t *testing.T) {
+// scenario:
+// start an arma network with 4 parties and mTLS enabled for assembler
+// send some transactions to the network
+// pull blocks from one of the assemblers and count them, verify that all expected transactions are included in the pulled blocks
+func TestPullBlocksFromAssemblerWithMTLS(t *testing.T) {
 	totalTxNumber := 100
 	dir, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
@@ -33,9 +38,9 @@ func TestTxClientSend(t *testing.T) {
 
 	// 1.
 	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, 4, 2, "none", "none")
+	netInfo := testutil.CreateNetwork(t, configPath, 4, 2, "none", "mTLS")
 	defer netInfo.CleanUp()
-	require.NotNil(t, netInfo)
+	require.NoError(t, err)
 	// 2.
 	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
 
@@ -69,8 +74,9 @@ func TestTxClientSend(t *testing.T) {
 	// 5. Check If Transaction is sent
 	t.Log("Finished submit")
 
+	// Pull some block from the middle and count them
 	startBlock := uint64(0)
-	endBlock := uint64(totalTxNumber + 1)
+	endBlock := uint64(math.MaxUint64)
 	totalTxs := 0
 	totalBlocks := 0
 
@@ -85,7 +91,9 @@ func TestTxClientSend(t *testing.T) {
 		}
 		return nil
 	}
-	dc.PullBlocks(cnx, 1, startBlock, endBlock, handler, signutil.CreateTestSigner(t, "org1", dir))
+	status, err := dc.PullBlocks(cnx, 1, startBlock, endBlock, handler, signutil.CreateTestSigner(t, "org1", dir))
+	assert.ErrorContains(t, err, "context canceled")
+	assert.Equal(t, common.Status(0), status)
 	assert.Equal(t, totalTxNumber+1, totalTxs)
 	assert.True(t, totalBlocks > 2)
 	t.Logf("Finished pull and count: %d, %d", totalBlocks, totalTxs)

--- a/test/basic/basic_test.go
+++ b/test/basic/basic_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package basic
 
 import (
 	"fmt"
@@ -18,10 +18,12 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/client"
 	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
+
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -131,7 +133,7 @@ func TestSubmitAndReceive(t *testing.T) {
 
 			signer := signutil.CreateTestSigner(t, "org1", dir)
 
-			PullFromAssemblers(t, &BlockPullerOptions{
+			utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 				UserConfig: uc,
 				Parties:    parties,
 				StartBlock: startBlock,
@@ -145,7 +147,7 @@ func TestSubmitAndReceive(t *testing.T) {
 			startBlock = uint64(0)
 			endBlock = uint64(1)
 
-			PullFromAssemblers(t, &BlockPullerOptions{
+			utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 				UserConfig: uc,
 				Parties:    parties,
 				StartBlock: startBlock,
@@ -159,7 +161,7 @@ func TestSubmitAndReceive(t *testing.T) {
 			startBlock = uint64(1)
 			endBlock = uint64(1000)
 
-			PullFromAssemblers(t, &BlockPullerOptions{
+			utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 				UserConfig: uc,
 				Parties:    parties,
 				StartBlock: startBlock,
@@ -246,7 +248,7 @@ func TestSubmitAndReceiveStatus(t *testing.T) {
 	signer := signutil.CreateTestSigner(t, "org1", dir)
 
 	statusSuccess := common.Status_SUCCESS
-	PullFromAssemblers(t, &BlockPullerOptions{
+	utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		StartBlock: startBlock,
@@ -256,7 +258,7 @@ func TestSubmitAndReceiveStatus(t *testing.T) {
 	})
 
 	statusUknown := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		StartBlock: startBlock,
@@ -271,7 +273,7 @@ func TestSubmitAndReceiveStatus(t *testing.T) {
 	endBlock = uint64(2)
 
 	statusBadRequest := common.Status_BAD_REQUEST
-	PullFromAssemblers(t, &BlockPullerOptions{
+	utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		StartBlock: startBlock,

--- a/test/basic/batcher_basic_test.go
+++ b/test/basic/batcher_basic_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package basic
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
+	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/hyperledger/fabric-x-orderer/common/utils"
+	config "github.com/hyperledger/fabric-x-orderer/config"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
+	"github.com/hyperledger/fabric-x-orderer/testutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/client"
+	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
+	"github.com/onsi/gomega/gexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifySignedTxsByBatcherSingleParty verifies that a single-party batcher network correctly processes
+// signed transactions with client signature verification enabled.
+func TestVerifySignedTxsByBatcherSingleParty(t *testing.T) {
+	// 1. compile arma
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	defer gexec.CleanupBuildArtifacts()
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	t.Logf("Running test with %d parties and %d shards", 1, 1)
+
+	// 2. Create a temporary directory for the test.
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	shardsNumber := 2
+
+	// 3. Create a config YAML file in the temporary directory.
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, 1, shardsNumber, "none", "none")
+	defer netInfo.CleanUp()
+	require.NotNil(t, netInfo)
+	numOfArmaNodes := len(netInfo)
+
+	// 4. Generate the config files in the temporary directory using the armageddon generate command.
+	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
+
+	for shardID := range shardsNumber {
+		configFilePath := filepath.Join(dir, fmt.Sprintf("config/party%d/local_config_batcher%d.yaml", types.PartyID(1), types.ShardID(shardID+1)))
+		conf, _, err := config.LoadLocalConfig(configFilePath)
+		require.NoError(t, err)
+
+		// Modify the batcher configuration to require client signature verification.
+		conf.NodeLocalConfig.GeneralConfig.ClientSignatureVerificationRequired = true
+		utils.WriteToYAML(conf.NodeLocalConfig, configFilePath)
+	}
+
+	// 5. Run the arma nodes.
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	// Obtains a test user configuration and constructs a broadcast client.
+	readyChan := make(chan string, numOfArmaNodes)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+
+	uc, err := testutil.GetUserConfig(dir, types.PartyID(1))
+	assert.NoError(t, err)
+	assert.NotNil(t, uc)
+
+	totalTxNumber := 100
+	// rate limiter parameters
+	fillInterval := 10 * time.Millisecond
+	fillFrequency := 1000 / int(fillInterval.Milliseconds())
+	rate := 500
+
+	capacity := rate / fillFrequency
+	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start a rate limiter")
+		os.Exit(3)
+	}
+
+	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
+	signer, certBytes, err := testutil.LoadCryptoMaterialsFromDir(t, uc.MSPDir)
+	require.NoError(t, err)
+
+	org := fmt.Sprintf("org%d", types.PartyID(1))
+
+	for i := range totalTxNumber {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(i, 64, []byte("sessionNumber"))
+		env := tx.CreateSignedStructuredEnvelope(txContent, signer, certBytes, org)
+		err = broadcastClient.SendTx(env)
+		require.NoError(t, err)
+	}
+
+	broadcastClient.Stop()
+
+	// 6. make sure assemblers of all the parties get transactions (expect 1000 TXs).
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          []types.PartyID{1},
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxNumber,
+		Timeout:          60,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           signutil.CreateTestSigner(t, "org1", dir),
+	})
+
+	// 7. Verify that the batchers have received the transactions.
+	txsReceived := 0
+
+	for shardId := range shardsNumber {
+		batcherToMonitor := armaNetwork.GetBatcher(t, types.PartyID(1), types.ShardID(shardId+1))
+		url := testutil.CaptureArmaNodePrometheusServiceURL(t, batcherToMonitor)
+
+		pattern := fmt.Sprintf(`batcher_router_txs_total\{party_id="%d",shard_id="%d"\} \d+`, types.PartyID(1), types.ShardID(shardId+1))
+		regex := regexp.MustCompile(pattern)
+		txsReceived += testutil.FetchPrometheusMetricValue(t, regex, url)
+	}
+
+	require.GreaterOrEqual(t, txsReceived, totalTxNumber, "Expected %d transactions to be received by the batchers, but got %d", totalTxNumber, txsReceived)
+}
+
+// TestVerifySignedTxsByBatcherForwardRequest tests the batcher's ability to forward
+// signed transactions from a non-primary batcher to a primary batcher while verifying
+// client signatures.
+func TestVerifySignedTxsByBatcherForwardRequest(t *testing.T) {
+	// 1. compile arma
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	defer gexec.CleanupBuildArtifacts()
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	numOfParties := 2
+	numShards := 1
+
+	t.Logf("Running test with %d parties and %d shards", numOfParties, numShards)
+
+	// 2. Create a temporary directory for the test.
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// 3. Create a config YAML file in the temporary directory.
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, numShards, "none", "none")
+	defer netInfo.CleanUp()
+	require.NotNil(t, netInfo)
+	numOfArmaNodes := len(netInfo)
+
+	// 4. Generate the config files in the temporary directory using the armageddon generate command.
+	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
+
+	for partyID := range numOfParties {
+		configFilePath := filepath.Join(dir, fmt.Sprintf("config/party%d/local_config_batcher%d.yaml", partyID+1, types.ShardID(1)))
+		conf, _, err := config.LoadLocalConfig(configFilePath)
+		require.NoError(t, err)
+
+		// Modify the batcher configuration to require client signature verification.
+		conf.NodeLocalConfig.GeneralConfig.ClientSignatureVerificationRequired = true
+		utils.WriteToYAML(conf.NodeLocalConfig, configFilePath)
+	}
+
+	// 5. Run the arma nodes.
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	// Obtains a test user configuration and constructs a broadcast client.
+	readyChan := make(chan string, numOfArmaNodes)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+
+	uc, err := testutil.GetUserConfig(dir, types.PartyID(1))
+	assert.NoError(t, err)
+	assert.NotNil(t, uc)
+
+	txNumber := 10
+	// rate limiter parameters
+	fillInterval := 10 * time.Millisecond
+	fillFrequency := 1000 / int(fillInterval.Milliseconds())
+	rate := 100
+
+	capacity := rate / fillFrequency
+	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start a rate limiter")
+		os.Exit(3)
+	}
+
+	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
+	signer, certBytes, err := testutil.LoadCryptoMaterialsFromDir(t, uc.MSPDir)
+	require.NoError(t, err)
+
+	// 6. Determine primary and non-primary party IDs for shard 1 by calculating the primary party ID using the formula:
+	// types.PartyID((uint64(b.Shard) + term) % uint64(b.N)) where term is assumed to be 0 and b.N is the number of parties.
+	primaryPartyID := types.PartyID((uint64(1))%uint64(numOfParties) + 1)
+	nonPrimaryPartyID := types.PartyID(uint64(primaryPartyID)%uint64(numOfParties) + 1)
+
+	t.Logf("Non-primary party ID is %d", nonPrimaryPartyID)
+	t.Logf("Primary party ID is %d", primaryPartyID)
+
+	// 7. Send TXs to a non-primary batcher
+	for i := range txNumber {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(i, 64, []byte("sessionNumber"))
+		env := tx.CreateSignedStructuredEnvelope(txContent, signer, certBytes, "org1")
+		err = broadcastClient.SendTxTo(env, nonPrimaryPartyID)
+		require.NoError(t, err)
+	}
+
+	broadcastClient.Stop()
+
+	// 8. Verify that the non-primary batcher have received all the transactions.
+	nonPrimaryBatcherToMonitor := armaNetwork.GetBatcher(t, nonPrimaryPartyID, types.ShardID(1))
+	url := testutil.CaptureArmaNodePrometheusServiceURL(t, nonPrimaryBatcherToMonitor)
+
+	pattern := fmt.Sprintf(`batcher_router_txs_total\{party_id="%d",shard_id="%d"\} \d+`, nonPrimaryPartyID, types.ShardID(1))
+	re := regexp.MustCompile(pattern)
+
+	require.Eventually(t, func() bool {
+		return testutil.FetchPrometheusMetricValue(t, re, url) == txNumber
+	}, 30*time.Second, 100*time.Millisecond)
+
+	primaryBatcherToMonitor := armaNetwork.GetBatcher(t, primaryPartyID, types.ShardID(1))
+	url = testutil.CaptureArmaNodePrometheusServiceURL(t, primaryBatcherToMonitor)
+
+	// 9. Verify that the non-primary batcher have forwarded all the transactions to the primary batcher and the primary one have batched all the transactions.
+	pattern = fmt.Sprintf(`batcher_batched_txs_total\{party_id="%d",shard_id="%d"\} \d+`, primaryPartyID, types.ShardID(1))
+	re = regexp.MustCompile(pattern)
+
+	require.Eventually(t, func() bool {
+		return testutil.FetchPrometheusMetricValue(t, re, url) == txNumber
+	}, 30*time.Second, 100*time.Millisecond)
+
+	// 10. Verify that the non-primary batcher did not receive any transactions.
+	pattern = fmt.Sprintf(`batcher_router_txs_total\{party_id="%d",shard_id="%d"\} \d+`, primaryPartyID, types.ShardID(1))
+	re = regexp.MustCompile(pattern)
+
+	txsReceived := testutil.FetchPrometheusMetricValue(t, re, url)
+	require.Equal(t, txsReceived, 0, "Expected %d transactions to be received by the non-primary batcher, but got %d", 0, txsReceived)
+}

--- a/test/basic/router_basic_test.go
+++ b/test/basic/router_basic_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package basic
 
 import (
 	"crypto/ecdsa"
@@ -22,270 +22,14 @@ import (
 	config "github.com/hyperledger/fabric-x-orderer/config"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/crypto"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/client"
 	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 	"github.com/onsi/gomega/gexec"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestRouterRestartRecover tests the ability of the router to restart and recover from a shutdown.
-// The test sends transactions to the router and then stops it. After that, it waits for the router to
-// be restarted and verifies that all transactions were successfully delivered.
-//
-// The test consists of the following steps:
-// 1. Compile the arma binary.
-// 2. Create a temporary directory for the test.
-// 3. Create a config YAML file in the temporary directory.
-// 4. Generate the config files in the temporary directory using the armageddon generate command.
-// 5. Run the arma nodes.
-// 6. Send transactions to the router.
-// 7. Stop a secondary router.
-// 8. Pull blocks from all assemblers.
-// 9. Start the secondary router.
-// 10. Pull blocks from all assemblers again.
-// 11. Stop a primary router.
-// 12. Pull blocks from all assemblers again.
-// 13. Start the primary router.
-// 14. Stop the broadcast client.
-// 15. Pull blocks from all assemblers again.
-func TestRouterRestartRecover(t *testing.T) {
-	// 1. compile arma
-	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
-	defer gexec.CleanupBuildArtifacts()
-	require.NoError(t, err)
-	require.NotNil(t, armaBinaryPath)
-
-	// Number of parties in the test
-	numOfParties := 4
-
-	t.Logf("Running test with %d parties and %d shards", numOfParties, 1)
-
-	// 2. Create a temporary directory for the test.
-	dir, err := os.MkdirTemp("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	// 3. Create a config YAML file in the temporary directory.
-	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, 1, "none", "none")
-	defer netInfo.CleanUp()
-	require.NoError(t, err)
-	numOfArmaNodes := len(netInfo)
-
-	// 4. Generate the config files in the temporary directory using the armageddon generate command.
-	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
-
-	// 5. Run the arma nodes.
-	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
-	readyChan := make(chan string, numOfArmaNodes)
-	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
-
-	uc, err := testutil.GetUserConfig(dir, 1)
-	assert.NoError(t, err)
-	assert.NotNil(t, uc)
-
-	// 6. Send transactions to the routers.
-	totalTxNumber := 1000
-	// rate limiter parameters
-	fillInterval := 10 * time.Millisecond
-	fillFrequency := 1000 / int(fillInterval.Milliseconds())
-	rate := 500
-	totalTxSent := 0
-
-	capacity := rate / fillFrequency
-	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start a rate limiter")
-		os.Exit(3)
-	}
-
-	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
-
-	for i := 0; i < totalTxNumber; i++ {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
-		env := tx.CreateStructuredEnvelope(txContent)
-		err = broadcastClient.SendTx(env)
-		require.NoError(t, err)
-	}
-
-	totalTxSent += totalTxNumber
-
-	parties := []types.PartyID{}
-	for partyID := 1; partyID <= numOfParties; partyID++ {
-		parties = append(parties, types.PartyID(partyID))
-	}
-
-	signer := signutil.CreateTestSigner(t, "org1", dir)
-
-	pullerInfos := PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig:       uc,
-		Parties:          parties,
-		StartBlock:       0,
-		EndBlock:         math.MaxUint64,
-		Transactions:     totalTxSent,
-		Timeout:          60,
-		NeedVerification: true,
-		ErrString:        "cancelled pull from assembler: %d",
-		Signer:           signer,
-	})
-
-	primaryPartyId := pullerInfos[types.PartyID(1)].Primary[types.ShardID(1)]
-	secondaryPartyId := primaryPartyId%types.PartyID(numOfParties) + 1
-
-	// 7. Stop a secondary router.
-	routerToStop := armaNetwork.GetRouter(t, secondaryPartyId)
-
-	t.Logf("Stopping router: party %d", routerToStop.PartyId)
-	routerToStop.StopArmaNode()
-	gotError := false
-
-	for i := range totalTxNumber {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
-		env := tx.CreateStructuredEnvelope(txContent)
-		err = broadcastClient.SendTx(env)
-		if err != nil {
-			require.ErrorContains(t, err, "EOF")
-			gotError = true
-		}
-	}
-
-	require.True(t, gotError, "expected to get an error when sending tx to a stopped router")
-
-	totalTxSent += totalTxNumber
-
-	// 8. Pull blocks from all assemblers.
-	PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig:       uc,
-		Parties:          parties,
-		StartBlock:       0,
-		EndBlock:         math.MaxUint64,
-		Transactions:     totalTxSent,
-		Timeout:          60,
-		NeedVerification: true,
-		ErrString:        "cancelled pull from assembler: %d",
-		Signer:           signer,
-	})
-
-	// 9. Restart the secondary router.
-	routerToStop.RestartArmaNode(t, readyChan)
-	testutil.WaitReady(t, readyChan, 1, 10)
-
-	for i := range totalTxNumber {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
-		env := tx.CreateStructuredEnvelope(txContent)
-		err = broadcastClient.SendTx(env)
-		require.NoError(t, err)
-	}
-
-	totalTxSent += totalTxNumber
-
-	// 10. Pull blocks from all assemblers.
-	PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig:       uc,
-		Parties:          parties,
-		StartBlock:       0,
-		EndBlock:         math.MaxUint64,
-		Transactions:     totalTxSent,
-		Timeout:          60,
-		NeedVerification: true,
-		ErrString:        "cancelled pull from assembler: %d",
-		Signer:           signer,
-	})
-
-	// 11. Stop a primary router.
-	primaryRouterToStop := armaNetwork.GetRouter(t, primaryPartyId)
-	t.Logf("Stopping router: party %d", primaryRouterToStop.PartyId)
-	primaryRouterToStop.StopArmaNode()
-
-	gotError = false
-
-	for i := 0; i < totalTxNumber; i++ {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
-		env := tx.CreateStructuredEnvelope(txContent)
-		err = broadcastClient.SendTx(env)
-		if err != nil {
-			require.ErrorContains(t, err, "EOF")
-			gotError = true
-		}
-	}
-
-	require.True(t, gotError, "expected to get an error when sending tx to a stopped router")
-
-	totalTxSent += totalTxNumber
-
-	// 12. Pull blocks from all assemblers.
-	PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig:       uc,
-		Parties:          parties,
-		StartBlock:       0,
-		EndBlock:         math.MaxUint64,
-		Transactions:     totalTxSent,
-		Timeout:          60,
-		NeedVerification: true,
-		ErrString:        "cancelled pull from assembler: %d",
-		Signer:           signer,
-	})
-
-	// 13. Restart the primary router.
-	primaryRouterToStop.RestartArmaNode(t, readyChan)
-	testutil.WaitReady(t, readyChan, 1, 10)
-
-	for i := 0; i < totalTxNumber; i++ {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
-		env := tx.CreateStructuredEnvelope(txContent)
-		err = broadcastClient.SendTx(env)
-		require.NoError(t, err)
-	}
-
-	totalTxSent += totalTxNumber
-
-	// 14. Stop the broadcast client.
-	broadcastClient.Stop()
-
-	// 15. Pull blocks from all assemblers.
-	PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig:       uc,
-		Parties:          parties,
-		StartBlock:       0,
-		EndBlock:         math.MaxUint64,
-		Transactions:     totalTxSent,
-		Timeout:          60,
-		NeedVerification: true,
-		ErrString:        "cancelled pull from assembler: %d",
-		Signer:           signer,
-	})
-}
 
 // TestSubmitToRouterGetMetrics tests the end-to-end flow of submitting transactions to the router
 // and verifying that the metrics endpoint correctly reflects the number of incoming transactions.
@@ -468,7 +212,7 @@ func TestVerifySignedTxsByRouterSingleParty(t *testing.T) {
 		return testutil.FetchPrometheusMetricValue(t, re, url) == totalTxNumber
 	}, 30*time.Second, 100*time.Millisecond)
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          []types.PartyID{1},
 		StartBlock:       0,
@@ -565,7 +309,7 @@ func TestMTLSFromClientNotSpecifiedInLocalConfig(t *testing.T) {
 		parties = append(parties, types.PartyID(partyID+1))
 	}
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          parties,
 		StartBlock:       0,
@@ -595,7 +339,7 @@ func TestMTLSFromClientNotSpecifiedInLocalConfig(t *testing.T) {
 	require.ErrorContains(t, err, "failed to create a gRPC client connection to routers")
 
 	// Attempt to pull blocks from assemblers and expect failure due to mTLS verification.
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		ErrString:  "failed to create a gRPC client connection to assembler: %d",

--- a/test/basic/sigverify_test.go
+++ b/test/basic/sigverify_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package basic
 
 import (
 	"fmt"
@@ -16,9 +16,9 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/client"
-	cfgutil "github.com/hyperledger/fabric-x-orderer/testutil/configutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 	"github.com/onsi/gomega/gexec"
@@ -77,7 +77,7 @@ func TestSubmitReceiveAndVerifySignaturesAssemblerBlocks(t *testing.T) {
 	logger := testutil.CreateLogger(t, 0)
 
 	// 4.
-	verifier := BuildVerifier(dir, types.PartyID(1), logger)
+	verifier := test_utils.BuildVerifier(dir, types.PartyID(1), logger)
 
 	// 5.
 	totalTxNumber := 500
@@ -113,93 +113,13 @@ func TestSubmitReceiveAndVerifySignaturesAssemblerBlocks(t *testing.T) {
 	endBlock := uint64(numOfShards)
 
 	statusSuccess := common.Status_SUCCESS
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		StartBlock: startBlock,
 		EndBlock:   endBlock,
 		Status:     &statusSuccess,
 		Verifier:   verifier,
-		Signer:     signutil.CreateTestSigner(t, "org1", dir),
-	})
-}
-
-// TestSubmitReceiveAndVerifySignaturesConfigBlock tests the end-to-end process of submitting a configuration
-// transaction, receiving the resulting configuration block, and verifying its signatures.
-func TestSubmitReceiveAndVerifySignaturesConfigBlock(t *testing.T) {
-	// 1. Builds the arma binary and creates a temporary directory for test artifacts
-	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
-	defer gexec.CleanupBuildArtifacts()
-	require.NoError(t, err)
-	require.NotNil(t, armaBinaryPath)
-
-	numOfShards := 1
-	numOfParties := 1
-
-	// create temp dir
-	dir, err := os.MkdirTemp("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	// 2. Creates a network configuration with the specified number of shards and parties
-	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, numOfShards, "none", "none")
-	defer netInfo.CleanUp()
-	require.NotNil(t, netInfo)
-	numOfArmaNodes := len(netInfo)
-
-	// 3. Generates necessary cryptographic materials and network artifacts using the arma CLI
-	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
-
-	// 4. Starts arma nodes and waits for them to be ready
-	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
-	readyChan := make(chan string, numOfArmaNodes)
-	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
-
-	uc, err := testutil.GetUserConfig(dir, 1)
-	assert.NoError(t, err)
-	assert.NotNil(t, uc)
-
-	logger := testutil.CreateLogger(t, 0)
-
-	// 5. Builds a signature verifier from the consenter information
-	verifier := BuildVerifier(dir, types.PartyID(1), logger)
-
-	// 6. Creates a broadcast client to submit transactions and submits a configuration transaction based on the genesis block
-	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
-	defer broadcastClient.Stop()
-
-	// Create config tx
-	genesisBlockPath := filepath.Join(dir, "bootstrap/bootstrap.block")
-	submittingPartyID := 1
-	configUpdateBuilder, cleanUp := cfgutil.NewConfigUpdateBuilder(t, dir, genesisBlockPath)
-	defer cleanUp()
-
-	configUpdatePbData := configUpdateBuilder.UpdateBatchSizeConfig(t, cfgutil.NewBatchSizeConfig(cfgutil.BatchSizeConfigName.MaxMessageCount, 500))
-	require.NotEmpty(t, configUpdatePbData)
-
-	env := cfgutil.CreateConfigTX(t, dir, []types.PartyID{1}, submittingPartyID, configUpdatePbData)
-	require.NotNil(t, env)
-
-	// Send the config tx
-	err = broadcastClient.SendTx(env)
-	require.NoError(t, err)
-	totalBlocks := 2 // genesis + config block
-
-	// 7. Pulls and verifies blocks from assemblers, ensuring the configuration block's signatures are valid
-	statusSuccess := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig: uc,
-		Parties:    []types.PartyID{types.PartyID(submittingPartyID)},
-		StartBlock: uint64(0),
-		Status:     &statusSuccess,
-		Verifier:   verifier,
-		Blocks:     totalBlocks,
-		ErrString:  "cancelled pull from assembler: %d",
-		LogString:  "configuration block 1 partyID %d verified with",
 		Signer:     signutil.CreateTestSigner(t, "org1", dir),
 	})
 }

--- a/test/basic/tx_client_test.go
+++ b/test/basic/tx_client_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package basic
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
+	"github.com/hyperledger/fabric-x-orderer/testutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/client"
+	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
+	"github.com/onsi/gomega/gexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxClientSend(t *testing.T) {
+	totalTxNumber := 100
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	var broadcastClient *client.BroadcastTxClient
+
+	// 1.
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, 4, 2, "none", "none")
+	defer netInfo.CleanUp()
+	require.NotNil(t, netInfo)
+	// 2.
+	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
+
+	// 3.
+	// compile arma
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	// run arma nodes
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	readyChan := make(chan string, 20)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, 20, 10)
+
+	// 4. Send To Routers
+	uc, err := testutil.GetUserConfig(dir, 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, uc)
+	broadcastClient = client.NewBroadcastTxClient(uc, 10*time.Second)
+	defer broadcastClient.Stop()
+	require.NoError(t, err)
+	for i := 0; i < totalTxNumber; i++ {
+		txContent := tx.PrepareTxWithTimestamp(i, 100, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		require.NoError(t, err)
+	}
+	// 5. Check If Transaction is sent
+	t.Log("Finished submit")
+
+	startBlock := uint64(0)
+	endBlock := uint64(totalTxNumber + 1)
+	totalTxs := 0
+	totalBlocks := 0
+
+	dc := client.NewDeliverClient(uc)
+	cnx, cancel := context.WithCancel(context.Background())
+	handler := func(block *common.Block) error {
+		totalTxs += len(block.Data.Data)
+		totalBlocks++
+		if totalTxs == totalTxNumber+1 {
+			cancel()
+			return context.Canceled
+		}
+		return nil
+	}
+	dc.PullBlocks(cnx, 1, startBlock, endBlock, handler, signutil.CreateTestSigner(t, "org1", dir))
+	assert.Equal(t, totalTxNumber+1, totalTxs)
+	assert.True(t, totalBlocks > 2)
+	t.Logf("Finished pull and count: %d, %d", totalBlocks, totalTxs)
+}

--- a/test/faulttolerance/assembler_test.go
+++ b/test/faulttolerance/assembler_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package faulttolerance
 
 import (
 	"context"
@@ -247,78 +247,4 @@ func TestStartAssemblerGetMetrics(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	require.GreaterOrEqual(t, testutil.FetchPrometheusMetricValue(t, blocksCountRe, url), 2)
-}
-
-// scenario:
-// start an arma network with 4 parties and mTLS enabled for assembler
-// send some transactions to the network
-// pull blocks from one of the assemblers and count them, verify that all expected transactions are included in the pulled blocks
-func TestPullBlocksFromAssemblerWithMTLS(t *testing.T) {
-	totalTxNumber := 100
-	dir, err := os.MkdirTemp("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	var broadcastClient *client.BroadcastTxClient
-
-	// 1.
-	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, 4, 2, "none", "mTLS")
-	defer netInfo.CleanUp()
-	require.NoError(t, err)
-	// 2.
-	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
-
-	// 3.
-	// compile arma
-	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
-	require.NoError(t, err)
-	require.NotNil(t, armaBinaryPath)
-
-	// run arma nodes
-	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
-	readyChan := make(chan string, 20)
-	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, 20, 10)
-
-	// 4. Send To Routers
-	uc, err := testutil.GetUserConfig(dir, 1)
-	assert.NoError(t, err)
-	assert.NotNil(t, uc)
-	broadcastClient = client.NewBroadcastTxClient(uc, 10*time.Second)
-	defer broadcastClient.Stop()
-	require.NoError(t, err)
-	for i := 0; i < totalTxNumber; i++ {
-		txContent := tx.PrepareTxWithTimestamp(i, 100, []byte("sessionNumber"))
-		env := tx.CreateStructuredEnvelope(txContent)
-		err = broadcastClient.SendTx(env)
-		require.NoError(t, err)
-	}
-	// 5. Check If Transaction is sent
-	t.Log("Finished submit")
-
-	// Pull some block from the middle and count them
-	startBlock := uint64(0)
-	endBlock := uint64(math.MaxUint64)
-	totalTxs := 0
-	totalBlocks := 0
-
-	dc := client.NewDeliverClient(uc)
-	cnx, cancel := context.WithCancel(context.Background())
-	handler := func(block *common.Block) error {
-		totalTxs += len(block.Data.Data)
-		totalBlocks++
-		if totalTxs == totalTxNumber+1 {
-			cancel()
-			return context.Canceled
-		}
-		return nil
-	}
-	status, err := dc.PullBlocks(cnx, 1, startBlock, endBlock, handler, signutil.CreateTestSigner(t, "org1", dir))
-	assert.ErrorContains(t, err, "context canceled")
-	assert.Equal(t, common.Status(0), status)
-	assert.Equal(t, totalTxNumber+1, totalTxs)
-	assert.True(t, totalBlocks > 2)
-	t.Logf("Finished pull and count: %d, %d", totalBlocks, totalTxs)
 }

--- a/test/faulttolerance/batcher_consenter_test.go
+++ b/test/faulttolerance/batcher_consenter_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package faulttolerance
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/common/utils"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/config"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 
 	"github.com/stretchr/testify/require"
@@ -29,21 +30,21 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	require.NoError(t, err)
 	numParties := 4
 
-	batcherNodesShard0, batchersInfoShard0 := createBatcherNodesAndInfo(t, ca, numParties)
-	batcherNodesShard1, batchersInfoShard1 := createBatcherNodesAndInfo(t, ca, numParties)
-	consenterNodes, consentersInfo := createConsenterNodesAndInfo(t, ca, numParties)
+	batcherNodesShard0, batchersInfoShard0 := test_utils.CreateBatcherNodesAndInfo(t, ca, numParties)
+	batcherNodesShard1, batchersInfoShard1 := test_utils.CreateBatcherNodesAndInfo(t, ca, numParties)
+	consenterNodes, consentersInfo := test_utils.CreateConsenterNodesAndInfo(t, ca, numParties)
 
 	shards := []config.ShardInfo{{ShardId: 0, Batchers: batchersInfoShard0}, {ShardId: 1, Batchers: batchersInfoShard1}}
 
 	genesisBlock := utils.EmptyGenesisBlock("arma")
 
-	_, _, _, clean := createConsenters(t, numParties, consenterNodes, consentersInfo, shards, genesisBlock)
+	_, _, _, clean := test_utils.CreateConsenters(t, numParties, consenterNodes, consentersInfo, shards, genesisBlock)
 	defer clean()
 
-	batchers0, configs, loggers, clean := createBatchersForShard(t, numParties, batcherNodesShard0, shards, consentersInfo, shards[0].ShardId, genesisBlock)
+	batchers0, configs, loggers, clean := test_utils.CreateBatchersForShard(t, numParties, batcherNodesShard0, shards, consentersInfo, shards[0].ShardId, genesisBlock)
 	defer clean()
 
-	batchers1, _, _, clean := createBatchersForShard(t, numParties, batcherNodesShard1, shards, consentersInfo, shards[1].ShardId, genesisBlock)
+	batchers1, _, _, clean := test_utils.CreateBatchersForShard(t, numParties, batcherNodesShard1, shards, consentersInfo, shards[1].ShardId, genesisBlock)
 	defer clean()
 
 	for i := 0; i < 4; i++ {
@@ -98,7 +99,7 @@ func TestBatcherFailuresAndRecoveryWithTwoShards(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// Recover old primary in shard 0
-	batchers0[0] = recoverBatcher(t, ca, configs[0], batcherNodesShard0[0], loggers[0])
+	batchers0[0] = test_utils.RecoverBatcher(t, ca, configs[0], batcherNodesShard0[0], loggers[0])
 
 	require.Eventually(t, func() bool {
 		return batchers0[0].Ledger.Height(2) == 1

--- a/test/faulttolerance/batcher_test.go
+++ b/test/faulttolerance/batcher_test.go
@@ -4,21 +4,19 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package faulttolerance
 
 import (
 	"fmt"
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 	"time"
 
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
-	"github.com/hyperledger/fabric-x-orderer/common/utils"
-	config "github.com/hyperledger/fabric-x-orderer/config"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/client"
 	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
@@ -117,7 +115,7 @@ func TestPrimaryBatcherRestartRecover(t *testing.T) {
 	signer := signutil.CreateTestSigner(t, "org1", dir)
 
 	// Pull from Assemblers
-	infos := PullFromAssemblers(t, &BlockPullerOptions{
+	infos := test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          parties,
 		StartBlock:       0,
@@ -174,7 +172,7 @@ func TestPrimaryBatcherRestartRecover(t *testing.T) {
 			correctParties = append(correctParties, types.PartyID(partyID))
 		}
 	}
-	infos = PullFromAssemblers(t, &BlockPullerOptions{
+	infos = test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		Parties:          correctParties,
 		UserConfig:       uc,
 		StartBlock:       0,
@@ -196,7 +194,7 @@ func TestPrimaryBatcherRestartRecover(t *testing.T) {
 
 	testutil.WaitReady(t, readyChan, 1, 10)
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          []types.PartyID{primaryBatcher.PartyId},
 		StartBlock:       0,
@@ -237,7 +235,7 @@ func TestPrimaryBatcherRestartRecover(t *testing.T) {
 
 	// Pull from Assemblers
 	// make sure assemblers of all the parties get transactions (expect 3000 TXs).
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          parties,
 		StartBlock:       0,
@@ -337,7 +335,7 @@ func TestSecondaryBatcherRestartRecover(t *testing.T) {
 	signer := signutil.CreateTestSigner(t, "org1", dir)
 
 	// Pull from Assemblers
-	infos := PullFromAssemblers(t, &BlockPullerOptions{
+	infos := test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          parties,
 		StartBlock:       0,
@@ -398,7 +396,7 @@ func TestSecondaryBatcherRestartRecover(t *testing.T) {
 
 	// 5.
 	// make sure assemblers of correct parties continue to get transactions (expect 2000 TXs).
-	infos = PullFromAssemblers(t, &BlockPullerOptions{
+	infos = test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		Parties:          correctParties,
 		UserConfig:       uc,
 		StartBlock:       0,
@@ -420,7 +418,7 @@ func TestSecondaryBatcherRestartRecover(t *testing.T) {
 
 	testutil.WaitReady(t, readyChan, 1, 10)
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:       uc,
 		Parties:          []types.PartyID{secondaryBatcher.PartyId},
 		StartBlock:       0,
@@ -457,7 +455,7 @@ func TestSecondaryBatcherRestartRecover(t *testing.T) {
 
 	// Pull from Assemblers
 	// make sure assemblers of all the parties get transactions (expect 3000 TXs).
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		Parties:          parties,
 		UserConfig:       uc,
 		StartBlock:       0,
@@ -468,239 +466,4 @@ func TestSecondaryBatcherRestartRecover(t *testing.T) {
 		ErrString:        "cancelled pull from assembler: %d",
 		Signer:           signer,
 	})
-}
-
-// TestVerifySignedTxsByBatcherSingleParty verifies that a single-party batcher network correctly processes
-// signed transactions with client signature verification enabled.
-func TestVerifySignedTxsByBatcherSingleParty(t *testing.T) {
-	// 1. compile arma
-	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
-	defer gexec.CleanupBuildArtifacts()
-	require.NoError(t, err)
-	require.NotNil(t, armaBinaryPath)
-
-	t.Logf("Running test with %d parties and %d shards", 1, 1)
-
-	// 2. Create a temporary directory for the test.
-	dir, err := os.MkdirTemp("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	shardsNumber := 2
-
-	// 3. Create a config YAML file in the temporary directory.
-	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, 1, shardsNumber, "none", "none")
-	defer netInfo.CleanUp()
-	require.NotNil(t, netInfo)
-	numOfArmaNodes := len(netInfo)
-
-	// 4. Generate the config files in the temporary directory using the armageddon generate command.
-	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
-
-	for shardID := range shardsNumber {
-		configFilePath := filepath.Join(dir, fmt.Sprintf("config/party%d/local_config_batcher%d.yaml", types.PartyID(1), types.ShardID(shardID+1)))
-		conf, _, err := config.LoadLocalConfig(configFilePath)
-		require.NoError(t, err)
-
-		// Modify the batcher configuration to require client signature verification.
-		conf.NodeLocalConfig.GeneralConfig.ClientSignatureVerificationRequired = true
-		utils.WriteToYAML(conf.NodeLocalConfig, configFilePath)
-	}
-
-	// 5. Run the arma nodes.
-	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
-	// Obtains a test user configuration and constructs a broadcast client.
-	readyChan := make(chan string, numOfArmaNodes)
-	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
-
-	uc, err := testutil.GetUserConfig(dir, types.PartyID(1))
-	assert.NoError(t, err)
-	assert.NotNil(t, uc)
-
-	totalTxNumber := 100
-	// rate limiter parameters
-	fillInterval := 10 * time.Millisecond
-	fillFrequency := 1000 / int(fillInterval.Milliseconds())
-	rate := 500
-
-	capacity := rate / fillFrequency
-	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start a rate limiter")
-		os.Exit(3)
-	}
-
-	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
-	signer, certBytes, err := testutil.LoadCryptoMaterialsFromDir(t, uc.MSPDir)
-	require.NoError(t, err)
-
-	org := fmt.Sprintf("org%d", types.PartyID(1))
-
-	for i := range totalTxNumber {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(i, 64, []byte("sessionNumber"))
-		env := tx.CreateSignedStructuredEnvelope(txContent, signer, certBytes, org)
-		err = broadcastClient.SendTx(env)
-		require.NoError(t, err)
-	}
-
-	broadcastClient.Stop()
-
-	// 6. make sure assemblers of all the parties get transactions (expect 1000 TXs).
-	PullFromAssemblers(t, &BlockPullerOptions{
-		UserConfig:       uc,
-		Parties:          []types.PartyID{1},
-		StartBlock:       0,
-		EndBlock:         math.MaxUint64,
-		Transactions:     totalTxNumber,
-		Timeout:          60,
-		NeedVerification: true,
-		ErrString:        "cancelled pull from assembler: %d",
-		Signer:           signutil.CreateTestSigner(t, "org1", dir),
-	})
-
-	// 7. Verify that the batchers have received the transactions.
-	txsReceived := 0
-
-	for shardId := range shardsNumber {
-		batcherToMonitor := armaNetwork.GetBatcher(t, types.PartyID(1), types.ShardID(shardId+1))
-		url := testutil.CaptureArmaNodePrometheusServiceURL(t, batcherToMonitor)
-
-		pattern := fmt.Sprintf(`batcher_router_txs_total\{party_id="%d",shard_id="%d"\} \d+`, types.PartyID(1), types.ShardID(shardId+1))
-		regex := regexp.MustCompile(pattern)
-		txsReceived += testutil.FetchPrometheusMetricValue(t, regex, url)
-	}
-
-	require.GreaterOrEqual(t, txsReceived, totalTxNumber, "Expected %d transactions to be received by the batchers, but got %d", totalTxNumber, txsReceived)
-}
-
-// TestVerifySignedTxsByBatcherForwardRequest tests the batcher's ability to forward
-// signed transactions from a non-primary batcher to a primary batcher while verifying
-// client signatures.
-func TestVerifySignedTxsByBatcherForwardRequest(t *testing.T) {
-	// 1. compile arma
-	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
-	defer gexec.CleanupBuildArtifacts()
-	require.NoError(t, err)
-	require.NotNil(t, armaBinaryPath)
-
-	numOfParties := 2
-	numShards := 1
-
-	t.Logf("Running test with %d parties and %d shards", numOfParties, numShards)
-
-	// 2. Create a temporary directory for the test.
-	dir, err := os.MkdirTemp("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	// 3. Create a config YAML file in the temporary directory.
-	configPath := filepath.Join(dir, "config.yaml")
-	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, numShards, "none", "none")
-	defer netInfo.CleanUp()
-	require.NotNil(t, netInfo)
-	numOfArmaNodes := len(netInfo)
-
-	// 4. Generate the config files in the temporary directory using the armageddon generate command.
-	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
-
-	for partyID := range numOfParties {
-		configFilePath := filepath.Join(dir, fmt.Sprintf("config/party%d/local_config_batcher%d.yaml", partyID+1, types.ShardID(1)))
-		conf, _, err := config.LoadLocalConfig(configFilePath)
-		require.NoError(t, err)
-
-		// Modify the batcher configuration to require client signature verification.
-		conf.NodeLocalConfig.GeneralConfig.ClientSignatureVerificationRequired = true
-		utils.WriteToYAML(conf.NodeLocalConfig, configFilePath)
-	}
-
-	// 5. Run the arma nodes.
-	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
-	// Obtains a test user configuration and constructs a broadcast client.
-	readyChan := make(chan string, numOfArmaNodes)
-	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
-	defer armaNetwork.Stop()
-
-	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
-
-	uc, err := testutil.GetUserConfig(dir, types.PartyID(1))
-	assert.NoError(t, err)
-	assert.NotNil(t, uc)
-
-	txNumber := 10
-	// rate limiter parameters
-	fillInterval := 10 * time.Millisecond
-	fillFrequency := 1000 / int(fillInterval.Milliseconds())
-	rate := 100
-
-	capacity := rate / fillFrequency
-	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start a rate limiter")
-		os.Exit(3)
-	}
-
-	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
-	signer, certBytes, err := testutil.LoadCryptoMaterialsFromDir(t, uc.MSPDir)
-	require.NoError(t, err)
-
-	// 6. Determine primary and non-primary party IDs for shard 1 by calculating the primary party ID using the formula:
-	// types.PartyID((uint64(b.Shard) + term) % uint64(b.N)) where term is assumed to be 0 and b.N is the number of parties.
-	primaryPartyID := types.PartyID((uint64(1))%uint64(numOfParties) + 1)
-	nonPrimaryPartyID := types.PartyID(uint64(primaryPartyID)%uint64(numOfParties) + 1)
-
-	t.Logf("Non-primary party ID is %d", nonPrimaryPartyID)
-	t.Logf("Primary party ID is %d", primaryPartyID)
-
-	// 7. Send TXs to a non-primary batcher
-	for i := range txNumber {
-		status := rl.GetToken()
-		if !status {
-			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
-			os.Exit(3)
-		}
-		txContent := tx.PrepareTxWithTimestamp(i, 64, []byte("sessionNumber"))
-		env := tx.CreateSignedStructuredEnvelope(txContent, signer, certBytes, "org1")
-		err = broadcastClient.SendTxTo(env, nonPrimaryPartyID)
-		require.NoError(t, err)
-	}
-
-	broadcastClient.Stop()
-
-	// 8. Verify that the non-primary batcher have received all the transactions.
-	nonPrimaryBatcherToMonitor := armaNetwork.GetBatcher(t, nonPrimaryPartyID, types.ShardID(1))
-	url := testutil.CaptureArmaNodePrometheusServiceURL(t, nonPrimaryBatcherToMonitor)
-
-	pattern := fmt.Sprintf(`batcher_router_txs_total\{party_id="%d",shard_id="%d"\} \d+`, nonPrimaryPartyID, types.ShardID(1))
-	re := regexp.MustCompile(pattern)
-
-	require.Eventually(t, func() bool {
-		return testutil.FetchPrometheusMetricValue(t, re, url) == txNumber
-	}, 30*time.Second, 100*time.Millisecond)
-
-	primaryBatcherToMonitor := armaNetwork.GetBatcher(t, primaryPartyID, types.ShardID(1))
-	url = testutil.CaptureArmaNodePrometheusServiceURL(t, primaryBatcherToMonitor)
-
-	// 9. Verify that the non-primary batcher have forwarded all the transactions to the primary batcher and the primary one have batched all the transactions.
-	pattern = fmt.Sprintf(`batcher_batched_txs_total\{party_id="%d",shard_id="%d"\} \d+`, primaryPartyID, types.ShardID(1))
-	re = regexp.MustCompile(pattern)
-
-	require.Eventually(t, func() bool {
-		return testutil.FetchPrometheusMetricValue(t, re, url) == txNumber
-	}, 30*time.Second, 100*time.Millisecond)
-
-	// 10. Verify that the non-primary batcher did not receive any transactions.
-	pattern = fmt.Sprintf(`batcher_router_txs_total\{party_id="%d",shard_id="%d"\} \d+`, primaryPartyID, types.ShardID(1))
-	re = regexp.MustCompile(pattern)
-
-	txsReceived := testutil.FetchPrometheusMetricValue(t, re, url)
-	require.Equal(t, txsReceived, 0, "Expected %d transactions to be received by the non-primary batcher, but got %d", 0, txsReceived)
 }

--- a/test/faulttolerance/consensus_test.go
+++ b/test/faulttolerance/consensus_test.go
@@ -3,7 +3,8 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
-package test
+
+package faulttolerance
 
 import (
 	"fmt"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
 	"github.com/onsi/gomega/gexec"
@@ -83,7 +85,7 @@ func TestSubmitStopThenRestartConsenter(t *testing.T) {
 
 	signer := signutil.CreateTestSigner(t, "org1", dir)
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		StartBlock:   0,
@@ -110,7 +112,7 @@ func TestSubmitStopThenRestartConsenter(t *testing.T) {
 			correctParties = append(correctParties, types.PartyID(i+1))
 		}
 	}
-	PullFromAssemblers(t, &BlockPullerOptions{
+	utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      correctParties,
 		StartBlock:   0,
@@ -130,7 +132,7 @@ func TestSubmitStopThenRestartConsenter(t *testing.T) {
 
 	waitForTxSent.Wait()
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	utils.PullFromAssemblers(t, &utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		StartBlock:   0,

--- a/test/faulttolerance/router_test.go
+++ b/test/faulttolerance/router_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package faulttolerance
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-orderer/common/tools/armageddon"
+	"github.com/hyperledger/fabric-x-orderer/common/types"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
+	"github.com/hyperledger/fabric-x-orderer/testutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/client"
+	"github.com/hyperledger/fabric-x-orderer/testutil/signutil"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
+	"github.com/onsi/gomega/gexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouterRestartRecover tests the ability of the router to restart and recover from a shutdown.
+// The test sends transactions to the router and then stops it. After that, it waits for the router to
+// be restarted and verifies that all transactions were successfully delivered.
+//
+// The test consists of the following steps:
+// 1. Compile the arma binary.
+// 2. Create a temporary directory for the test.
+// 3. Create a config YAML file in the temporary directory.
+// 4. Generate the config files in the temporary directory using the armageddon generate command.
+// 5. Run the arma nodes.
+// 6. Send transactions to the router.
+// 7. Stop a secondary router.
+// 8. Pull blocks from all assemblers.
+// 9. Start the secondary router.
+// 10. Pull blocks from all assemblers again.
+// 11. Stop a primary router.
+// 12. Pull blocks from all assemblers again.
+// 13. Start the primary router.
+// 14. Stop the broadcast client.
+// 15. Pull blocks from all assemblers again.
+func TestRouterRestartRecover(t *testing.T) {
+	// 1. compile arma
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	defer gexec.CleanupBuildArtifacts()
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	// Number of parties in the test
+	numOfParties := 4
+
+	t.Logf("Running test with %d parties and %d shards", numOfParties, 1)
+
+	// 2. Create a temporary directory for the test.
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// 3. Create a config YAML file in the temporary directory.
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, 1, "none", "none")
+	defer netInfo.CleanUp()
+	require.NoError(t, err)
+	numOfArmaNodes := len(netInfo)
+
+	// 4. Generate the config files in the temporary directory using the armageddon generate command.
+	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
+
+	// 5. Run the arma nodes.
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	readyChan := make(chan string, numOfArmaNodes)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+
+	uc, err := testutil.GetUserConfig(dir, 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, uc)
+
+	// 6. Send transactions to the routers.
+	totalTxNumber := 1000
+	// rate limiter parameters
+	fillInterval := 10 * time.Millisecond
+	fillFrequency := 1000 / int(fillInterval.Milliseconds())
+	rate := 500
+	totalTxSent := 0
+
+	capacity := rate / fillFrequency
+	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start a rate limiter")
+		os.Exit(3)
+	}
+
+	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
+
+	for i := 0; i < totalTxNumber; i++ {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		require.NoError(t, err)
+	}
+
+	totalTxSent += totalTxNumber
+
+	parties := []types.PartyID{}
+	for partyID := 1; partyID <= numOfParties; partyID++ {
+		parties = append(parties, types.PartyID(partyID))
+	}
+
+	signer := signutil.CreateTestSigner(t, "org1", dir)
+
+	pullerInfos := test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          parties,
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxSent,
+		Timeout:          60,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           signer,
+	})
+
+	primaryPartyId := pullerInfos[types.PartyID(1)].Primary[types.ShardID(1)]
+	secondaryPartyId := primaryPartyId%types.PartyID(numOfParties) + 1
+
+	// 7. Stop a secondary router.
+	routerToStop := armaNetwork.GetRouter(t, secondaryPartyId)
+
+	t.Logf("Stopping router: party %d", routerToStop.PartyId)
+	routerToStop.StopArmaNode()
+	gotError := false
+
+	for i := range totalTxNumber {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		if err != nil {
+			require.ErrorContains(t, err, "EOF")
+			gotError = true
+		}
+	}
+
+	require.True(t, gotError, "expected to get an error when sending tx to a stopped router")
+
+	totalTxSent += totalTxNumber
+
+	// 8. Pull blocks from all assemblers.
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          parties,
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxSent,
+		Timeout:          60,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           signer,
+	})
+
+	// 9. Restart the secondary router.
+	routerToStop.RestartArmaNode(t, readyChan)
+	testutil.WaitReady(t, readyChan, 1, 10)
+
+	for i := range totalTxNumber {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		require.NoError(t, err)
+	}
+
+	totalTxSent += totalTxNumber
+
+	// 10. Pull blocks from all assemblers.
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          parties,
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxSent,
+		Timeout:          60,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           signer,
+	})
+
+	// 11. Stop a primary router.
+	primaryRouterToStop := armaNetwork.GetRouter(t, primaryPartyId)
+	t.Logf("Stopping router: party %d", primaryRouterToStop.PartyId)
+	primaryRouterToStop.StopArmaNode()
+
+	gotError = false
+
+	for i := 0; i < totalTxNumber; i++ {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		if err != nil {
+			require.ErrorContains(t, err, "EOF")
+			gotError = true
+		}
+	}
+
+	require.True(t, gotError, "expected to get an error when sending tx to a stopped router")
+
+	totalTxSent += totalTxNumber
+
+	// 12. Pull blocks from all assemblers.
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          parties,
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxSent,
+		Timeout:          60,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           signer,
+	})
+
+	// 13. Restart the primary router.
+	primaryRouterToStop.RestartArmaNode(t, readyChan)
+	testutil.WaitReady(t, readyChan, 1, 10)
+
+	for i := 0; i < totalTxNumber; i++ {
+		status := rl.GetToken()
+		if !status {
+			fmt.Fprintf(os.Stderr, "failed to send tx %d", i+1)
+			os.Exit(3)
+		}
+		txContent := tx.PrepareTxWithTimestamp(totalTxSent+i, 64, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		require.NoError(t, err)
+	}
+
+	totalTxSent += totalTxNumber
+
+	// 14. Stop the broadcast client.
+	broadcastClient.Stop()
+
+	// 15. Pull blocks from all assemblers.
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          parties,
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxSent,
+		Timeout:          60,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           signer,
+	})
+}

--- a/test/reconfig/config_disseminate_test.go
+++ b/test/reconfig/config_disseminate_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package reconfig
 
 import (
 	"context"
@@ -38,6 +38,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
 	"github.com/hyperledger/fabric-x-orderer/node/ledger"
 	protos "github.com/hyperledger/fabric-x-orderer/node/protos/comm"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 	"github.com/stretchr/testify/require"
 )
@@ -50,24 +51,24 @@ func TestConfigDisseminate(t *testing.T) {
 	require.NoError(t, err)
 	numParties := 4
 
-	batcherNodes, batcherInfos := createBatcherNodesAndInfo(t, ca, numParties)
-	consenterNodes, consenterInfos := createConsenterNodesAndInfo(t, ca, numParties)
+	batcherNodes, batcherInfos := test_utils.CreateBatcherNodesAndInfo(t, ca, numParties)
+	consenterNodes, consenterInfos := test_utils.CreateConsenterNodesAndInfo(t, ca, numParties)
 
 	shards := []config.ShardInfo{{ShardId: 1, Batchers: batcherInfos}}
 
 	genesisBlock := utils.EmptyGenesisBlock("arma")
 
-	consenters, consentersConfigs, consentersLoggers, _ := createConsenters(t, numParties, consenterNodes, consenterInfos, shards, genesisBlock)
+	consenters, consentersConfigs, consentersLoggers, _ := test_utils.CreateConsenters(t, numParties, consenterNodes, consenterInfos, shards, genesisBlock)
 
-	batchers, batchersConfigs, batchersLoggers, _ := createBatchersForShard(t, numParties, batcherNodes, shards, consenterInfos, shards[0].ShardId, genesisBlock)
+	batchers, batchersConfigs, batchersLoggers, _ := test_utils.CreateBatchersForShard(t, numParties, batcherNodes, shards, consenterInfos, shards[0].ShardId, genesisBlock)
 
-	routers, certs, routersConfigs, routersLoggers := createRouters(t, numParties, batcherInfos, ca, shards[0].ShardId, []string{consenterNodes[0].Address(), consenterNodes[1].Address(), consenterNodes[2].Address(), consenterNodes[3].Address()}, genesisBlock)
+	routers, certs, routersConfigs, routersLoggers := test_utils.CreateRouters(t, numParties, batcherInfos, ca, shards[0].ShardId, []string{consenterNodes[0].Address(), consenterNodes[1].Address(), consenterNodes[2].Address(), consenterNodes[3].Address()}, genesisBlock)
 
 	for i := range routers {
 		routers[i].StartRouterService()
 	}
 
-	assemblers, assemblersDir, assemblersConfigs, assemblersLoggers, _ := createAssemblers(t, numParties, ca, shards, consenterInfos, genesisBlock)
+	assemblers, assemblersDir, assemblersConfigs, assemblersLoggers, _ := test_utils.CreateAssemblers(t, numParties, ca, shards, consenterInfos, genesisBlock)
 
 	// update consensus router config
 	for i := range consenters {
@@ -100,7 +101,7 @@ func TestConfigDisseminate(t *testing.T) {
 	}
 
 	// submit data txs and make sure the assembler got them
-	sendTransactions(t, routers, assemblers[0])
+	test_utils.SendTransactions(t, routers, assemblers[0])
 
 	// check the init size of the config store
 	for i := range routers {
@@ -177,10 +178,10 @@ func TestConfigDisseminate(t *testing.T) {
 	}
 
 	for i := 0; i < numParties; i++ {
-		batchers[i] = recoverBatcher(t, ca, batchersConfigs[i], batcherNodes[i], batchersLoggers[i])
-		consenters[i] = recoverConsenter(t, ca, consentersConfigs[i], consenterNodes[i], consentersLoggers[i], lastBlock)
-		assemblers[i] = recoverAssembler(t, assemblersConfigs[i], assemblersLoggers[i], lastBlock)
-		routers[i] = recoverRouter(routersConfigs[i], routersLoggers[i])
+		batchers[i] = test_utils.RecoverBatcher(t, ca, batchersConfigs[i], batcherNodes[i], batchersLoggers[i])
+		consenters[i] = test_utils.RecoverConsenter(t, ca, consentersConfigs[i], consenterNodes[i], consentersLoggers[i], lastBlock)
+		assemblers[i] = test_utils.RecoverAssembler(t, assemblersConfigs[i], assemblersLoggers[i], lastBlock)
+		routers[i] = test_utils.RecoverRouter(routersConfigs[i], routersLoggers[i])
 	}
 	time.Sleep(5 * time.Second)
 
@@ -195,7 +196,7 @@ func TestConfigDisseminate(t *testing.T) {
 	}
 
 	// submit data txs and make sure the assembler receives them after recovery
-	sendTransactions(t, routers, assemblers[0])
+	test_utils.SendTransactions(t, routers, assemblers[0])
 
 	// verify last block points to the last config block
 	for i := range assemblers {
@@ -291,7 +292,7 @@ func TestConfigTXDisseminationWithVerification(t *testing.T) {
 	endBlock := uint64(1)
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		StartBlock: startBlock,
@@ -348,7 +349,7 @@ func TestConfigTXDisseminationWithVerification(t *testing.T) {
 	err = broadcastClient2.SendTx(env)
 	require.NoError(t, err)
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig: uc,
 		Parties:    parties,
 		StartBlock: startBlock,

--- a/test/reconfig/create_config_update_test.go
+++ b/test/reconfig/create_config_update_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package reconfig
 
 import (
 	"os"

--- a/test/reconfig/send_config_update_test.go
+++ b/test/reconfig/send_config_update_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package reconfig
 
 import (
 	"bytes"
@@ -30,6 +30,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/config"
 	"github.com/hyperledger/fabric-x-orderer/config/generate"
 	"github.com/hyperledger/fabric-x-orderer/config/protos"
+	test_utils "github.com/hyperledger/fabric-x-orderer/test/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/client"
 	"github.com/hyperledger/fabric-x-orderer/testutil/configutil"
@@ -120,7 +121,7 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 
 	statusUknown := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -169,7 +170,7 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 
 	// Pull blocks to verify all transactions are included
 	userBlockHandler := &verifyRouterEndpointUpdate{updatedParty: partyToUpdate, routerIP: routerIP, newPort: newPort}
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber + 1, // including config update tx
@@ -222,7 +223,7 @@ func TestUpdatePartyRouterEndpoint(t *testing.T) {
 
 	// Pull blocks to verify all transactions are included
 	userBlockHandler = &verifyRouterEndpointUpdate{updatedParty: partyToUpdate, routerIP: routerIP, newPort: newPort}
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber*2 + 1, // including config update tx
@@ -479,7 +480,7 @@ func TestRemoveStoppedPartyThenRestart(t *testing.T) {
 
 	statusUnknown := common.Status_UNKNOWN
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      remainingParties,
 		Transactions: totalTxNumber*2 + 1, // including config update tx
@@ -583,7 +584,7 @@ func TestRemoveParty(t *testing.T) {
 	statusUnknown := common.Status_UNKNOWN
 
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -654,7 +655,7 @@ func TestRemoveParty(t *testing.T) {
 	statusUnknown = common.Status_UNKNOWN
 
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      remainingParties,
 		Transactions: totalTxNumber*2 + 1, // including config update tx
@@ -764,7 +765,7 @@ func TestAddNewParty(t *testing.T) {
 
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 	statusUnknown := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -794,7 +795,7 @@ func TestAddNewParty(t *testing.T) {
 	configBlockStoreDir := t.TempDir()
 	newConfigBlockPath := filepath.Join(configBlockStoreDir, "config.block")
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber + 1, // include the config block
@@ -886,7 +887,7 @@ func TestAddNewParty(t *testing.T) {
 
 	pullRequestSigner = signutil.CreateTestSigner(t, "org1", dir)
 	statusUnknown = common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber*2 + 2, // including the config tx and the single tx
@@ -970,7 +971,7 @@ func TestChangePartyCertificates(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown := common.Status_UNKNOWN
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1132,7 +1133,7 @@ func TestChangePartyCertificates(t *testing.T) {
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown = common.Status_UNKNOWN
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber*2 + 1, // including config update tx
@@ -1225,7 +1226,7 @@ func TestChangePartyCACertificates(t *testing.T) {
 	// Pull blocks to verify all transactions are included
 	pullRequestSigner := signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1361,7 +1362,7 @@ func TestChangePartyCACertificates(t *testing.T) {
 	// Pull blocks to verify all transactions are included
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown = common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1465,7 +1466,7 @@ func TestChangePartyCACertificates(t *testing.T) {
 	// Pull blocks to verify all transactions are included
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown = common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1530,7 +1531,7 @@ func TestChangePartyCACertificates(t *testing.T) {
 	// Pull blocks to verify all transactions are included
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown = common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1699,7 +1700,7 @@ func TestUpdateTimeoutParameters(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 
 	statusUnknown := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1755,7 +1756,7 @@ func TestUpdateTimeoutParameters(t *testing.T) {
 
 	totalTxNumber += txNumber
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber + 1, // including config update tx
@@ -1874,7 +1875,7 @@ func TestUpdateSmartBFTParameters(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 
 	statusUnknown := common.Status_UNKNOWN
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -1922,7 +1923,7 @@ func TestUpdateSmartBFTParameters(t *testing.T) {
 
 	totalTxNumber += txNumber
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber + 1, // including config update tx
@@ -2072,7 +2073,7 @@ func TestUpdateBatchingParameters(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, "org1", dir)
 	statusUnknown := common.Status_UNKNOWN
 
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   userConfig,
 		Parties:      parties,
 		Transactions: totalTxNumber + 1, // including config update tx
@@ -2191,7 +2192,7 @@ func TestReplacePartiesPartially(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown := common.Status_UNKNOWN
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -2353,7 +2354,7 @@ func TestReplacePartiesPartially(t *testing.T) {
 
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -2438,7 +2439,7 @@ func TestRemoveMultipleParties(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown := common.Status_UNKNOWN
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -2517,7 +2518,7 @@ func TestRemoveMultipleParties(t *testing.T) {
 
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -2604,7 +2605,7 @@ func TestJoinMultipleParties(t *testing.T) {
 	pullRequestSigner := signutil.CreateTestSigner(t, submittingOrg, dir)
 	statusUnknown := common.Status_UNKNOWN
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -2702,7 +2703,7 @@ func TestJoinMultipleParties(t *testing.T) {
 
 	pullRequestSigner = signutil.CreateTestSigner(t, submittingOrg, dir)
 	// Pull blocks to verify all transactions are included
-	PullFromAssemblers(t, &BlockPullerOptions{
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
 		UserConfig:   uc,
 		Parties:      parties,
 		Transactions: totalTxNumber,
@@ -2710,5 +2711,85 @@ func TestJoinMultipleParties(t *testing.T) {
 		Timeout:      60,
 		Status:       &statusUnknown,
 		Signer:       pullRequestSigner,
+	})
+}
+
+// TestSubmitReceiveAndVerifySignaturesConfigBlock tests the end-to-end process of submitting a configuration
+// transaction, receiving the resulting configuration block, and verifying its signatures.
+func TestSubmitReceiveAndVerifySignaturesConfigBlock(t *testing.T) {
+	// 1. Builds the arma binary and creates a temporary directory for test artifacts
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	defer gexec.CleanupBuildArtifacts()
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	numOfShards := 1
+	numOfParties := 1
+
+	// create temp dir
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// 2. Creates a network configuration with the specified number of shards and parties
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, numOfShards, "none", "none")
+	defer netInfo.CleanUp()
+	require.NotNil(t, netInfo)
+	numOfArmaNodes := len(netInfo)
+
+	// 3. Generates necessary cryptographic materials and network artifacts using the arma CLI
+	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
+
+	// 4. Starts arma nodes and waits for them to be ready
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	readyChan := make(chan string, numOfArmaNodes)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+
+	uc, err := testutil.GetUserConfig(dir, 1)
+	require.NoError(t, err)
+	require.NotNil(t, uc)
+
+	logger := testutil.CreateLogger(t, 0)
+
+	// 5. Builds a signature verifier from the consenter information
+	verifier := test_utils.BuildVerifier(dir, types.PartyID(1), logger)
+
+	// 6. Creates a broadcast client to submit transactions and submits a configuration transaction based on the genesis block
+	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
+	defer broadcastClient.Stop()
+
+	// Create config tx
+	genesisBlockPath := filepath.Join(dir, "bootstrap/bootstrap.block")
+	submittingPartyID := 1
+	configUpdateBuilder, cleanUp := configutil.NewConfigUpdateBuilder(t, dir, genesisBlockPath)
+	defer cleanUp()
+
+	configUpdatePbData := configUpdateBuilder.UpdateBatchSizeConfig(t, configutil.NewBatchSizeConfig(configutil.BatchSizeConfigName.MaxMessageCount, 500))
+	require.NotEmpty(t, configUpdatePbData)
+
+	env := configutil.CreateConfigTX(t, dir, []types.PartyID{1}, submittingPartyID, configUpdatePbData)
+	require.NotNil(t, env)
+
+	// Send the config tx
+	err = broadcastClient.SendTx(env)
+	require.NoError(t, err)
+	totalBlocks := 2 // genesis + config block
+
+	// 7. Pulls and verifies blocks from assemblers, ensuring the configuration block's signatures are valid
+	statusSuccess := common.Status_UNKNOWN
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig: uc,
+		Parties:    []types.PartyID{types.PartyID(submittingPartyID)},
+		StartBlock: uint64(0),
+		Status:     &statusSuccess,
+		Verifier:   verifier,
+		Blocks:     totalBlocks,
+		ErrString:  "cancelled pull from assembler: %d",
+		LogString:  "configuration block 1 partyID %d verified with",
+		Signer:     signutil.CreateTestSigner(t, "org1", dir),
 	})
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package test
+package utils
 
 import (
 	"bytes"
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -96,7 +97,7 @@ func keygen(t *testing.T) (*ecdsa.PrivateKey, []byte) {
 	return sk, rawPK
 }
 
-func createRouters(t *testing.T, num int, batcherInfos []node_config.BatcherInfo, ca tlsgen.CA, shardId types.ShardID, consenterEndpoint []string, genesisBlock *common.Block) ([]*router.Router, []node_config.RawBytes, []*node_config.RouterNodeConfig, []*flogging.FabricLogger) {
+func CreateRouters(t *testing.T, num int, batcherInfos []node_config.BatcherInfo, ca tlsgen.CA, shardId types.ShardID, consenterEndpoint []string, genesisBlock *common.Block) ([]*router.Router, []node_config.RawBytes, []*node_config.RouterNodeConfig, []*flogging.FabricLogger) {
 	var routers []*router.Router
 	var certs []node_config.RawBytes
 	var configs []*node_config.RouterNodeConfig
@@ -161,7 +162,7 @@ func createRouters(t *testing.T, num int, batcherInfos []node_config.BatcherInfo
 	return routers, certs, configs, loggers
 }
 
-func createAssemblers(t *testing.T, num int, ca tlsgen.CA, shards []node_config.ShardInfo, consenterInfos []node_config.ConsenterInfo, genesisBlock *common.Block) ([]*assembler.Assembler, []string, []*node_config.AssemblerNodeConfig, []*flogging.FabricLogger, func()) {
+func CreateAssemblers(t *testing.T, num int, ca tlsgen.CA, shards []node_config.ShardInfo, consenterInfos []node_config.ConsenterInfo, genesisBlock *common.Block) ([]*assembler.Assembler, []string, []*node_config.AssemblerNodeConfig, []*flogging.FabricLogger, func()) {
 	var assemblerDirs []string
 	var assemblers []*assembler.Assembler
 	var loggers []*flogging.FabricLogger
@@ -212,7 +213,7 @@ func createAssemblers(t *testing.T, num int, ca tlsgen.CA, shards []node_config.
 	}
 }
 
-func createConsenters(t *testing.T, num int, consenterNodes []*node, consenterInfos []node_config.ConsenterInfo, shardInfo []node_config.ShardInfo, genesisBlock *common.Block) ([]*consensus.Consensus, []*node_config.ConsenterNodeConfig, []*flogging.FabricLogger, func()) {
+func CreateConsenters(t *testing.T, num int, consenterNodes []*node, consenterInfos []node_config.ConsenterInfo, shardInfo []node_config.ShardInfo, genesisBlock *common.Block) ([]*consensus.Consensus, []*node_config.ConsenterNodeConfig, []*flogging.FabricLogger, func()) {
 	var consensuses []*consensus.Consensus
 	var loggers []*flogging.FabricLogger
 	var configs []*node_config.ConsenterNodeConfig
@@ -295,7 +296,7 @@ func createConsenters(t *testing.T, num int, consenterNodes []*node, consenterIn
 	}
 }
 
-func createBatchersForShard(t *testing.T, num int, batcherNodes []*node, shards []node_config.ShardInfo, consenterInfos []node_config.ConsenterInfo, shardID types.ShardID, genesisBlock *common.Block) ([]*batcher.Batcher, []*node_config.BatcherNodeConfig, []*flogging.FabricLogger, func()) {
+func CreateBatchersForShard(t *testing.T, num int, batcherNodes []*node, shards []node_config.ShardInfo, consenterInfos []node_config.ConsenterInfo, shardID types.ShardID, genesisBlock *common.Block) ([]*batcher.Batcher, []*node_config.BatcherNodeConfig, []*flogging.FabricLogger, func()) {
 	var batchers []*batcher.Batcher
 	var loggers []*flogging.FabricLogger
 	var configs []*node_config.BatcherNodeConfig
@@ -376,7 +377,7 @@ func createBatchersForShard(t *testing.T, num int, batcherNodes []*node, shards 
 	}
 }
 
-func createBatcherNodesAndInfo(t *testing.T, ca tlsgen.CA, num int) ([]*node, []node_config.BatcherInfo) {
+func CreateBatcherNodesAndInfo(t *testing.T, ca tlsgen.CA, num int) ([]*node, []node_config.BatcherInfo) {
 	nodes := createNodes(t, num, ca)
 
 	var batchersInfo []node_config.BatcherInfo
@@ -393,7 +394,7 @@ func createBatcherNodesAndInfo(t *testing.T, ca tlsgen.CA, num int) ([]*node, []
 	return nodes, batchersInfo
 }
 
-func createConsenterNodesAndInfo(t *testing.T, ca tlsgen.CA, num int) ([]*node, []node_config.ConsenterInfo) {
+func CreateConsenterNodesAndInfo(t *testing.T, ca tlsgen.CA, num int) ([]*node, []node_config.ConsenterInfo) {
 	nodes := createNodes(t, num, ca)
 
 	var consentersInfo []node_config.ConsenterInfo
@@ -432,7 +433,7 @@ func createNodes(t *testing.T, num int, ca tlsgen.CA) []*node {
 	return result
 }
 
-func recoverBatcher(t *testing.T, ca tlsgen.CA, conf *node_config.BatcherNodeConfig, batcherNode *node, logger *flogging.FabricLogger) *batcher.Batcher {
+func RecoverBatcher(t *testing.T, ca tlsgen.CA, conf *node_config.BatcherNodeConfig, batcherNode *node, logger *flogging.FabricLogger) *batcher.Batcher {
 	newBatcherNode := &node{
 		TLSCert: batcherNode.TLSCert,
 		TLSKey:  batcherNode.TLSKey,
@@ -467,7 +468,7 @@ func recoverBatcher(t *testing.T, ca tlsgen.CA, conf *node_config.BatcherNodeCon
 	return batcher
 }
 
-func recoverConsenter(t *testing.T, ca tlsgen.CA, conf *node_config.ConsenterNodeConfig, consenterNode *node, logger *flogging.FabricLogger, lastConfigBlock *common.Block) *consensus.Consensus {
+func RecoverConsenter(t *testing.T, ca tlsgen.CA, conf *node_config.ConsenterNodeConfig, consenterNode *node, logger *flogging.FabricLogger, lastConfigBlock *common.Block) *consensus.Consensus {
 	newConsenterNode := &node{
 		TLSCert: consenterNode.TLSCert,
 		TLSKey:  consenterNode.TLSKey,
@@ -512,13 +513,13 @@ func recoverConsenter(t *testing.T, ca tlsgen.CA, conf *node_config.ConsenterNod
 	return consenter
 }
 
-func recoverAssembler(t *testing.T, conf *node_config.AssemblerNodeConfig, logger *flogging.FabricLogger, lastConfigBlock *common.Block) *assembler.Assembler {
+func RecoverAssembler(t *testing.T, conf *node_config.AssemblerNodeConfig, logger *flogging.FabricLogger, lastConfigBlock *common.Block) *assembler.Assembler {
 	assembler := assembler.NewAssembler(conf, &config.Configuration{}, lastConfigBlock, make(chan struct{}), logger)
 	assembler.StartAssemblerService()
 	return assembler
 }
 
-func recoverRouter(conf *node_config.RouterNodeConfig, logger *flogging.FabricLogger) *router.Router {
+func RecoverRouter(conf *node_config.RouterNodeConfig, logger *flogging.FabricLogger) *router.Router {
 	bundle := &configMocks.FakeConfigResources{}
 	configtxValidator := &policyMocks.FakeConfigtxValidator{}
 	configtxValidator.ChannelIDReturns("arma")
@@ -539,7 +540,7 @@ func recoverRouter(conf *node_config.RouterNodeConfig, logger *flogging.FabricLo
 	return router
 }
 
-func sendTxn(workerID int, txnNum int, routers []*router.Router) {
+func SendTxn(workerID int, txnNum int, routers []*router.Router) {
 	txn := make([]byte, 32)
 	binary.BigEndian.PutUint64(txn, uint64(txnNum))
 	binary.BigEndian.PutUint16(txn[30:], uint16(workerID))
@@ -832,4 +833,47 @@ func BuildVerifier(configDir string, partyID types.PartyID, logger *flogging.Fab
 	}
 
 	return &verifier
+}
+
+func SendTransactions(t *testing.T, routers []*router.Router, assembler *assembler.Assembler) {
+	SendTxn(runtime.NumCPU()+1, 0, routers)
+
+	time.Sleep(time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(runtime.NumCPU())
+
+	workPerWorker := 100
+
+	initialCount := int(assembler.GetTxCount())
+
+	start := time.Now()
+
+	for workerID := 0; workerID < runtime.NumCPU(); workerID++ {
+		go func(workerID int) {
+			defer wg.Done()
+
+			for txNum := 0; txNum < workPerWorker; txNum++ {
+				SendTxn(workerID, initialCount+txNum, routers)
+			}
+		}(workerID)
+	}
+
+	wg.Wait()
+
+	totalTxn := workPerWorker * runtime.NumCPU()
+	expected := initialCount + totalTxn
+	t.Logf("Expecting %d TXs (%d to %d)", totalTxn, initialCount, expected)
+	require.Eventually(t, func() bool {
+		n := assembler.GetTxCount()
+		t.Logf("Received TXs: %d", n)
+		return int(n) >= expected
+	}, time.Minute, time.Second)
+
+	elapsed := int(time.Since(start).Seconds())
+	if elapsed == 0 {
+		elapsed = 1
+	}
+
+	t.Logf("%f (totalTxn / elapsed)\n", float32(totalTxn)/float32(elapsed))
 }


### PR DESCRIPTION
Split integration tests into basic, faulttolerance and reconfig.
Moved tests to the correct category.
Split CI jobs accordingly.

#835 