### PR TITLE
Remove Egress lock and make Egress a named field

### DIFF
--- a/node/comm/egress.go
+++ b/node/comm/egress.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package comm
 
 import (
-	"sync"
-
 	protos "github.com/hyperledger-labs/SmartBFT/smartbftprotos"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -20,18 +18,14 @@ import (
 
 // Egress implementation
 type Egress struct {
-	Channel  string
-	RPC      *RPC
-	Logger   *flogging.FabricLogger
-	NodeList []uint64
-	lock     sync.Mutex
+	Channel string
+	RPC     *RPC
+	Logger  *flogging.FabricLogger
 }
 
-// Nodes returns nodes from the runtime config
+// Nodes returns the set of member node IDs, delegating to the thread-safe RPC.
 func (e *Egress) Nodes() []uint64 {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	return e.NodeList
+	return e.RPC.Nodes()
 }
 
 // SendConsensus sends the BFT message to the cluster
@@ -62,10 +56,7 @@ func bftMsgToClusterMsg(message *protos.Message) *ab.ConsensusRequest {
 	}
 }
 
-// Reconfigure updates the list of nodes and reconfigures the RPC
-func (e *Egress) Reconfigure(nodes []uint64, members []RemoteNode) {
-	e.lock.Lock()
-	defer e.lock.Unlock()
+// Reconfigure reconfigures the RPC with the given members.
+func (e *Egress) Reconfigure(members []RemoteNode) {
 	e.RPC.Reconfigure(members)
-	e.NodeList = nodes
 }

--- a/node/comm/rpc.go
+++ b/node/comm/rpc.go
@@ -44,6 +44,7 @@ type RPC struct {
 	Comm          Communicator
 	lock          sync.RWMutex
 	StreamsByType map[OperationType]map[uint64]*Stream
+	nodes         []uint64
 }
 
 // NewStreamsByType returns a mapping of operation type to
@@ -72,7 +73,8 @@ func (ot OperationType) String() string {
 	return "consensus"
 }
 
-// Reconfigure configures the communicator of the RPC and replaces the stream map.
+// Reconfigure configures the communicator of the RPC, replaces the stream map,
+// and records the set of member node IDs.
 // The previous streams are abandoned here; they are aborted out-of-band by
 // Comm.Configure, which deactivates stubs and aborts their RemoteContext.
 func (s *RPC) Reconfigure(members []RemoteNode) {
@@ -80,6 +82,20 @@ func (s *RPC) Reconfigure(members []RemoteNode) {
 	defer s.lock.Unlock()
 	s.StreamsByType = NewStreamsByType()
 	s.Comm.Configure(members)
+	nodes := make([]uint64, len(members))
+	for i, member := range members {
+		nodes[i] = member.ID
+	}
+	s.nodes = nodes
+}
+
+// Nodes returns a copy of the set of member node IDs.
+func (s *RPC) Nodes() []uint64 {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	nodes := make([]uint64, len(s.nodes))
+	copy(nodes, s.nodes)
+	return nodes
 }
 
 // SendConsensus passes the given ConsensusRequest message to the given destination node.

--- a/node/comm/rpc_test.go
+++ b/node/comm/rpc_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package comm_test
+
+import (
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-orderer/node/comm"
+)
+
+// fakeCommunicator is a no-op comm.Communicator used to exercise RPC.Reconfigure
+// without establishing real connections.
+type fakeCommunicator struct{}
+
+func (f *fakeCommunicator) Remote(id uint64) (*comm.RemoteContext, error) { return nil, nil }
+func (f *fakeCommunicator) Configure(members []comm.RemoteNode)           {}
+func (f *fakeCommunicator) Shutdown()                                     {}
+
+func newTestRPC() *comm.RPC {
+	return &comm.RPC{
+		StreamsByType: comm.NewStreamsByType(),
+		Timeout:       time.Minute,
+		Comm:          &fakeCommunicator{},
+	}
+}
+
+func member(id uint64) comm.RemoteNode {
+	return comm.RemoteNode{NodeAddress: comm.NodeAddress{ID: id}}
+}
+
+func TestRPCNodesAfterReconfigure(t *testing.T) {
+	rpc := newTestRPC()
+
+	if got := rpc.Nodes(); len(got) != 0 {
+		t.Fatalf("expected no nodes before reconfigure, got %v", got)
+	}
+
+	rpc.Reconfigure([]comm.RemoteNode{member(1), member(2), member(3)})
+
+	got := rpc.Nodes()
+	slices.Sort(got)
+	want := []uint64{1, 2, 3}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestRPCNodesReturnsCopy(t *testing.T) {
+	rpc := newTestRPC()
+	rpc.Reconfigure([]comm.RemoteNode{member(1), member(2)})
+
+	first := rpc.Nodes()
+	first[0] = 99 // mutate the returned slice
+
+	second := rpc.Nodes()
+	for _, id := range second {
+		if id == 99 {
+			t.Fatalf("mutating a returned slice affected internal state: %v", second)
+		}
+	}
+}
+
+func TestRPCNodesReconfigureRace(t *testing.T) {
+	rpc := newTestRPC()
+	rpc.Reconfigure([]comm.RemoteNode{member(1)})
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = rpc.Nodes()
+		}()
+		go func(n uint64) {
+			defer wg.Done()
+			rpc.Reconfigure([]comm.RemoteNode{member(n), member(n + 1)})
+		}(uint64(i))
+	}
+	wg.Wait()
+}

--- a/node/consensus/consensus.go
+++ b/node/consensus/consensus.go
@@ -92,7 +92,7 @@ type BFT interface {
 type Consensus struct {
 	delivery.DeliverService
 	*comm.ClusterService
-	*comm.Egress
+	Egress       *comm.Egress
 	Logger       *flogging.FabricLogger
 	Config       *node_config.ConsenterNodeConfig
 	SigVerifier  SigVerifier

--- a/node/consensus/consensus_builder.go
+++ b/node/consensus/consensus_builder.go
@@ -470,7 +470,7 @@ func configureComm(c *Consensus) {
 		})
 	}
 	c.ClusterService.ConfigureNodeCerts(consenterConfigs)
-	c.Egress.Reconfigure(c.CurrentNodes, remotesNodes)
+	c.Egress.Reconfigure(remotesNodes)
 }
 
 func setupComm(c *Consensus) {
@@ -493,8 +493,7 @@ func setupComm(c *Consensus) {
 	}
 
 	c.Egress = &comm.Egress{
-		NodeList: c.CurrentNodes,
-		Logger:   c.Logger,
+		Logger: c.Logger,
 		RPC: &comm.RPC{
 			StreamsByType: comm.NewStreamsByType(),
 			Timeout:       c.fullConfig.LocalConfig.ClusterConfig.RPCTimeout,
@@ -505,7 +504,7 @@ func setupComm(c *Consensus) {
 
 	configureComm(c)
 
-	c.BFT.Comm = c
+	c.BFT.Comm = c.Egress
 }
 
 func getSelfID(consenterInfos []node_config.ConsenterInfo, partyID arma_types.PartyID) []byte {

--- a/node/consensus/consensus_builder.go
+++ b/node/consensus/consensus_builder.go
@@ -460,7 +460,7 @@ func configureComm(c *Consensus) {
 		})
 	}
 	c.ClusterService.ConfigureNodeCerts(consenterConfigs)
-	c.Egress.Reconfigure(c.CurrentNodes, remotesNodes)
+	c.Egress.Reconfigure(remotesNodes)
 }
 
 func setupComm(c *Consensus) {
@@ -483,8 +483,7 @@ func setupComm(c *Consensus) {
 	}
 
 	c.Egress = &comm.Egress{
-		NodeList: c.CurrentNodes,
-		Logger:   c.Logger,
+		Logger: c.Logger,
 		RPC: &comm.RPC{
 			StreamsByType: comm.NewStreamsByType(),
 			Timeout:       c.fullConfig.LocalConfig.ClusterConfig.RPCTimeout,
@@ -495,7 +494,7 @@ func setupComm(c *Consensus) {
 
 	configureComm(c)
 
-	c.BFT.Comm = c
+	c.BFT.Comm = c.Egress
 }
 
 func getSelfID(consenterInfos []node_config.ConsenterInfo, partyID arma_types.PartyID) []byte {


### PR DESCRIPTION
Follow-up to #959, addressing the review nit at https://github.com/hyperledger/fabric-x-orderer/pull/959#discussion_r3756972299.

## What

**Remove the `Egress` lock.** `Egress` kept its own `NodeList` guarded by a `sync.Mutex`. The node IDs are derivable from the members already passed to `RPC` (both are built from the same `Consenters` list), and `RPC` is thread-safe, so:
- `RPC` now records the member node IDs on `Reconfigure` and exposes `Nodes()`, returning a **copy** per SmartBFT's `Comm.Nodes()` contract (the old `Egress.Nodes()` returned the shared slice).
- `Egress.Nodes()` and `Egress.Reconfigure()` delegate to `RPC`; the `NodeList` field, the mutex, and the `sync` import are gone.
- `Egress.Reconfigure` drops its now-redundant `nodes` parameter.

**Make `Egress` a named field.** `*comm.Egress` was anonymously embedded in `Consensus` purely so method promotion satisfied SmartBFT's `Comm` interface (`c.BFT.Comm = c`). It's now a named field `Egress`, and the assignment is `c.BFT.Comm = c.Egress`.

## Testing

- New `-race` tests in `node/comm/rpc_test.go`: node-list correctness after `Reconfigure`, copy semantics, and concurrent `Nodes()`/`Reconfigure`.
- `make unit-tests-consensus` passes (`-race`).
- `node/comm` suite passes (`-race`).
- `make basic-checks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)