### PR TITLE
Fix data race on c.BFT.Synchronizer during dynamic reconfiguration

### DIFF
--- a/node/consensus/consensus.go
+++ b/node/consensus/consensus.go
@@ -123,7 +123,12 @@ type Consensus struct {
 	ReconfigAbort chan struct{}
 
 	synchronizerFactory bft_synch.SynchronizerFactory // Builds a BFT synchronizer
-	Synchronizer        SynchronizerStopper           // The BFT synchronizer built by the factory
+	// synchronizerHolder is the stable indirection handed to SmartBFT (as BFT.Synchronizer) and
+	// held as c.Synchronizer. It is created once at BFT creation and never reassigned; the dynamic
+	// reconfiguration path swaps its inner synchronizer under the holder's lock instead. This
+	// avoids racing SmartBFT's unlocked read of BFT.Synchronizer in pkg/consensus.Sync().
+	synchronizerHolder *bft_synch.Holder
+	Synchronizer       SynchronizerStopper // The BFT synchronizer built by the factory (the holder)
 
 	RequestVerifier        *requestfilter.RulesVerifier
 	ConfigUpdateProposer   policy.ConfigUpdateProposer

--- a/node/consensus/consensus_builder.go
+++ b/node/consensus/consensus_builder.go
@@ -167,8 +167,18 @@ func (c *Consensus) configureConsensus(nodeConfig *node_config.ConsenterNodeConf
 	)
 	c.Logger.Info("Created a BFT Synchronizer")
 
-	c.BFT.Synchronizer = bftSynch
-	c.Synchronizer = bftSynch
+	if createNewBFT {
+		// Initial creation: build the holder once and hand it to SmartBFT (and keep it as
+		// c.Synchronizer). It is never reassigned afterwards.
+		c.synchronizerHolder = bft_synch.NewHolder(bftSynch)
+		c.BFT.Synchronizer = c.synchronizerHolder
+		c.Synchronizer = c.synchronizerHolder
+	} else {
+		// Dynamic reconfig: the existing BFT keeps running and still holds the same holder, so we
+		// only swap the inner synchronizer under the holder's lock rather than reassigning the
+		// BFT.Synchronizer field (which SmartBFT reads without a lock).
+		c.synchronizerHolder.Swap(bftSynch)
+	}
 }
 
 func (c *Consensus) InitOperationSystem() {

--- a/node/consensus/synchronizer/synchronizer_holder.go
+++ b/node/consensus/synchronizer/synchronizer_holder.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package synchronizer
+
+import (
+	"sync"
+
+	smartbft_types "github.com/hyperledger-labs/SmartBFT/pkg/types"
+)
+
+// Holder is a stable indirection over a SynchronizerWithStop.
+//
+// SmartBFT reads its Synchronizer field without a lock in pkg/consensus.Sync(), and the
+// viewchanger goroutine can drive a Sync() independently of the controller goroutine. On the
+// dynamic reconfiguration path the inner synchronizer must be replaced while the BFT instance
+// keeps running, which would race that unlocked read if we reassigned the field directly.
+//
+// Instead, SmartBFT (and arma's own c.Synchronizer) holds the Holder once, at BFT creation, and
+// never sees it reassigned. Reconfiguration calls Swap to replace the inner synchronizer under
+// the Holder's own lock, so Sync()/Stop() reads and the swap are serialized.
+type Holder struct {
+	mu    sync.RWMutex
+	inner SynchronizerWithStop
+}
+
+// NewHolder returns a Holder wrapping the given inner synchronizer.
+func NewHolder(inner SynchronizerWithStop) *Holder {
+	return &Holder{inner: inner}
+}
+
+func (h *Holder) Sync() smartbft_types.SyncResponse {
+	h.mu.RLock()
+	s := h.inner
+	h.mu.RUnlock()
+	return s.Sync()
+}
+
+func (h *Holder) Stop() {
+	h.mu.RLock()
+	s := h.inner
+	h.mu.RUnlock()
+	s.Stop()
+}
+
+// Swap replaces the inner synchronizer under the Holder's lock. It is safe to call concurrently
+// with Sync()/Stop().
+func (h *Holder) Swap(inner SynchronizerWithStop) {
+	h.mu.Lock()
+	h.inner = inner
+	h.mu.Unlock()
+}
+
+var _ SynchronizerWithStop = (*Holder)(nil)

--- a/node/consensus/synchronizer/synchronizer_holder_test.go
+++ b/node/consensus/synchronizer/synchronizer_holder_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package synchronizer_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	smartbft_types "github.com/hyperledger-labs/SmartBFT/pkg/types"
+	"github.com/hyperledger/fabric-x-orderer/node/consensus/synchronizer"
+	"github.com/stretchr/testify/require"
+)
+
+// countingSynchronizer is a trivial SynchronizerWithStop that records how many times Sync and Stop
+// were called. Its counters are atomic so they can be read after concurrent use without racing.
+type countingSynchronizer struct {
+	syncCalls atomic.Int64
+	stopCalls atomic.Int64
+}
+
+func (c *countingSynchronizer) Sync() smartbft_types.SyncResponse {
+	c.syncCalls.Add(1)
+	return smartbft_types.SyncResponse{}
+}
+
+func (c *countingSynchronizer) Stop() {
+	c.stopCalls.Add(1)
+}
+
+// TestHolderSwapDoesNotRaceSync spins up goroutines that call Sync() and Stop() on the holder while
+// another goroutine swaps the inner synchronizer, reproducing the dynamic-reconfiguration race
+// between SmartBFT's unlocked read of BFT.Synchronizer and the reconfiguration write. It must run
+// clean under -race.
+func TestHolderSwapDoesNotRaceSync(t *testing.T) {
+	first := &countingSynchronizer{}
+	holder := synchronizer.NewHolder(first)
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+
+	// Reader: continuously drives Sync() like SmartBFT's viewchanger/controller goroutines.
+	wg.Go(func() {
+		for range iterations {
+			holder.Sync()
+		}
+	})
+
+	// Reader: continuously drives Stop() like SoftStop/Stop.
+	wg.Go(func() {
+		for range iterations {
+			holder.Stop()
+		}
+	})
+
+	// Writer: continuously swaps the inner synchronizer like the reconfiguration goroutine.
+	wg.Go(func() {
+		for range iterations {
+			holder.Swap(&countingSynchronizer{})
+		}
+	})
+
+	wg.Wait()
+}
+
+func TestHolderSwapReplacesInner(t *testing.T) {
+	first := &countingSynchronizer{}
+	second := &countingSynchronizer{}
+	holder := synchronizer.NewHolder(first)
+
+	holder.Sync()
+	holder.Stop()
+	require.Equal(t, int64(1), first.syncCalls.Load())
+	require.Equal(t, int64(1), first.stopCalls.Load())
+
+	holder.Swap(second)
+
+	holder.Sync()
+	holder.Stop()
+	// The first synchronizer is no longer touched after the swap.
+	require.Equal(t, int64(1), first.syncCalls.Load())
+	require.Equal(t, int64(1), first.stopCalls.Load())
+	require.Equal(t, int64(1), second.syncCalls.Load())
+	require.Equal(t, int64(1), second.stopCalls.Load())
+}
+
+var _ synchronizer.SynchronizerWithStop = (*countingSynchronizer)(nil)


### PR DESCRIPTION
## What

Fixes the data race on `c.BFT.Synchronizer` during dynamic reconfiguration, described in #1101 (raised in review of #959).

### The race

On the dynamic reconfiguration path (`configureConsensus` with `createNewBFT=false`, from `stopAndReconfigure`), the still-running BFT instance had its `Synchronizer` field reassigned. SmartBFT reads that field **without a lock** in `pkg/consensus.Sync()`, and the viewchanger goroutine can drive a sync independently of the reconfiguration goroutine's write — a genuine data race under the Go memory model, flagged by `-race`.

### The fix

Introduce a `synchronizer.Holder`: a stable indirection over `SynchronizerWithStop` guarded by an `RWMutex`.

- SmartBFT (`c.BFT.Synchronizer`) and arma's `c.Synchronizer` hold the `Holder` **once**, at BFT creation, and never see it reassigned.
- The dynamic path calls `holder.Swap(newSynchronizer)` instead of reassigning the field.
- `Sync()`/`Stop()` reads and the swap are serialized by the holder's own lock.
- No change to vendored SmartBFT.

## Acceptance

- [x] `c.BFT.Synchronizer` is never reassigned after BFT creation
- [x] Dynamic reconfiguration swaps the inner synchronizer under a lock
- [x] Covered by a test run under `-race`

## Testing

- New `TestHolderSwapDoesNotRaceSync` / `TestHolderSwapReplacesInner` — pass under `-race`.
- `TestConsensusWithRealConfigUpdate` (full dynamic-reconfig e2e) — passes under `-race`.
- `make basic-checks` — clean.

Fixes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)