### PR TITLE
Fix armageddon help text grammar

### DIFF
--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -162,21 +162,21 @@ func (cli *CLI) configureCommands() {
 	commands["version"] = version
 
 	submit := cli.app.Command("submit", "Submit txs to routers and verify the submission")
-	cli.userConfigFile = submit.Flag("config", "The user configuration needed to connection with routers and assemblers").File()
+	cli.userConfigFile = submit.Flag("config", "The user configuration needed to connect with routers and assemblers").File()
 	cli.transactions = submit.Flag("transactions", "The number of transactions to be sent").Int()
-	cli.rate = submit.Flag("rate", "The rate specify the number of transactions per second to be sent").Int()
+	cli.rate = submit.Flag("rate", "The rate specifies the number of transactions per second to be sent").Int()
 	cli.txSize = submit.Flag("txSize", "The required transaction size in bytes").Default("512").Int()
 	commands["submit"] = submit
 
 	load := cli.app.Command("load", "Submit txs to routers and verify the routers have received the txs")
-	cli.loadUserConfigFile = load.Flag("config", "The user configuration needed to connection with routers").File()
+	cli.loadUserConfigFile = load.Flag("config", "The user configuration needed to connect with routers").File()
 	cli.loadTransactions = load.Flag("transactions", "The number of transactions to be sent").Int()
 	cli.loadRate = load.Flag("rate", "The rate specifies the number of transactions per second to be sent as one or more rate numbers separated by space").String()
 	cli.loadTxSize = load.Flag("txSize", "The required transaction size in bytes").Int()
 	commands["load"] = load
 
 	receive := cli.app.Command("receive", "Pull txs from some assembler and report statistics")
-	cli.receiveUserConfigFile = receive.Flag("config", "The user configuration needed to connection with assemblers").File()
+	cli.receiveUserConfigFile = receive.Flag("config", "The user configuration needed to connect with assemblers").File()
 	cli.receiveExpectedNumOfTxs = receive.Flag("expectedTxs", "The expected number of transactions the assembler should received").Default("-1").Int()
 	cli.receiveOutputDir = receive.Flag("output", "The output directory in which to place statistics file").Default(".").String()
 	cli.pullFromPartyId = receive.Flag("pullFromPartyId", "The party id of the assembler to pull blocks from").Int()

--- a/docs/cli/armageddon.md
+++ b/docs/cli/armageddon.md
@@ -97,10 +97,10 @@ Submit txs to routers and verify the submission
 Flags:
   --help                       Show context-sensitive help (also try --help-long
                                and --help-man).
-  --config=CONFIG              The user configuration needed to connection with
+  --config=CONFIG              The user configuration needed to connect with
                                routers and assemblers
   --transactions=TRANSACTIONS  The number of transactions to be sent
-  --rate=RATE                  The rate specify the number of transactions per
+  --rate=RATE                  The rate specifies the number of transactions per
                                second to be sent
   --txSize=512                 The required transaction size in bytes
 ```
@@ -115,7 +115,7 @@ Submit txs to routers and verify the routers have received the txs
 Flags:
   --help                       Show context-sensitive help (also try --help-long
                                and --help-man).
-  --config=CONFIG              The user configuration needed to connection with
+  --config=CONFIG              The user configuration needed to connect with
                                routers
   --transactions=TRANSACTIONS  The number of transactions to be sent
   --rate=RATE                  The rate specifies the number of transactions
@@ -134,7 +134,7 @@ Pull txs from some assembler and report statistics
 Flags:
   --help            Show context-sensitive help (also try --help-long and
                     --help-man).
-  --config=CONFIG   The user configuration needed to connection with assemblers
+  --config=CONFIG   The user configuration needed to connect with assemblers
   --expectedTxs=-1  The expected number of transactions the assembler should
                     received
   --output="."      The output directory in which to place statistics file


### PR DESCRIPTION
﻿Fixes the Armageddon flag description grammar ("needed to connect with..." and "rate specifies...") in the CLI source.
Also updates the generated `docs/cli/armageddon.md` output to keep help docs in sync.
