### PR TITLE
Add chaos test GitHub Actions workflow

### DIFF
--- a/.github/workflows/chaos-test.yml
+++ b/.github/workflows/chaos-test.yml
@@ -1,0 +1,156 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Chaos Test
+
+on:
+  schedule:
+    # Sunday-Thursday: 2-hour chaos test
+    - cron: '0 3 * * 0-4'
+    # Friday: Extended 5.5-hour chaos test
+    - cron: '0 3 * * 5'
+
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: 'Test duration in minutes'
+        required: true
+        default: '120'
+        type: string
+      tx_rate:
+        description: 'Transactions per second'
+        required: true
+        default: '1000'
+        type: string
+      tx_size:
+        description: 'Transaction size in bytes'
+        required: true
+        default: '300'
+        type: string
+      num_parties:
+        description: 'Number of parties (4, 7, or 10)'
+        required: true
+        default: '4'
+        type: choice
+        options:
+          - '4'
+          - '7'
+          - '10'
+      num_shards:
+        description: 'Number of shards (1, 2, or 4)'
+        required: true
+        default: '2'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '4'
+      chaos_enabled:
+        description: 'Enable chaos testing'
+        required: true
+        default: true
+        type: boolean
+      chaos_initial_wait:
+        description: 'Wait before starting chaos (seconds)'
+        required: true
+        default: '300'
+        type: string
+      chaos_stop_duration:
+        description: 'How long to keep component down (seconds)'
+        required: true
+        default: '60'
+        type: string
+      chaos_restart_wait:
+        description: 'Wait after component restart (seconds)'
+        required: true
+        default: '60'
+        type: string
+
+env:
+  GOPATH: /opt/go
+  PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+permissions:
+  contents: read
+
+jobs:
+  chaos-test:
+    name: Chaos Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+
+    steps:
+      - name: Checkout Fabric-X Code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build arma and armageddon binaries
+        run: make binary
+
+      - name: Determine test duration
+        id: duration
+        run: |
+          if [ -n "${{ inputs.duration_minutes }}" ]; then
+            echo "minutes=${{ inputs.duration_minutes }}" >> $GITHUB_OUTPUT
+            echo "Manual trigger: Using ${{ inputs.duration_minutes }} minutes"
+          else
+            DAY_OF_WEEK=$(date -u +%u)
+            if [ "$DAY_OF_WEEK" = "7" ]; then
+              DAY_OF_WEEK=0
+            fi
+
+            if [ "$DAY_OF_WEEK" = "5" ]; then
+              echo "minutes=330" >> $GITHUB_OUTPUT
+              echo "Friday: Using extended duration (330 minutes / 5.5 hours)"
+            else
+              echo "minutes=120" >> $GITHUB_OUTPUT
+              echo "Weekday: Using standard duration (120 minutes / 2 hours)"
+            fi
+          fi
+
+      - name: Run Chaos Test
+        env:
+          DURATION_MINUTES: ${{ steps.duration.outputs.minutes }}
+          TX_RATE: ${{ inputs.tx_rate || '1000' }}
+          TX_SIZE: ${{ inputs.tx_size || '300' }}
+          NUM_PARTIES: ${{ inputs.num_parties || '4' }}
+          NUM_SHARDS: ${{ inputs.num_shards || '2' }}
+          CHAOS_ENABLED: ${{ inputs.chaos_enabled != false }}
+          CHAOS_INITIAL_WAIT: ${{ inputs.chaos_initial_wait || '300' }}
+          CHAOS_STOP_DURATION: ${{ inputs.chaos_stop_duration || '60' }}
+          CHAOS_RESTART_WAIT: ${{ inputs.chaos_restart_wait || '60' }}
+        run: |
+          chmod +x test/chaos/*.sh
+          test/chaos/chaos-test.sh
+
+      - name: Upload test summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-test-summary-${{ github.run_number }}
+          path: test-results/summary/
+          retention-days: 30
+
+      - name: Upload statistics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-test-statistics-${{ github.run_number }}
+          path: test-results/statistics/
+          retention-days: 30
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-test-logs-${{ github.run_number }}
+          path: test-results/logs/
+          retention-days: 30
+          if-no-files-found: ignore

--- a/test/chaos/README.md
+++ b/test/chaos/README.md
@@ -1,0 +1,222 @@
+# Chaos Test
+
+## Overview
+
+This directory contains the scripts used to run the ARMA chaos test.
+
+The test starts a local ARMA network (4 parties, 2 shards by default), sends transactions through the loader, pulls blocks from each party's assembler via receivers, optionally runs a chaos runner that stops and restarts ARMA components one party at a time, monitors progress, and then collects logs, statistics, and a summary.
+
+The same scripts are used by the GitHub Actions workflow and can also be executed locally from the command line on a Linux machine.
+
+## Scripts
+
+```text
+test/chaos/
+├── chaos-test.sh
+├── start-arma-network.sh
+├── chaos-runner.sh
+├── monitor-completion.sh
+├── collect-results.sh
+└── README.md
+```
+
+### `chaos-test.sh`
+
+Main orchestration script.
+
+It reads configuration from environment variables, removes stale log files from previous runs, generates the network config YAML, runs `armageddon generate` to produce all crypto and config files, patches the generated FileStore `Location` and consenter `WALDir` paths to writable temp directories, starts the ARMA network, starts receivers and the loader, optionally starts the chaos runner, runs the monitor, and collects results.
+
+### `start-arma-network.sh`
+
+Starts all ARMA network components in the correct order: consenters first, then batchers, assemblers, and routers. Stores each process PID under the test directory.
+
+### `chaos-runner.sh`
+
+Stops and restarts ARMA components one party at a time in a continuous loop until the stop signal is received.
+
+For each party it kills and restarts: assembler, consenter, router, then all batchers in shard order. After each full party cycle it writes a signal file so `monitor-completion.sh` knows to print a status snapshot.
+
+### `monitor-completion.sh`
+
+Monitors test execution.
+
+- In chaos mode: prints a status snapshot after each party's full chaos cycle completes.
+- Without chaos: prints a status snapshot every 5 minutes.
+- Always: stops when the configured duration is reached or when the loader and all receivers finish early.
+
+After duration expires, stops the loader immediately then gives receivers a 30-second drain window to pull remaining blocks from the assemblers before killing them.
+
+### `collect-results.sh`
+
+Collects test results.
+
+Cleans the `test-results/` directory from any previous run, then extracts loader and receiver statistics, copies all component and loader/receiver logs into `test-results/logs/` and compresses them with gzip, collects receiver statistics CSV files, and creates a summary report.
+
+## Prerequisites
+
+Build the binaries before running the test:
+
+```bash
+make binary
+```
+
+The scripts expect the following binaries to exist:
+
+```text
+./bin/arma
+./bin/armageddon
+```
+
+Run the test from the repository root.
+
+## Running Locally
+
+Execute the test from the repository root.
+
+### Without chaos (basic smoke test)
+
+```bash
+chmod +x test/chaos/*.sh
+
+DURATION_MINUTES=5 \
+TX_RATE=100 \
+TX_SIZE=300 \
+NUM_PARTIES=4 \
+NUM_SHARDS=2 \
+CHAOS_ENABLED=false \
+test/chaos/chaos-test.sh
+```
+
+### With chaos enabled
+
+```bashsame idea
+chmod +x test/chaos/*.sh
+
+DURATION_MINUTES=5 \
+TX_RATE=1000 \
+TX_SIZE=300 \
+NUM_PARTIES=4 \
+NUM_SHARDS=2 \
+CHAOS_ENABLED=true \
+CHAOS_INITIAL_WAIT=120 \
+CHAOS_STOP_DURATION=30 \
+CHAOS_RESTART_WAIT=30 \
+test/chaos/chaos-test.sh
+```
+
+The values can be adjusted as needed for the desired test configuration.
+
+## Configuration
+
+The test is configured using environment variables.
+
+The values shown below are the defaults used by `chaos-test.sh`.
+
+| Variable              | Description                                   | Default |
+| --------------------- | --------------------------------------------- | ------- |
+| `DURATION_MINUTES`    | Test duration in minutes                      | `120`   |
+| `TX_RATE`             | Transactions per second                       | `1000`  |
+| `TX_SIZE`             | Transaction size in bytes                     | `300`   |
+| `NUM_PARTIES`         | Number of parties                             | `4`     |
+| `NUM_SHARDS`          | Number of shards                              | `2`     |
+| `CHAOS_ENABLED`       | Whether to run the chaos runner               | `true`  |
+| `CHAOS_INITIAL_WAIT`  | Wait before first chaos action, in seconds    | `300`   |
+| `CHAOS_STOP_DURATION` | How long to keep a component down, in seconds | `60`    |
+| `CHAOS_RESTART_WAIT`  | Wait after restarting a component, in seconds | `60`    |
+
+## Test Flow
+
+When `chaos-test.sh` runs, it performs the following steps:
+
+1. Reads configuration from environment variables.
+2. Calculates the total number of transactions (`DURATION_MINUTES × 60 × TX_RATE`).
+3. Creates a temporary test directory using `mktemp`.
+4. Generates a network config YAML with ports allocated at `127.0.0.1:8011–8045`.
+5. Runs `./bin/armageddon generate --sampleConfigPath=testutil/fabric/sampleconfig`.
+6. Patches all generated `Location` (FileStore) and `WALDir` (consenter) paths to writable per-component subdirectories under the temp dir.
+7. Removes stale log files from any previous run.
+8. Starts the ARMA network using `start-arma-network.sh`.
+9. Starts one receiver per party (background).
+10. Starts the loader (background).
+11. Starts `chaos-runner.sh` if `CHAOS_ENABLED=true` (background).
+12. Runs `monitor-completion.sh` (blocks until duration expires or all components finish).
+13. Waits briefly for the chaos runner to stop gracefully.
+14. Runs `collect-results.sh`.
+15. Kills any remaining `arma` and `armageddon` processes.
+
+## Receiver Behaviour
+
+Each party runs an independent assembler. Every transaction sent by the loader is committed to **every** party's assembler ledger. Each receiver pulls from its own party's assembler independently. This means each party's receiver is expected to receive the full `TOTAL_TXS` count — not `TOTAL_TXS / NUM_PARTIES`.
+
+The receiver stops pulling when it has received at least `expectedTxs` transactions. Because it processes whole blocks, it may overshoot by the number of transactions in the final block — this is expected and not an error.
+
+## Chaos Behaviour
+
+The chaos runner cycles through all parties in order. For each party it kills and waits `CHAOS_STOP_DURATION` seconds, then restarts:
+
+1. Assembler
+2. Consenter
+3. Router
+4. Batcher shard 1
+5. Batcher shard 2 (and any further shards)
+
+After the restart, it waits `CHAOS_RESTART_WAIT` seconds before moving to the next component. After all components of a party are done, it signals the monitor to print a status snapshot, then moves to the next party.
+
+A full round across all 4 parties with default timings (`STOP_DURATION=60`, `RESTART_WAIT=60`) takes approximately:
+```
+4 parties × (4 components + NUM_SHARDS) × (60 + 60)s ≈ 57 minutes
+```
+
+## Generated Artifacts
+
+During execution, the test creates a temporary directory:
+
+```text
+/tmp/chaos-test-XXXXXX/
+├── config/          # generated armageddon config per party
+├── crypto/          # generated crypto material
+├── bootstrap/       # genesis block and shared config
+├── data/            # per-component writable data directories
+├── output*/         # receiver statistics CSV files per party
+└── pids/            # PID files for all started processes
+```
+
+Result artifacts are written to (cleaned at the start of each run):
+
+```text
+test-results/
+├── logs/            # component and loader/receiver logs
+├── statistics/      # per-party statistics CSV files
+└── summary/         # summary.txt with pass/fail and tx counts
+```
+
+## GitHub Actions Workflow
+
+The workflow is defined at `.github/workflows/chaos-test.yml`.
+
+It runs on a schedule (Sunday–Thursday: 2-hour test, Friday: 5.5-hour test) and can also be triggered manually via `workflow_dispatch`.
+
+Steps:
+1. Checks out the repository.
+2. Installs Go.
+3. Builds binaries with `make binary`.
+4. Determines test duration (schedule-based or from manual input).
+5. Sets configuration via environment variables.
+6. Runs `test/chaos/chaos-test.sh`.
+7. Uploads `test-results/` artifacts (summary, statistics, logs — all as separate CI artifacts).
+
+## Manual Workflow Trigger
+
+The following parameters can be set when triggering manually:
+
+| Parameter             | Description                          | Default |
+| --------------------- | ------------------------------------ | ------- |
+| `duration_minutes`    | Test duration in minutes             | `120`   |
+| `tx_rate`             | Transactions per second              | `1000`  |
+| `tx_size`             | Transaction size in bytes            | `300`   |
+| `num_parties`         | Number of parties (4, 7, or 10)      | `4`     |
+| `num_shards`          | Number of shards (1, 2, or 4)        | `2`     |
+| `chaos_enabled`       | Enable chaos testing                 | `true`  |
+| `chaos_initial_wait`  | Wait before starting chaos (seconds) | `300`   |
+| `chaos_stop_duration` | How long to keep component down (s)  | `60`    |
+| `chaos_restart_wait`  | Wait after component restart (s)     | `60`    |

--- a/test/chaos/chaos-runner.sh
+++ b/test/chaos/chaos-runner.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Chaos runner - stops and starts components in sequential order
+
+TEST_DIR=$1
+NUM_PARTIES=$2
+NUM_SHARDS=$3
+
+# Read timing configuration from environment or use defaults
+INITIAL_WAIT=${CHAOS_INITIAL_WAIT:-300}
+STOP_WAIT=${CHAOS_STOP_DURATION:-60}
+START_WAIT=${CHAOS_RESTART_WAIT:-60}
+
+# Get PID directory and working directory
+PID_DIR="${TEST_DIR}/pids"
+WORK_DIR=$(cat ${PID_DIR}/work_dir.txt 2>/dev/null || pwd)
+
+# Create a stop signal file that monitor-completion.sh will create when done
+STOP_SIGNAL="${TEST_DIR}/chaos_stop_signal"
+
+echo "=========================================="
+echo "Chaos Runner Started"
+echo "=========================================="
+echo "Configuration:"
+echo "  Initial wait: ${INITIAL_WAIT}s"
+echo "  Stop duration: ${STOP_WAIT}s"
+echo "  Restart wait: ${START_WAIT}s"
+echo "  PID directory: ${PID_DIR}"
+echo "  Working directory: ${WORK_DIR}"
+echo "  Stop signal file: ${STOP_SIGNAL}"
+echo "=========================================="
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Waiting ${INITIAL_WAIT}s for network to stabilize..."
+sleep $INITIAL_WAIT
+
+# Function to kill and restart a component
+kill_and_restart() {
+  local component=$1
+  local party=$2
+  local shard=$3  # Optional, only for batchers
+  local config_file=$4
+  local log_file=$5
+  
+  # Determine PID file name
+  local pid_file
+  if [ -n "$shard" ]; then
+    pid_file="${PID_DIR}/${component}${party}-${shard}.pid"
+  else
+    pid_file="${PID_DIR}/${component}${party}.pid"
+  fi
+  
+  # Read PID from file
+  if [ ! -f "$pid_file" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING: ${component} (party ${party}${shard:+ shard ${shard}}) PID file not found: ${pid_file}"
+    return
+  fi
+  
+  local PID=$(cat ${pid_file} 2>/dev/null)
+  
+  # Check if process is still running
+  if [ -z "$PID" ] || ! kill -0 $PID 2>/dev/null; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING: ${component} (party ${party}${shard:+ shard ${shard}}) not running (PID: ${PID:-unknown})"
+    # Try to restart anyway
+  else
+    # Kill the process
+    kill $PID 2>/dev/null
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Stopping ${component} (party ${party}${shard:+ shard ${shard}}) - was PID ${PID}"
+    
+    # Wait for process to die
+    local wait_count=0
+    while kill -0 $PID 2>/dev/null && [ $wait_count -lt 10 ]; do
+      sleep 1
+      wait_count=$((wait_count + 1))
+    done
+    
+    # Force kill if still running
+    if kill -0 $PID 2>/dev/null; then
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] Force killing ${component} (party ${party}${shard:+ shard ${shard}})"
+      kill -9 $PID 2>/dev/null
+    fi
+  fi
+  
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ${component} (party ${party}${shard:+ shard ${shard}}) DOWN — waiting ${STOP_WAIT} seconds"
+  sleep $STOP_WAIT
+  
+  # Restart the component from the correct working directory
+  cd ${WORK_DIR}
+  ${WORK_DIR}/bin/arma ${component} --config=${config_file} >> ${log_file} 2>&1 &
+  local NEW_PID=$!
+  echo ${NEW_PID} > ${pid_file}
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting ${component} (party ${party}${shard:+ shard ${shard}}) - PID ${NEW_PID}"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ${component} (party ${party}${shard:+ shard ${shard}}) UP — waiting ${START_WAIT} seconds"
+  sleep $START_WAIT
+}
+
+# Main chaos loop - run until stop signal is received
+while true; do
+  # Check if we should stop (test completed)
+  if [ -f "${STOP_SIGNAL}" ]; then
+    echo "=========================================="
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Stop signal received - chaos runner exiting"
+    echo "=========================================="
+    break
+  fi
+  
+  for party in $(seq 1 $NUM_PARTIES); do
+    # Check stop signal before each party
+    if [ -f "${STOP_SIGNAL}" ]; then
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] Stop signal received - exiting chaos loop"
+      break 2
+    fi
+    
+    echo "----------------------------------------------------"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] PARTY ${party} — starting chaos sequence"
+    echo "----------------------------------------------------"
+    
+    # 1. Assembler
+    kill_and_restart "assembler" ${party} "" \
+      "${TEST_DIR}/config/party${party}/local_config_assembler.yaml" \
+      "assembler${party}.log"
+    
+    # 2. Consenter
+    kill_and_restart "consensus" ${party} "" \
+      "${TEST_DIR}/config/party${party}/local_config_consenter.yaml" \
+      "consenter${party}.log"
+    
+    # 3. Router
+    kill_and_restart "router" ${party} "" \
+      "${TEST_DIR}/config/party${party}/local_config_router.yaml" \
+      "router${party}.log"
+    
+    # 4. Batchers (in order)
+    for shard in $(seq 1 $NUM_SHARDS); do
+      kill_and_restart "batcher" ${party} ${shard} \
+        "${TEST_DIR}/config/party${party}/local_config_batcher${shard}.yaml" \
+        "batcher${party}-${shard}.log"
+    done
+    
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] PARTY ${party} — chaos sequence DONE"
+    # Signal monitor that party ${party} chaos cycle is complete
+    touch "${TEST_DIR}/chaos_party${party}_done"
+  done
+done
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Chaos runner finished"

--- a/test/chaos/chaos-test.sh
+++ b/test/chaos/chaos-test.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Main chaos test orchestration script
+
+# Exit on error
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Parse inputs from environment variables
+DURATION=${DURATION_MINUTES:-120}
+TX_RATE=${TX_RATE:-1000}
+TX_SIZE=${TX_SIZE:-300}
+NUM_PARTIES=${NUM_PARTIES:-4}
+NUM_SHARDS=${NUM_SHARDS:-2}
+CHAOS_ENABLED=${CHAOS_ENABLED:-true}
+
+# Export variables so child processes (like collect-results.sh) can access them
+export DURATION TX_RATE TX_SIZE NUM_PARTIES NUM_SHARDS CHAOS_ENABLED
+
+# Calculate total transactions
+TOTAL_TXS=$((DURATION * 60 * TX_RATE))
+
+echo "=========================================="
+echo "Chaos Test Configuration"
+echo "=========================================="
+echo "Duration: ${DURATION} minutes"
+echo "TX Rate: ${TX_RATE} tx/s"
+echo "TX Size: ${TX_SIZE} bytes"
+echo "Total TXs: ${TOTAL_TXS}"
+echo "Parties: ${NUM_PARTIES}"
+echo "Shards: ${NUM_SHARDS}"
+echo "Chaos Enabled: ${CHAOS_ENABLED}"
+echo "=========================================="
+
+# Create temp directory for test
+TEST_DIR=$(mktemp -d -t chaos-test-XXXXXX)
+echo "Test directory: ${TEST_DIR}"
+
+# Generate config YAML
+CONFIG_PATH="${TEST_DIR}/config.yaml"
+echo "Generating config at ${CONFIG_PATH}..."
+
+cat > ${CONFIG_PATH} <<EOF
+Parties:
+EOF
+
+# Generate party configurations
+for i in $(seq 1 $NUM_PARTIES); do
+  cat >> ${CONFIG_PATH} <<EOF
+  - ID: $i
+    AssemblerEndpoint: "127.0.0.1:$((8000 + i * 10 + 1))"
+    ConsenterEndpoint: "127.0.0.1:$((8000 + i * 10 + 2))"
+    RouterEndpoint: "127.0.0.1:$((8000 + i * 10 + 3))"
+    BatchersEndpoints:
+EOF
+  for j in $(seq 1 $NUM_SHARDS); do
+    echo "      - \"127.0.0.1:$((8000 + i * 10 + 3 + j))\"" >> ${CONFIG_PATH}
+  done
+done
+
+cat >> ${CONFIG_PATH} <<EOF
+UseTLSRouter: "none"
+UseTLSAssembler: "none"
+EOF
+
+echo "Config generated successfully"
+
+# Generate arma configs using armageddon
+echo "Generating ARMA configurations..."
+./bin/armageddon generate --config=${CONFIG_PATH} --output=${TEST_DIR} --sampleConfigPath=testutil/fabric/sampleconfig
+echo "ARMA configurations generated"
+
+# Create data directory with proper permissions
+DATA_DIR="${TEST_DIR}/data"
+mkdir -p ${DATA_DIR}
+echo "Created data directory: ${DATA_DIR}"
+
+# Fix FileStore Location in all generated config files to use writable temp directory
+# Each component needs its own data directory to avoid LevelDB lock conflicts
+echo "Updating FileStore Location in generated configs..."
+for config_file in ${TEST_DIR}/config/party*/local_config_*.yaml; do
+  if [ -f "$config_file" ]; then
+    # Extract component type and party from filename
+    # e.g., local_config_assembler.yaml → assembler
+    # e.g., local_config_batcher1.yaml → batcher1
+    filename=$(basename "$config_file")
+    component=$(echo "$filename" | sed 's/local_config_//; s/\.yaml//')
+    party=$(echo "$config_file" | grep -oP 'party\K[0-9]+')
+
+    # Create unique data path for this component
+    component_data="${DATA_DIR}/${component}_party${party}"
+    mkdir -p "$component_data"
+
+    # Replace the Location line under FileStore section
+    sed -i "s|Location: /var/dec-trust.*|Location: ${component_data}|g" "$config_file"
+    # Replace the WALDir line under ConsensusParams (consenter only, no-op on others)
+    sed -i "s|WALDir: /var/dec-trust.*|WALDir: ${component_data}/wal|g" "$config_file"
+    echo "  Updated: $config_file → $component_data"
+  fi
+done
+echo "FileStore Location updated in all configs (each component has its own data)"
+
+# Remove log files from any previous run so the monitor does not read stale data
+echo "Cleaning up log files from previous runs..."
+rm -f loader.log
+for i in $(seq 1 $NUM_PARTIES); do
+  rm -f receiver${i}.log
+done
+for i in $(seq 1 $NUM_PARTIES); do
+  rm -f consenter${i}.log assembler${i}.log router${i}.log
+  for j in $(seq 1 $NUM_SHARDS); do
+    rm -f batcher${i}-${j}.log
+  done
+done
+echo "Log files cleaned up"
+
+# Start ARMA network
+echo "Starting ARMA network..."
+"${SCRIPT_DIR}/start-arma-network.sh" "${TEST_DIR}" "${NUM_PARTIES}" "${NUM_SHARDS}"
+
+# Create output directories for receivers
+echo "Creating output directories for receivers..."
+for i in $(seq 1 $NUM_PARTIES); do
+  mkdir -p ${TEST_DIR}/output${i}
+  echo "  Created: ${TEST_DIR}/output${i}"
+done
+
+# Start receivers (background)
+echo "Starting receivers..."
+for i in $(seq 1 $NUM_PARTIES); do
+  ./bin/armageddon receive \
+    --config=${TEST_DIR}/config/party${i}/user_config.yaml \
+    --pullFromPartyId=${i} \
+    --expectedTxs=${TOTAL_TXS} \
+    --output=${TEST_DIR}/output${i} \
+    >> receiver${i}.log 2>&1 &
+  echo "Started receiver for party ${i} (PID: $!)"
+done
+
+# Start loader (background)
+echo "Starting loader..."
+./bin/armageddon load \
+  --config=${TEST_DIR}/config/party1/user_config.yaml \
+  --transactions=${TOTAL_TXS} \
+  --rate=${TX_RATE} \
+  --txSize=${TX_SIZE} \
+  >> loader.log 2>&1 &
+LOADER_PID=$!
+echo "Started loader (PID: ${LOADER_PID})"
+
+# Start chaos runner (if enabled)
+if [ "$CHAOS_ENABLED" = "true" ]; then
+  echo "Starting chaos runner..."
+  # Write marker so monitor-completion.sh knows chaos mode is active
+  touch "${TEST_DIR}/chaos_enabled"
+  "${SCRIPT_DIR}/chaos-runner.sh" "${TEST_DIR}" "${NUM_PARTIES}" "${NUM_SHARDS}" &
+  CHAOS_PID=$!
+  echo "Started chaos runner (PID: ${CHAOS_PID})"
+fi
+
+# Monitor completion (with duration timeout)
+echo "Monitoring test completion..."
+"${SCRIPT_DIR}/monitor-completion.sh" "${NUM_PARTIES}" "${TOTAL_TXS}" "${TEST_DIR}" "${DURATION}"
+
+# Wait a bit for chaos runner to see the stop signal and exit gracefully
+if [ "$CHAOS_ENABLED" = "true" ] && [ -n "$CHAOS_PID" ]; then
+  echo "Waiting for chaos runner to stop gracefully..."
+  sleep 5
+
+  # Check if it's still running and force kill if needed
+  if kill -0 ${CHAOS_PID} 2>/dev/null; then
+    echo "Force stopping chaos runner..."
+    kill ${CHAOS_PID} 2>/dev/null || true
+  else
+    echo "Chaos runner stopped gracefully"
+  fi
+fi
+
+# Collect results
+echo "Collecting results..."
+"${SCRIPT_DIR}/collect-results.sh" "${TEST_DIR}" "${NUM_PARTIES}" "${DURATION}"
+
+# Cleanup processes
+echo "Cleaning up processes..."
+pkill -f "arma " || true
+pkill -f "armageddon" || true
+
+echo "=========================================="
+echo "✅ Chaos test completed successfully!"
+echo "=========================================="

--- a/test/chaos/collect-results.sh
+++ b/test/chaos/collect-results.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Collect test results and create summary
+
+TEST_DIR=$1
+NUM_PARTIES=$2
+DURATION=$3
+
+echo "=========================================="
+echo "Collecting Results"
+echo "=========================================="
+
+# Clean and recreate results directories so previous run artifacts never mix in
+rm -rf test-results
+mkdir -p test-results/logs
+mkdir -p test-results/statistics
+mkdir -p test-results/summary
+
+# Extract statistics BEFORE compressing/moving logs
+echo "Extracting statistics from logs..."
+
+# Extract loader statistics
+if grep -q "Load command finished" loader.log 2>/dev/null; then
+  SENT=$(grep "Load command finished" loader.log 2>/dev/null | tail -1 | grep -oP 'sent \K[0-9]+')
+  LOADER_STATUS="completed"
+else
+  SENT=$(grep -o "Sent [0-9]* transactions" loader.log 2>/dev/null | tail -1 | awk '{print $2}')
+  LOADER_STATUS="timeout"
+fi
+
+# Extract receiver statistics
+declare -a RECEIVER_STATS
+declare -a RECEIVER_STATUS
+for i in $(seq 1 $NUM_PARTIES); do
+  if grep -q "Receive command finished" receiver${i}.log 2>/dev/null; then
+    # Extract from "1800000 txs were expected and overall 1800186 were successfully received" example from the log
+    RECEIVED=$(grep "were successfully received" receiver${i}.log 2>/dev/null | tail -1 | grep -oP 'overall \K\d+(?= were successfully received)')
+    RECEIVER_STATS[$i]="${RECEIVED:-unknown}"
+    RECEIVER_STATUS[$i]="completed"
+  else
+    # For stopped receivers, check the statistics CSV file
+    if [ -f "${TEST_DIR}/output${i}/statistics.csv" ]; then
+      BLOCKS=$(tail -n +2 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | wc -l)
+      RECEIVED=$(tail -n +2 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | awk -F',' '{sum+=$3} END {print sum}')
+      RECEIVER_STATS[$i]="${RECEIVED:-0}"
+      RECEIVER_STATUS[$i]="timeout"
+    else
+      RECEIVER_STATS[$i]="0"
+      RECEIVER_STATUS[$i]="no_data"
+    fi
+  fi
+done
+
+echo "  Loader: ${SENT:-0} txs (${LOADER_STATUS})"
+for i in $(seq 1 $NUM_PARTIES); do
+  echo "  Party ${i}: ${RECEIVER_STATS[$i]} txs (${RECEIVER_STATUS[$i]})"
+done
+
+# Collect all logs — always, regardless of duration — and gzip them
+echo "Collecting and compressing logs..."
+cp consenter*.log test-results/logs/ 2>/dev/null || true
+cp batcher*.log test-results/logs/ 2>/dev/null || true
+cp assembler*.log test-results/logs/ 2>/dev/null || true
+cp router*.log test-results/logs/ 2>/dev/null || true
+cp loader.log test-results/logs/ 2>/dev/null || true
+cp receiver*.log test-results/logs/ 2>/dev/null || true
+gzip test-results/logs/*.log 2>/dev/null || true
+echo "  All logs collected and compressed"
+
+# Collect statistics from receivers
+echo "Collecting statistics..."
+for i in $(seq 1 $NUM_PARTIES); do
+  if [ -f "${TEST_DIR}/output${i}/statistics.csv" ]; then
+    cp "${TEST_DIR}/output${i}/statistics.csv" test-results/statistics/party${i}_statistics.csv
+    echo "  Collected statistics for party ${i}"
+  fi
+done
+
+# Create summary report
+echo "Creating summary report..."
+cat > test-results/summary/summary.txt <<EOF
+========================================
+Chaos Test Summary
+========================================
+Date: $(date)
+Duration: ${DURATION} minutes
+TX Rate: ${TX_RATE} tx/s
+TX Size: ${TX_SIZE} bytes
+Total TXs Expected: $((DURATION * 60 * TX_RATE))
+Parties: ${NUM_PARTIES}
+Shards: ${NUM_SHARDS}
+Chaos Enabled: ${CHAOS_ENABLED}
+
+========================================
+Loader Results
+========================================
+EOF
+
+# Use pre-extracted statistics
+if [ "$LOADER_STATUS" = "completed" ]; then
+  echo "✅ Loader completed" >> test-results/summary/summary.txt
+  echo "Sent: ${SENT:-unknown} transactions" >> test-results/summary/summary.txt
+else
+  echo "⏰ Loader stopped by timeout" >> test-results/summary/summary.txt
+  echo "Sent: ${SENT:-0} transactions (incomplete)" >> test-results/summary/summary.txt
+fi
+
+cat >> test-results/summary/summary.txt <<EOF
+
+========================================
+Receiver Results
+========================================
+EOF
+
+# Use pre-extracted receiver statistics
+TOTAL_RECEIVED=0
+for i in $(seq 1 $NUM_PARTIES); do
+  echo "Party ${i}:" >> test-results/summary/summary.txt
+  
+  RECEIVED="${RECEIVER_STATS[$i]}"
+  STATUS="${RECEIVER_STATUS[$i]}"
+  
+  if [ "$STATUS" = "completed" ]; then
+    echo "  ✅ Completed - Received: ${RECEIVED} txs" >> test-results/summary/summary.txt
+    if [ -n "$RECEIVED" ] && [ "$RECEIVED" != "unknown" ] && [ "$RECEIVED" -gt 0 ] 2>/dev/null; then
+      TOTAL_RECEIVED=$((TOTAL_RECEIVED + RECEIVED))
+    fi
+  elif [ "$STATUS" = "timeout" ]; then
+    # Get block count from CSV
+    if [ -f "${TEST_DIR}/output${i}/statistics.csv" ]; then
+      BLOCKS=$(tail -n +2 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | wc -l)
+      echo "  ⏰ Stopped by timeout - Received: ${RECEIVED} txs in ${BLOCKS} blocks" >> test-results/summary/summary.txt
+    else
+      echo "  ⏰ Stopped by timeout - Received: ${RECEIVED} txs" >> test-results/summary/summary.txt
+    fi
+    if [ -n "$RECEIVED" ] && [ "$RECEIVED" -gt 0 ] 2>/dev/null; then
+      TOTAL_RECEIVED=$((TOTAL_RECEIVED + RECEIVED))
+    fi
+  else
+    echo "  ❌ No statistics available" >> test-results/summary/summary.txt
+  fi
+done
+
+# Overall statistics: each party independently receives all sent txs, so the
+# meaningful metric is per-party success rate, not a cross-party sum.
+PARTY_SUCCESS_RATE=0
+if [ -n "$SENT" ] && [ "$SENT" -gt 0 ]; then
+  # Use the first completed/timeout party as representative received count
+  REPRESENTATIVE_RECEIVED=${RECEIVER_STATS[1]:-0}
+  if [ -n "$REPRESENTATIVE_RECEIVED" ] && [ "$REPRESENTATIVE_RECEIVED" -gt 0 ] 2>/dev/null; then
+    PARTY_SUCCESS_RATE=$((REPRESENTATIVE_RECEIVED * 100 / SENT))
+  fi
+fi
+
+cat >> test-results/summary/summary.txt <<EOF
+
+========================================
+Overall Statistics
+========================================
+Sent: ${SENT:-0} transactions
+Expected per party: ${SENT:-0} transactions
+Received per party: ${REPRESENTATIVE_RECEIVED:-0} transactions
+Success Rate: ${PARTY_SUCCESS_RATE}%
+EOF
+
+# Create a simple pass/fail indicator
+echo "" >> test-results/summary/summary.txt
+echo "========================================" >> test-results/summary/summary.txt
+echo "Test Status" >> test-results/summary/summary.txt
+echo "========================================" >> test-results/summary/summary.txt
+
+if [ -n "$SENT" ] && [ "$SENT" -gt 0 ] && [ "${REPRESENTATIVE_RECEIVED:-0}" -gt 0 ] 2>/dev/null; then
+  echo "✅ PASSED - Test ran for ${DURATION} minutes" >> test-results/summary/summary.txt
+  echo "   Sent: ${SENT} txs, each party received: ${REPRESENTATIVE_RECEIVED} txs (${PARTY_SUCCESS_RATE}%)" >> test-results/summary/summary.txt
+else
+  echo "❌ FAILED - No transactions processed" >> test-results/summary/summary.txt
+fi
+
+echo "=========================================="
+echo "✅ Results collected in test-results/"
+echo "=========================================="
+
+# Display summary
+cat test-results/summary/summary.txt

--- a/test/chaos/monitor-completion.sh
+++ b/test/chaos/monitor-completion.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Monitor test completion - wait for duration timeout OR all components finish
+
+NUM_PARTIES=$1
+TOTAL_TXS=$2
+TEST_DIR=$3
+DURATION_MINUTES=$4
+
+# Calculate end time
+START_TIME=$(date +%s)
+END_TIME=$((START_TIME + DURATION_MINUTES * 60))
+
+echo "=========================================="
+echo "Monitoring Test Completion"
+echo "=========================================="
+echo "Test will run for ${DURATION_MINUTES} minutes"
+echo "Expected TXs: ${TOTAL_TXS}"
+echo "Start time: $(date -d @${START_TIME} '+%Y-%m-%d %H:%M:%S')"
+echo "End time: $(date -d @${END_TIME} '+%Y-%m-%d %H:%M:%S')"
+echo "=========================================="
+
+# Function to check if time limit reached
+time_limit_reached() {
+  CURRENT_TIME=$(date +%s)
+  [ $CURRENT_TIME -ge $END_TIME ]
+}
+
+# Function to get current stats
+get_current_stats() {
+  echo ""
+  echo "=========================================="
+  echo "Current Status at $(date '+%Y-%m-%d %H:%M:%S')"
+  echo "=========================================="
+  
+  # Check loader
+  # Actual log line: "Load command finished, sent N TXs in ..."
+  if grep -q "Load command finished" loader.log 2>/dev/null; then
+    SENT=$(grep "Load command finished" loader.log 2>/dev/null | tail -1 | grep -oP 'sent \K[0-9]+')
+    echo "Loader: ✅ Completed - Sent ${SENT:-unknown} txs total"
+  else
+    # Sum all per-10s Report lines per router to get exact cumulative sent count per router.
+    # Actual log line: "BroadcastClient to Router 127.0.0.1:XXXX sent N transactions in the last 10s"
+    echo "Loader: 🔄 Running"
+    for i in $(seq 1 $NUM_PARTIES); do
+      SENT_ROUTER=$(grep "BroadcastClientToRouter${i}.*Report" loader.log 2>/dev/null \
+        | grep -oP 'sent \K[0-9]+(?= transactions in the last)' \
+        | awk '{sum+=$1} END {print sum}')
+      echo "  → Router ${i}: ${SENT_ROUTER:-0} txs sent so far"
+    done
+  fi
+  
+  # Check receivers
+  for i in $(seq 1 $NUM_PARTIES); do
+    if grep -q "Receive command finished" receiver${i}.log 2>/dev/null; then
+      # Actual log line: "N txs were expected and overall N were successfully received"
+      RECEIVED=$(grep "were successfully received" receiver${i}.log 2>/dev/null | tail -1 | grep -oP 'overall \K[0-9]+')
+      echo "Party ${i}: ✅ Completed - Received ${RECEIVED:-unknown} txs"
+    else
+      # For running receivers, read cumulative txs from CSV (column 2 = num txs, column 3 = num blocks)
+      if [ -f "${TEST_DIR}/output${i}/statistics.csv" ]; then
+        RECEIVED=$(tail -n +3 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | awk -F',' '{sum+=$2} END {print sum}')
+        echo "Party ${i}: 🔄 Running - Received ${RECEIVED:-0} txs so far"
+      else
+        echo "Party ${i}: 🔄 Running - Received 0 txs so far"
+      fi
+    fi
+  done
+  
+  CURRENT_TIME=$(date +%s)
+  ELAPSED=$((CURRENT_TIME - START_TIME))
+  if [ $CURRENT_TIME -ge $END_TIME ]; then
+     REMAINING=0
+   else
+     REMAINING=$((END_TIME - CURRENT_TIME))
+   fi
+  echo ""
+  echo "Time elapsed: $((ELAPSED / 60)) minutes"
+  echo "Time remaining: $((REMAINING / 60)) minutes"
+  echo "=========================================="
+}
+
+# Determine if chaos mode is active by checking for the chaos stop signal path
+# (chaos-runner.sh is only started when CHAOS_ENABLED=true, and it creates party done files)
+CHAOS_MODE=false
+# We detect chaos mode by checking if the chaos runner is running (its stop signal file
+# path exists means chaos was enabled - we use a marker written by chaos-test.sh)
+if [ -f "${TEST_DIR}/chaos_enabled" ]; then
+  CHAOS_MODE=true
+fi
+
+# Monitor with timeout
+echo "Monitoring test progress..."
+LAST_STATS_TIME=$START_TIME
+# Track which party cycles we have already printed stats for
+LAST_CHAOS_PARTY=0
+
+while true; do
+  CURRENT_TIME=$(date +%s)
+
+  # Check if duration reached
+  if time_limit_reached; then
+    echo ""
+    echo "=========================================="
+    echo "⏰ Duration limit reached (${DURATION_MINUTES} minutes)"
+    echo "=========================================="
+    get_current_stats
+    break
+  fi
+
+  # Check if all completed early
+  LOADER_DONE=false
+  ALL_RECEIVERS_DONE=true
+
+  if grep -q "Load command finished" loader.log 2>/dev/null; then
+    LOADER_DONE=true
+  fi
+
+  for i in $(seq 1 $NUM_PARTIES); do
+    if ! grep -q "Receive command finished" receiver${i}.log 2>/dev/null; then
+      ALL_RECEIVERS_DONE=false
+      break
+    fi
+  done
+
+  if [ "$LOADER_DONE" = "true" ] && [ "$ALL_RECEIVERS_DONE" = "true" ]; then
+    echo ""
+    echo "=========================================="
+    echo "✅ All components completed before timeout!"
+    echo "=========================================="
+    get_current_stats
+    break
+  fi
+
+  if [ "$CHAOS_MODE" = "true" ]; then
+    # In chaos mode: print stats after each party's full chaos cycle completes
+    for party in $(seq 1 $NUM_PARTIES); do
+      SIGNAL_FILE="${TEST_DIR}/chaos_party${party}_done"
+      if [ -f "$SIGNAL_FILE" ]; then
+        echo ""
+        echo "=========================================="
+        echo "🔥 Party ${party} chaos cycle complete"
+        echo "=========================================="
+        get_current_stats
+        rm -f "$SIGNAL_FILE"
+      fi
+    done
+  else
+    # No chaos: print stats every 5 minutes
+    if [ $((CURRENT_TIME - LAST_STATS_TIME)) -ge 300 ]; then
+      get_current_stats
+      LAST_STATS_TIME=$CURRENT_TIME
+    fi
+  fi
+
+  sleep 5
+done
+
+# Final statistics
+echo ""
+echo "=========================================="
+echo "Final Test Statistics"
+echo "=========================================="
+
+# Loader final stats
+if grep -q "Load command finished" loader.log 2>/dev/null; then
+  SENT=$(grep "Load command finished" loader.log 2>/dev/null | tail -1 | grep -oP 'sent \K[0-9]+')
+  echo "Total Sent: ${SENT:-unknown} transactions"
+else
+  SENT=$(grep -oP 'sent \K[0-9]+(?= transactions in the last)' loader.log 2>/dev/null | tail -1)
+  echo "Total Sent: ${SENT:-0} transactions (incomplete)"
+fi
+
+echo ""
+echo "Received per party:"
+for i in $(seq 1 $NUM_PARTIES); do
+  if grep -q "Receive command finished" receiver${i}.log 2>/dev/null; then
+    RECEIVED=$(grep "were successfully received" receiver${i}.log 2>/dev/null | tail -1 | grep -oP 'overall \K[0-9]+')
+    echo "  Party ${i}: ${RECEIVED:-unknown} txs"
+  else
+    RECEIVED=$(tail -n +3 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | awk -F',' '{sum+=$2} END {print sum}')
+    echo "  Party ${i}: ${RECEIVED:-0} txs (incomplete)"
+  fi
+done
+
+echo "=========================================="
+
+# Signal chaos runner and other processes to stop
+if [ -n "$TEST_DIR" ]; then
+  STOP_SIGNAL="${TEST_DIR}/chaos_stop_signal"
+  touch "${STOP_SIGNAL}"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Created stop signal: ${STOP_SIGNAL}"
+fi
+
+# Stop loader first - no more txs should be sent
+pkill -f "armageddon load" || true
+
+# Give receivers a drain window to pull remaining blocks from assemblers
+# before killing them. 30s is enough for the assembler backlog to clear.
+echo "Waiting 30s for receivers to drain remaining blocks..."
+DRAIN_DEADLINE=$(( $(date +%s) + 30 ))
+ALL_DONE=false
+while [ $(date +%s) -lt $DRAIN_DEADLINE ]; do
+  ALL_DONE=true
+  for i in $(seq 1 $NUM_PARTIES); do
+    if ! grep -q "Receive command finished" receiver${i}.log 2>/dev/null; then
+      ALL_DONE=false
+      break
+    fi
+  done
+  if [ "$ALL_DONE" = "true" ]; then
+    echo "All receivers finished draining"
+    break
+  fi
+  sleep 2
+done
+
+if [ "$ALL_DONE" = "false" ]; then
+  echo "Drain window elapsed, stopping receivers"
+fi
+pkill -f "armageddon receive" || true
+
+echo "=========================================="
+echo "✅ Monitoring completed"
+echo "=========================================="

--- a/test/chaos/start-arma-network.sh
+++ b/test/chaos/start-arma-network.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start all ARMA network components
+
+TEST_DIR=$1
+NUM_PARTIES=$2
+NUM_SHARDS=$3
+
+echo "=========================================="
+echo "Starting ARMA Network"
+echo "=========================================="
+echo "Parties: ${NUM_PARTIES}"
+echo "Shards: ${NUM_SHARDS}"
+echo "=========================================="
+
+# Create PID directory
+PID_DIR="${TEST_DIR}/pids"
+mkdir -p ${PID_DIR}
+echo "PID directory: ${PID_DIR}"
+
+# Save current working directory for later use
+WORK_DIR=$(pwd)
+echo "${WORK_DIR}" > ${PID_DIR}/work_dir.txt
+echo "Working directory: ${WORK_DIR}"
+
+# Start consenters first
+echo "Starting consenters..."
+for i in $(seq 1 $NUM_PARTIES); do
+  ./bin/arma consensus \
+    --config=${TEST_DIR}/config/party${i}/local_config_consenter.yaml \
+    >> consenter${i}.log 2>&1 &
+  PID=$!
+  echo ${PID} > ${PID_DIR}/consensus${i}.pid
+  echo "  Started consenter ${i} (PID: ${PID})"
+done
+
+# Wait for consenters to initialize
+echo "Waiting 5 seconds for consenters to initialize..."
+sleep 5
+
+# Start batchers
+echo "Starting batchers..."
+for i in $(seq 1 $NUM_PARTIES); do
+  for j in $(seq 1 $NUM_SHARDS); do
+    ./bin/arma batcher \
+      --config=${TEST_DIR}/config/party${i}/local_config_batcher${j}.yaml \
+      >> batcher${i}-${j}.log 2>&1 &
+    PID=$!
+    echo ${PID} > ${PID_DIR}/batcher${i}-${j}.pid
+    echo "  Started batcher ${i}-${j} (PID: ${PID})"
+  done
+done
+
+# Start assemblers
+echo "Starting assemblers..."
+for i in $(seq 1 $NUM_PARTIES); do
+  ./bin/arma assembler \
+    --config=${TEST_DIR}/config/party${i}/local_config_assembler.yaml \
+    >> assembler${i}.log 2>&1 &
+  PID=$!
+  echo ${PID} > ${PID_DIR}/assembler${i}.pid
+  echo "  Started assembler ${i} (PID: ${PID})"
+done
+
+# Start routers
+echo "Starting routers..."
+for i in $(seq 1 $NUM_PARTIES); do
+  ./bin/arma router \
+    --config=${TEST_DIR}/config/party${i}/local_config_router.yaml \
+    >> router${i}.log 2>&1 &
+  PID=$!
+  echo ${PID} > ${PID_DIR}/router${i}.pid
+  echo "  Started router ${i} (PID: ${PID})"
+done
+
+# Wait for network to stabilize
+echo "Waiting 10 seconds for network to stabilize..."
+sleep 10
+
+echo "=========================================="
+echo "✅ ARMA network started successfully"
+echo "=========================================="


### PR DESCRIPTION
#925 

This commit adds automated chaos testing infrastructure for ARMA:

- Daily scheduled runs at 6 AM Israel time (03:00 UTC) from Sun till Thu, only on Fri the test is longer
- Configurable test parameters (duration, rate, parties, shards)
- Sequential chaos pattern (stop/start components in order)
- Automatic result collection and artifact upload
- Support for both short and long-running tests

The workflow runs all ARMA components as separate processes on a single GitHub-hosted runner, with chaos testing that sequentially stops and restarts components to test system resilience.

Files added:
- .github/workflows/chaos-test.yml: Main workflow definition
- .github/workflows/chaosRunner/chaos-test.sh: Orchestration script
- .github/workflows/chaosRunner/start-arma-network.sh: Network startup
- .github/workflows/chaosRunner/chaos-runner.sh: Chaos implementation
- .github/workflows/chaosRunner/monitor-completion.sh: Test monitoring
- .github/workflows/chaosRunner/collect-results.sh: Result collection