### PR TITLE
extend and fix assembler metrics

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -32,18 +32,6 @@ It queries Prometheus for metric data and displays it as dashboards, graphs, and
 
 ### Assembler
 
-- **Namespace:** "assembler_ledger"  
-  **Name:** "transaction_count_total"  
-  **Help:** "The total number of transactions committed to the ledger."
-
-- **Namespace:** "assembler_ledger"  
-  **Name:** "blocks_size_bytes_total"  
-  **Help:** "The estimated total size in bytes of blocks committed to the ledger."
-
-- **Namespace:** "assembler_ledger"  
-  **Name:** "blocks_count_total"  
-  **Help:** "The total number of blocks committed to the ledger."
-
 - **Namespace:** "assembler"  
   **Name:** "batch_unary_fetch_latency_seconds"
   **Help:** "The latency to unary fetch a requested batch from the batchers in the shard."
@@ -59,6 +47,22 @@ It queries Prometheus for metric data and displays it as dashboards, graphs, and
 - **Namespace:** "assembler"  
   **Name:** "prefetch_index_size_bytes"
   **Help:** "The current size of the assembler prefetch index for a shard in bytes."
+
+- **Namespace:** "assembler"  
+  **Name:** "prefetch_index_evictions_total"  
+  **Help:** "The total number of evictions from the assembler prefetch index."
+
+- **Namespace:** "assembler_ledger"  
+  **Name:** "transaction_count_total"  
+  **Help:** "The total number of transactions committed to the ledger."
+
+- **Namespace:** "assembler_ledger"  
+  **Name:** "blocks_size_bytes_total"  
+  **Help:** "The estimated total size in bytes of blocks committed to the ledger."
+
+- **Namespace:** "assembler_ledger"  
+  **Name:** "blocks_count_total"  
+  **Help:** "The total number of blocks committed to the ledger."
 
 ---
 

--- a/node/assembler/assembler.go
+++ b/node/assembler/assembler.go
@@ -277,6 +277,7 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 	configBlockNumber := configBlock.GetHeader().GetNumber()
 	a.logger.Infof("Initializing assembler ledger, current height: %d, config block number: %d", ledgerHeight, configBlockNumber)
 
+	ledgerUpdatedDuringInit := false
 	if configBlockNumber == 0 && ledgerHeight == 0 {
 		// append config block only if it is the genesis block and the ledger is empty.
 		configBlock.Metadata.Metadata[common.BlockMetadataIndex_ORDERER] = common_utils.GenesisBlockMetadataBytes()
@@ -287,6 +288,7 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 			BatchCount:  1,
 		}
 		a.ledger.AppendConfig(ordInfo)
+		ledgerUpdatedDuringInit = true
 		a.logger.Infof("Appended genesis block, header digest: %s", hex.EncodeToString(protoutil.BlockHeaderHash(configBlock.GetHeader())))
 	} else if configBlockNumber >= ledgerHeight {
 		a.logger.Infof("Creating assembler synchronizer to sync to config block number %d, current ledger height is %d", configBlockNumber, ledgerHeight)
@@ -306,6 +308,7 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 		if err := synchronizer.Sync(); err != nil {
 			a.logger.Panicf("error while syncing to config block %v", err)
 		}
+		ledgerUpdatedDuringInit = true
 	} else {
 		a.logger.Infof("Assembler is starting with config block already in the ledger, config block number: %d, current ledger height: %d", configBlockNumber, ledgerHeight)
 	}
@@ -315,10 +318,10 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 		a.logger.Panicf("Assembler ledger is empty after initialization, this should not happen")
 	}
 
-	// update metrics with current ledger state only if we didn't just append the genesis block
-	// (if we just appended genesis block, metrics were already updated in AppendConfig)
-	// This happens when the assembler is restarting with an existing ledger or after syncing
-	if ledgerHeight > 1 || configBlockNumber > 0 {
+	// update metrics with current ledger state only if we didn't append blocks during initialization
+	// (if we appended genesis or synced blocks, metrics were already updated in AppendConfig/AppendBlock)
+	// This happens when the assembler is restarting with an existing ledger
+	if !ledgerUpdatedDuringInit {
 		var transactionCount uint64
 		block, err := a.ledger.LedgerReader().RetrieveBlockByNumber(ledgerHeight - 1)
 		if err != nil {

--- a/node/assembler/assembler.go
+++ b/node/assembler/assembler.go
@@ -277,7 +277,22 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 	configBlockNumber := configBlock.GetHeader().GetNumber()
 	a.logger.Infof("Initializing assembler ledger, current height: %d, config block number: %d", ledgerHeight, configBlockNumber)
 
-	ledgerUpdatedDuringInit := false
+	// update metrics with current ledger state before syncing
+	// (genesis and synced blocks are updated in AppendConfig/AppendBlock)
+	if ledgerHeight > 0 {
+		var transactionCount uint64
+		block, err := a.ledger.LedgerReader().RetrieveBlockByNumber(ledgerHeight - 1)
+		if err != nil {
+			a.logger.Panicf("error while fetching last block from ledger %v", err)
+		}
+		_, _, transactionCount, err = node_ledger.AssemblerBatchIdOrderingInfoAndTxCountFromBlock(block)
+		if err != nil {
+			a.logger.Panicf("error while fetching last block ordering info %v", err)
+		}
+		a.ledger.Metrics().TransactionCount.Add(float64(transactionCount))
+		a.ledger.Metrics().BlocksCount.Add(float64(ledgerHeight))
+	}
+
 	if configBlockNumber == 0 && ledgerHeight == 0 {
 		// append config block only if it is the genesis block and the ledger is empty.
 		configBlock.Metadata.Metadata[common.BlockMetadataIndex_ORDERER] = common_utils.GenesisBlockMetadataBytes()
@@ -288,7 +303,6 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 			BatchCount:  1,
 		}
 		a.ledger.AppendConfig(ordInfo)
-		ledgerUpdatedDuringInit = true
 		a.logger.Infof("Appended genesis block, header digest: %s", hex.EncodeToString(protoutil.BlockHeaderHash(configBlock.GetHeader())))
 	} else if configBlockNumber >= ledgerHeight {
 		a.logger.Infof("Creating assembler synchronizer to sync to config block number %d, current ledger height is %d", configBlockNumber, ledgerHeight)
@@ -308,7 +322,6 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 		if err := synchronizer.Sync(); err != nil {
 			a.logger.Panicf("error while syncing to config block %v", err)
 		}
-		ledgerUpdatedDuringInit = true
 	} else {
 		a.logger.Infof("Assembler is starting with config block already in the ledger, config block number: %d, current ledger height: %d", configBlockNumber, ledgerHeight)
 	}
@@ -316,23 +329,6 @@ func (a *Assembler) initLedger(configBlock *common.Block, nodeConfig *node_confi
 	ledgerHeight = a.ledger.LedgerReader().Height()
 	if ledgerHeight == 0 {
 		a.logger.Panicf("Assembler ledger is empty after initialization, this should not happen")
-	}
-
-	// update metrics with current ledger state only if we didn't append blocks during initialization
-	// (if we appended genesis or synced blocks, metrics were already updated in AppendConfig/AppendBlock)
-	// This happens when the assembler is restarting with an existing ledger
-	if !ledgerUpdatedDuringInit {
-		var transactionCount uint64
-		block, err := a.ledger.LedgerReader().RetrieveBlockByNumber(ledgerHeight - 1)
-		if err != nil {
-			a.logger.Panicf("error while fetching last block from ledger %v", err)
-		}
-		_, _, transactionCount, err = node_ledger.AssemblerBatchIdOrderingInfoAndTxCountFromBlock(block)
-		if err != nil {
-			a.logger.Panicf("error while fetching last block ordering info %v", err)
-		}
-		a.ledger.Metrics().TransactionCount.Add(float64(transactionCount))
-		a.ledger.Metrics().BlocksCount.Add(float64(ledgerHeight))
 	}
 
 	a.logger.Infof("Ledger was initialized, current ledger height: %d", ledgerHeight)

--- a/node/assembler/assembler_test.go
+++ b/node/assembler/assembler_test.go
@@ -464,6 +464,7 @@ func TestAssembler_InitLedgerSyncsWhenConfigBlockAheadOfLedger(t *testing.T) {
 	require.Equal(t, orderer_config.DefaultNodeLocalConfig.GeneralConfig.Cluster.ReplicationMaxRetryDuration, cluster.ReplicationMaxRetryDuration)
 	require.NotNil(t, fakeSync)
 	require.Equal(t, 1, fakeSync.SyncCallCount())
+	require.Equal(t, uint64(2), test.assembler.GetTxCount())
 
 	test.StopAssembler()
 	test.WaitAssemblerStopped(t)
@@ -536,6 +537,7 @@ func TestAssembler_InitLedgerDoesNotSyncWhenConfigBlockAlreadyInLedger(t *testin
 
 	// Assert: no synchronizer was created across either start.
 	require.Equal(t, 0, test.synchronizerFactoryMock.CreateSynchronizerCallCount())
+	require.Equal(t, uint64(1), test.assembler.GetTxCount())
 
 	test.StopAssembler()
 	test.WaitAssemblerStopped(t)

--- a/node/assembler/metrics.go
+++ b/node/assembler/metrics.go
@@ -53,6 +53,13 @@ var (
 		Help:       "The current size of the assembler prefetch index for a shard in bytes.",
 		LabelNames: []string{"party_id", "shard_id"},
 	}
+
+	prefetchIndexEvictionsTotalOpts = metrics.CounterOpts{
+		Namespace:  "assembler",
+		Name:       "prefetch_index_evictions_total",
+		Help:       "The total number of evictions from the assembler prefetch index.",
+		LabelNames: []string{"party_id"},
+	}
 )
 
 type Metrics struct {
@@ -62,6 +69,7 @@ type Metrics struct {
 	attestationToBatchCollationLatency metrics.Histogram
 	batchLedgerAppendLatency           metrics.Histogram
 	prefetchIndexSize                  metrics.Gauge
+	prefetchIndexEvictionsTotal        metrics.Counter
 
 	logger    *flogging.FabricLogger
 	interval  time.Duration
@@ -87,6 +95,7 @@ func NewMetrics(assemblerNodeConfig *config.AssemblerNodeConfig, ledgerMetrics *
 	batchLedgerAppendLatency := provider.NewHistogram(batchLedgerAppendLatencyOpts).With([]string{partyID}...)
 
 	prefetchIndexSize := provider.NewGauge(prefetchIndexSizeOpts)
+	prefetchIndexEvictionsTotal := provider.NewCounter(prefetchIndexEvictionsTotalOpts).With([]string{partyID}...)
 
 	return &Metrics{
 		ledgerMetrics:                      ledgerMetrics,
@@ -99,6 +108,7 @@ func NewMetrics(assemblerNodeConfig *config.AssemblerNodeConfig, ledgerMetrics *
 		attestationToBatchCollationLatency: attestationToBatchCollationLatency,
 		batchLedgerAppendLatency:           batchLedgerAppendLatency,
 		prefetchIndexSize:                  prefetchIndexSize,
+		prefetchIndexEvictionsTotal:        prefetchIndexEvictionsTotal,
 	}
 }
 
@@ -118,12 +128,13 @@ func (m *Metrics) StopMetricsTracker() {
 		txCommitted := uint64(monitoring.GetMetricValue(m.ledgerMetrics.TransactionCount.(prometheus.Counter), m.logger))
 		blocksCommitted := uint64(monitoring.GetMetricValue(m.ledgerMetrics.BlocksCount.(prometheus.Counter), m.logger))
 		blocksSizeCommitted := uint64(monitoring.GetMetricValue(m.ledgerMetrics.BlocksSize.(prometheus.Counter), m.logger))
+		prefetchIndexEvictions := uint64(monitoring.GetMetricValue(m.prefetchIndexEvictionsTotal.(prometheus.Counter), m.logger))
 
 		batchUnaryFetchLatencyAvg := monitoring.GetHistogramAverage(m.batchUnaryFetchLatency.(prometheus.Metric), m.logger)
 		attestationToBatchCollationLatencyAvg := monitoring.GetHistogramAverage(m.attestationToBatchCollationLatency.(prometheus.Metric), m.logger)
 		batchLedgerAppendLatencyAvg := monitoring.GetHistogramAverage(m.batchLedgerAppendLatency.(prometheus.Metric), m.logger)
 
-		m.logger.Infof("ASSEMBLER_METRICS: party_id=%d, total: TXs=%d, blocks=%d, estimated_block_size=%d, batch_unary_fetch_latency_avg_seconds=%.6f, attestation_to_batch_collation_latency_avg_seconds=%.6f, batch_ledger_append_latency_avg_seconds=%.6f", m.partyID, txCommitted, blocksCommitted, blocksSizeCommitted, batchUnaryFetchLatencyAvg, attestationToBatchCollationLatencyAvg, batchLedgerAppendLatencyAvg)
+		m.logger.Infof("ASSEMBLER_METRICS: party_id=%d, total: TXs=%d, blocks=%d, estimated_block_size=%d, batch_unary_fetch_latency_avg_seconds=%.6f, attestation_to_batch_collation_latency_avg_seconds=%.6f, batch_ledger_append_latency_avg_seconds=%.6f, prefetch_index_evictions=%d", m.partyID, txCommitted, blocksCommitted, blocksSizeCommitted, batchUnaryFetchLatencyAvg, attestationToBatchCollationLatencyAvg, batchLedgerAppendLatencyAvg, prefetchIndexEvictions)
 	})
 }
 
@@ -140,6 +151,7 @@ func (m *Metrics) trackMetrics() {
 			txCommitted := uint64(monitoring.GetMetricValue(m.ledgerMetrics.TransactionCount.(prometheus.Counter), m.logger))
 			blocksCommitted := uint64(monitoring.GetMetricValue(m.ledgerMetrics.BlocksCount.(prometheus.Counter), m.logger))
 			blocksSizeCommitted := uint64(monitoring.GetMetricValue(m.ledgerMetrics.BlocksSize.(prometheus.Counter), m.logger))
+			prefetchIndexEvictions := uint64(monitoring.GetMetricValue(m.prefetchIndexEvictionsTotal.(prometheus.Counter), m.logger))
 
 			newBlocks := uint64(0)
 			if blocksCommitted > lastBlocksCommitted {
@@ -155,7 +167,7 @@ func (m *Metrics) trackMetrics() {
 			attestationToBatchCollationLatencyAvg := monitoring.GetHistogramAverage(m.attestationToBatchCollationLatency.(prometheus.Metric), m.logger)
 			batchLedgerAppendLatencyAvg := monitoring.GetHistogramAverage(m.batchLedgerAppendLatency.(prometheus.Metric), m.logger)
 
-			m.logger.Infof("ASSEMBLER_METRICS: total: party_id=%d, TXs=%d, blocks=%d, estimated_block_size=%d, batch_unary_fetch_latency_avg_seconds=%.6f, attestation_to_batch_collation_latency_avg_seconds=%.6f, batch_ledger_append_latency_avg_seconds=%.6f, in the last %.2f seconds: TXs=%d, blocks=%d", m.partyID, txCommitted, blocksCommitted, blocksSizeCommitted, batchUnaryFetchLatencyAvg, attestationToBatchCollationLatencyAvg, batchLedgerAppendLatencyAvg, sec, newTXs, newBlocks)
+			m.logger.Infof("ASSEMBLER_METRICS: total: party_id=%d, TXs=%d, blocks=%d, estimated_block_size=%d, batch_unary_fetch_latency_avg_seconds=%.6f, attestation_to_batch_collation_latency_avg_seconds=%.6f, batch_ledger_append_latency_avg_seconds=%.6f, prefetch_index_evictions=%d, in the last %.2f seconds: TXs=%d, blocks=%d", m.partyID, txCommitted, blocksCommitted, blocksSizeCommitted, batchUnaryFetchLatencyAvg, attestationToBatchCollationLatencyAvg, batchLedgerAppendLatencyAvg, prefetchIndexEvictions, sec, newTXs, newBlocks)
 			lastTxCommitted, lastBlocksCommitted = txCommitted, blocksCommitted
 		case <-m.stopChan:
 			return

--- a/node/assembler/partition_prefetch_index.go
+++ b/node/assembler/partition_prefetch_index.go
@@ -373,6 +373,7 @@ func (pi *PartitionPrefetchIndex) evictOldestBatch() error {
 		return err
 	}
 	pi.metrics.updatePrefetchIndexSize(pi.partition.Shard, -batchSizeBytes(batch))
+	pi.metrics.prefetchIndexEvictionsTotal.Add(1)
 	pi.stateCond.Broadcast()
 	return nil
 }

--- a/node/ledger/assembler_ledger.go
+++ b/node/ledger/assembler_ledger.go
@@ -61,7 +61,6 @@ type AssemblerLedger struct {
 	cancellationContext  context.Context
 	cancelContextFunc    context.CancelFunc
 	metrics              AssemblerLedgerMetrics
-	blockHeaderSize      uint64
 }
 
 func NewAssemblerLedger(logger *flogging.FabricLogger, ledgerPath string) (*AssemblerLedger, error) {
@@ -93,7 +92,6 @@ func NewAssemblerLedger(logger *flogging.FabricLogger, ledgerPath string) (*Asse
 		cancelContextFunc:    cancel,
 	}
 
-	al.blockHeaderSize = uint64(0)
 	return al, nil
 }
 
@@ -119,16 +117,14 @@ func (l *AssemblerLedger) estimatedBlockSize(block *common.Block) uint64 {
 		}
 		blockSize += uint64(len(data))
 	}
-	if l.blockHeaderSize != 0 {
-		l.blockHeaderSize += uint64(len(protoutil.MarshalOrPanic(block.Header)))
-	}
 	for _, md := range block.GetMetadata().GetMetadata() {
 		if len(md) == 0 {
 			continue
 		}
 		blockSize += uint64(len(md))
 	}
-	return blockSize + l.blockHeaderSize
+	headerSize := uint64(len(protoutil.MarshalOrPanic(block.Header)))
+	return blockSize + headerSize
 }
 
 func (l *AssemblerLedger) Append(batch types.Batch, ordInfo *state.OrderingInformation) {


### PR DESCRIPTION
- Avoid double-counting blocks and transactions after genesis/sync.
- Include the block header in the estimated block size metric.
- Add prefetch index eviction count.

#414 