### PR TITLE
badb: fail-stop on LevelDB errors in Exists and Clean

### DIFF
--- a/node/consensus/badb/badb.go
+++ b/node/consensus/badb/badb.go
@@ -103,6 +103,13 @@ func (db *BatchAttestationDB) Clean(epochToDelete uint64) {
 		batch.Delete(epochKey)
 	}
 
+	// Next stops returning pairs on error; the error is retrieved via Error().
+	// Without this check Clean could write a partial/empty delete batch and
+	// mask an underlying corruption/IO fault.
+	if err := iter.Error(); err != nil {
+		db.logger.Panicf("Failed iterating over database: %v", err)
+	}
+
 	if err := db.db.Write(batch, nil); err != nil {
 		db.logger.Panicf("Failed updating database: %v", err)
 	}

--- a/node/consensus/badb/badb.go
+++ b/node/consensus/badb/badb.go
@@ -51,7 +51,22 @@ func (db *BatchAttestationDB) List() ([][]byte, []uint64) {
 
 func (db *BatchAttestationDB) Exists(digest []byte) bool {
 	_, err := db.db.Get(makeDigestKey(digest), nil)
-	return err == nil
+	switch err {
+	case nil:
+		return true
+	case leveldb.ErrNotFound:
+		return false
+	case leveldb.ErrClosed:
+		// The DB may be closed while the consenter is soft-stopping (the BFT
+		// engine can still drive Exists via SimulateStateTransition). Treat a
+		// closed DB as "digest absent" rather than fail-stopping.
+		return false
+	default:
+		// A corruption/IO error must not be silently reported as absence; match
+		// Put's fail-stop behavior.
+		db.logger.Panicf("Failed reading from database: %v", err)
+		return false
+	}
 }
 
 func (db *BatchAttestationDB) Put(digest [][]byte, epoch []uint64) {
@@ -88,7 +103,9 @@ func (db *BatchAttestationDB) Clean(epochToDelete uint64) {
 		batch.Delete(epochKey)
 	}
 
-	db.db.Write(batch, nil)
+	if err := db.db.Write(batch, nil); err != nil {
+		db.logger.Panicf("Failed updating database: %v", err)
+	}
 }
 
 func makeDigestKey(digest []byte) []byte {

--- a/node/consensus/badb/badb_test.go
+++ b/node/consensus/badb/badb_test.go
@@ -8,11 +8,18 @@ package badb
 
 import (
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 func TestBatchAttestationDB(t *testing.T) {
@@ -59,4 +66,104 @@ func TestBatchAttestationDB(t *testing.T) {
 	db.Close()
 	_, err = db.db.Get(makeDigestKey(digests[2]), nil)
 	assert.Error(t, err)
+}
+
+// TestExistsNotFound verifies that Exists returns false (and does not panic)
+// for a digest that was never stored, i.e. leveldb.ErrNotFound is treated as absence.
+func TestExistsNotFound(t *testing.T) {
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	logger := testutil.CreateLogger(t, 0)
+	db, err := NewBatchAttestationDB(dir, logger)
+	require.NoError(t, err)
+	defer db.Close()
+
+	assert.False(t, db.Exists([]byte{9, 9, 9}))
+}
+
+// TestExistsAfterClose verifies that Exists treats leveldb.ErrClosed as benign
+// and returns false. The consenter's SoftStop path closes the BADB while the
+// BFT engine is still running and may drive Exists via SimulateStateTransition.
+func TestExistsAfterClose(t *testing.T) {
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	logger := testutil.CreateLogger(t, 0)
+	db, err := NewBatchAttestationDB(dir, logger)
+	require.NoError(t, err)
+
+	db.Put([][]byte{{1}}, []uint64{1})
+	db.Close()
+
+	assert.NotPanics(t, func() {
+		assert.False(t, db.Exists([]byte{1}))
+	})
+}
+
+// TestExistsFailingReadPanics verifies that Exists fail-stops (panics) on a
+// genuine read error that is neither ErrNotFound nor ErrClosed, matching Put's
+// behavior of not silently discarding leveldb errors.
+func TestExistsFailingReadPanics(t *testing.T) {
+	logger := testutil.CreateLogger(t, 0)
+	stor := newFaultyStorage()
+
+	// Disable the open-files cache so every table read re-opens the file
+	// through the (faulty) storage layer.
+	ldb, err := leveldb.Open(stor, &opt.Options{OpenFilesCacheCapacity: -1})
+	require.NoError(t, err)
+	db := &BatchAttestationDB{db: ldb, logger: logger}
+	defer db.Close()
+
+	// Store a digest and flush it to an on-disk table so reads hit storage.Open.
+	db.Put([][]byte{{7}}, []uint64{1})
+	require.NoError(t, ldb.CompactRange(util.Range{}))
+
+	// Arm the fault: subsequent table opens fail with an IO error.
+	stor.failOpen.Store(true)
+
+	assert.Panics(t, func() {
+		db.Exists([]byte{7})
+	})
+}
+
+// faultyStorage wraps an in-memory leveldb storage and, once armed, fails all
+// Open calls with a non-ErrNotFound, non-ErrClosed error to simulate an IO fault.
+type faultyStorage struct {
+	storage.Storage
+	failOpen atomic.Bool
+}
+
+func newFaultyStorage() *faultyStorage {
+	return &faultyStorage{Storage: storage.NewMemStorage()}
+}
+
+func (fs *faultyStorage) Open(fd storage.FileDesc) (storage.Reader, error) {
+	if fs.failOpen.Load() {
+		return nil, errors.New("injected IO fault")
+	}
+	return fs.Storage.Open(fd)
+}
+
+// TestCleanFailingWritePanics verifies that Clean fail-stops (panics) when the
+// underlying db.Write fails, rather than silently discarding the error.
+func TestCleanFailingWritePanics(t *testing.T) {
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	logger := testutil.CreateLogger(t, 0)
+	db, err := NewBatchAttestationDB(dir, logger)
+	require.NoError(t, err)
+
+	db.Put([][]byte{{1}}, []uint64{1})
+
+	// Closing the DB makes the subsequent Write in Clean fail with ErrClosed.
+	db.Close()
+
+	assert.Panics(t, func() {
+		db.Clean(2)
+	})
 }

--- a/node/consensus/badb/badb_test.go
+++ b/node/consensus/badb/badb_test.go
@@ -167,3 +167,30 @@ func TestCleanFailingWritePanics(t *testing.T) {
 		db.Clean(2)
 	})
 }
+
+// TestCleanFailingIterationPanics verifies that Clean fail-stops (panics) when
+// the iterator encounters an error (surfaced via iter.Error()), rather than
+// silently writing a partial/empty delete batch and masking the fault.
+func TestCleanFailingIterationPanics(t *testing.T) {
+	logger := testutil.CreateLogger(t, 0)
+	stor := newFaultyStorage()
+
+	// Disable the open-files cache so every table read re-opens the file
+	// through the (faulty) storage layer.
+	ldb, err := leveldb.Open(stor, &opt.Options{OpenFilesCacheCapacity: -1})
+	require.NoError(t, err)
+	db := &BatchAttestationDB{db: ldb, logger: logger}
+	defer db.Close()
+
+	// Store a digest and flush it to an on-disk table so iteration hits storage.Open.
+	db.Put([][]byte{{7}}, []uint64{1})
+	require.NoError(t, ldb.CompactRange(util.Range{}))
+
+	// Arm the fault: subsequent table opens fail with an IO error, so the
+	// iterator in Clean cannot read the table and accumulates an error.
+	stor.failOpen.Store(true)
+
+	assert.Panics(t, func() {
+		db.Clean(2)
+	})
+}


### PR DESCRIPTION
BatchAttestationDB silently discarded LevelDB errors in two places, inconsistent with Put which fail-stops via Panicf:

- Exists returned `err == nil`, so ErrNotFound, ErrClosed, and corruption/IO errors were all reported identically as "digest absent".
- Clean discarded the db.Write error entirely.

Exists now switches on the error: ErrNotFound returns false (absent), and non-ErrNotFound errors Panicf like Put. ErrClosed is treated as benign because the consenter's SoftStop path closes the BADB while the BFT engine is still running and may drive Exists via SimulateStateTransition. Clean now Panicf's on Write errors.

Adds unit tests covering: ErrNotFound -> false, Exists after Close ->
false without panic, a genuine read fault -> panic (via a fault-injecting storage), and a failing Clean write -> panic.

Fixes #1070