### PR TITLE
Fix data race on Consensus.SigVerifier during dynamic reconfiguration

### DIFF
--- a/node/consensus/consensus.go
+++ b/node/consensus/consensus.go
@@ -694,6 +694,8 @@ func verifyBlockMessageToSign(msg *protoutil.MessageToSign, msgBytes []byte, sig
 // VerifySignature verifies the signature
 // (from SmartBFT API)
 func (c *Consensus) VerifySignature(signature smartbft_types.Signature) error {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.SigVerifier.VerifySignature(arma_types.PartyID(signature.ID), arma_types.ShardIDConsensus, signature.Msg, signature.Value)
 }
 


### PR DESCRIPTION
## What

Read `Consensus.SigVerifier` under `c.lock.RLock()` in `VerifySignature`.

## Why

`configureConsensus` reassigns `c.SigVerifier` under `c.lock.Lock()` during dynamic reconfiguration (`stopAndReconfigure` → `configureConsensus`), but `VerifySignature` read the field without the lock.

SmartBFT's `View.processCommits` spawns fire-and-forget `go verifyVote(...)` goroutines that are **not joined by `BFT.Stop()`**. `SoftStop()` stops the BFT engine before reconfiguration rewrites the struct, but a lingering `verifyVote` goroutine can still call `VerifySignature` and read `c.SigVerifier` concurrently with the reconfiguration write — a data race that makes `TestConsensusWithConsenterSyncAfterMissingConfigTx` flaky under `-race`.

The same call path (`VerifyConsenterSig`) already reads the other reconfiguration-mutated fields (`lastConfigBlockNum`, `decisionNumOfLastConfigBlock`) under the lock via `getBothDecisionNumAndLastConfigBlockNum`; this brings `SigVerifier` under the same discipline.

Fixes #1098

## Testing

```
go test -race -run '^TestConsensusWithConsenterSyncAfterMissingConfigTx$' ./node/consensus/
```

`ok  github.com/hyperledger/fabric-x-orderer/node/consensus  230.093s` — 0 data races, all subtests pass, including the reconfiguration-heavy ones that exercise the racing `configureConsensus` path.

## Note

`verifyCE` has the same unguarded reads of `c.SigVerifier` (consensus.go:1146/1156/1160). They were not part of this race report and are left out to keep the fix minimal and targeted; flagged in #1098 for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
