### PR TITLE
Test mTLS from application client

### DIFF
--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -381,6 +381,31 @@ func generateConfigAndCrypto(genConfigFile **os.File, outputDir *string, sampleC
 			os.Exit(-1)
 		}
 	}
+
+	// generate user config yaml file for peers
+	for _, peer := range profile.Application.Organizations {
+		userTLSPrivateKeyPath := filepath.Join(*outputDir, "crypto", "peerOrganizations", peer.Name, "users", fmt.Sprintf("client@%s", peer.Name), "tls", "client.key")
+		userTLSCertPath := filepath.Join(*outputDir, "crypto", "peerOrganizations", peer.Name, "users", fmt.Sprintf("client@%s", peer.Name), "tls", "client.crt")
+
+		userMSPDir := filepath.Join(*outputDir, "crypto", "peerOrganizations", peer.Name, "users", fmt.Sprintf("client@%s", peer.Name), "msp")
+		userConfig, err := NewUserConfig(userMSPDir, userTLSPrivateKeyPath, userTLSCertPath, tlsCACertsBytesPartiesCollection, networkConfig)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating user config: %s", err)
+			os.Exit(-1)
+		}
+
+		peerConfigDir := filepath.Join(*outputDir, "config", peer.Name)
+		if err := os.MkdirAll(peerConfigDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating peer config dir: %s", err)
+			os.Exit(-1)
+		}
+
+		err = utils.WriteToYAML(userConfig, filepath.Join(peerConfigDir, "user_config.yaml"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating user config yaml: %s", err)
+			os.Exit(-1)
+		}
+	}
 }
 
 func getConfigFileContent(genConfigFile **os.File) (*genconfig.Network, error) {

--- a/common/tools/armageddon/armageddon_test.go
+++ b/common/tools/armageddon/armageddon_test.go
@@ -667,6 +667,10 @@ func checkConfigDir(outputDir string) error {
 			return fmt.Errorf("error reading party dir, party %s does not describe a directory\n", party.Name())
 		}
 
+		if !strings.HasPrefix(party.Name(), "party") {
+			continue
+		}
+
 		partyDir := filepath.Join(configPath, party.Name())
 
 		for _, file := range requiredPartyFiles {

--- a/test/basic/router_basic_test.go
+++ b/test/basic/router_basic_test.go
@@ -393,3 +393,96 @@ func TestMTLSFromClientNotSpecifiedInLocalConfig(t *testing.T) {
 		Signer:     pullRequestSigner,
 	})
 }
+
+// TestMTLSFromApplicationClient tests that a router and assembler configured to use mTLS correctly accepts transactions
+// and delivery requests from a client whose certificate is specified in application local configuration.
+func TestMTLSFromApplicationClient(t *testing.T) {
+	// compile arma
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	t.Cleanup(func() {
+		gexec.CleanupBuildArtifacts()
+	})
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	// Number of parties in the test
+	numOfParties := 1
+	numOfShards := 1
+
+	t.Logf("Running test with %d parties and %d shards", numOfParties, numOfShards)
+
+	// create a temporary directory for the test.
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	// create a config YAML file in the temporary directory.
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, numOfParties, numOfShards, "mTLS", "mTLS")
+	t.Cleanup(func() {
+		netInfo.CleanUp()
+	})
+
+	numOfArmaNodes := len(netInfo)
+
+	// generate the config files in the temporary directory using the armageddon generate command.
+	armageddon.NewCLI().Run([]string{"generate", "--config", configPath, "--output", dir})
+
+	// run the arma nodes.
+	// NOTE: if one of the nodes is not started within 10 seconds, there is no point in continuing the test, so fail it
+	readyChan := make(chan string, numOfArmaNodes)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	t.Cleanup(func() {
+		armaNetwork.Stop()
+	})
+
+	testutil.WaitReady(t, readyChan, numOfArmaNodes, 10)
+
+	f, err := os.Open(filepath.Join(dir, "config", "peer1", "user_config.yaml"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = f.Close()
+	})
+	uc, err := armageddon.ReadUserConfig(&f)
+	require.NoError(t, err)
+
+	// Send transactions to the routers.
+	totalTxNumber := 10
+	// rate limiter parameters
+	fillInterval := 10 * time.Millisecond
+	fillFrequency := 1000 / int(fillInterval.Milliseconds())
+	rate := 500
+
+	capacity := rate / fillFrequency
+	rl, err := armageddon.NewRateLimiter(rate, fillInterval, capacity)
+	require.NoError(t, err)
+
+	broadcastClient := client.NewBroadcastTxClient(uc, 10*time.Second)
+	t.Cleanup(func() {
+		broadcastClient.Stop()
+	})
+
+	for i := range totalTxNumber {
+		status := rl.GetToken()
+		require.True(t, status, "failed to send tx %d", i+1)
+		txContent := tx.PrepareTxWithTimestamp(i, 64, []byte("sessionNumber"))
+		env := tx.CreateStructuredEnvelope(txContent)
+		err = broadcastClient.SendTx(env)
+		require.NoError(t, err)
+	}
+
+	pullRequestSigner, err := signutil.CreateSignerForUser(uc.MSPDir)
+	require.NoError(t, err)
+	test_utils.PullFromAssemblers(t, &test_utils.BlockPullerOptions{
+		UserConfig:       uc,
+		Parties:          []types.PartyID{types.PartyID(1)},
+		StartBlock:       0,
+		EndBlock:         math.MaxUint64,
+		Transactions:     totalTxNumber,
+		NeedVerification: true,
+		ErrString:        "cancelled pull from assembler: %d",
+		Signer:           pullRequestSigner,
+	})
+}

--- a/testutil/signutil/signer.go
+++ b/testutil/signutil/signer.go
@@ -116,10 +116,11 @@ func LoadCryptoMaterialForSigner(mspDir string) (*crypto.ECDSASigner, []byte, er
 }
 
 func GetMspIDfromDir(mspDir string) (string, error) {
-	re := regexp.MustCompile(`/ordererOrganizations/([^/]+)/`)
+	mspDir = filepath.ToSlash(mspDir)
+	re := regexp.MustCompile(`/(orderer|peer)Organizations/([^/]+)(/|$)`)
 	matches := re.FindStringSubmatch(mspDir)
-	if matches == nil || len(matches) > 2 {
+	if len(matches) < 4 {
 		return "", fmt.Errorf("failed to extract mspID from path: %s", mspDir)
 	}
-	return matches[1], nil
+	return matches[2], nil
 }


### PR DESCRIPTION
issue #548 
Test that we can submit TXs and pull blocks when the client (broadcast / delivery, resp) has a TLS and signing certificate from a CA(s) that belong to an application org (NOT orderer org).