### PR TITLE
Add release of `fabric-x-orderer-test-node` image to GitHub Actions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -78,3 +78,20 @@ jobs:
             docker.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer:latest
             ghcr.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer:${{ env.VERSION }}
             ghcr.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer:latest
+
+      - name: Build and Push Multi-Platform All-In-One Test Node Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./node/examples/all-in-one/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            CREATED=${{ env.CREATED }}
+            REVISION=${{ env.REVISION }}
+          push: true
+          tags: |
+            docker.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer-test-node:${{ env.VERSION }}
+            docker.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer-test-node:latest
+            ghcr.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer-test-node:${{ env.VERSION }}
+            ghcr.io/${{ env.IMAGE_PREFIX }}/fabric-x-orderer-test-node:latest

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,16 @@
 # 	- check-dco: check that commits include Signed-off-by
 #	- docker-local: builds a single-platform image for the host's OS/architecture
 #   - docker-multiarch: wrapper that triggers docker builds for multiple platforms
+#   - build-test-node-image: builds the all-in-one test-node image for the host's OS/architecture
+#   - build-multiplatform-test-node-image: builds the all-in-one test-node image for multiple platforms
 #   - deterministic-failure-test: runs the deterministic failure test locally (5 min, 1000 tx/s, failure runner enabled)
 
 # Docker image vars
 DOCKERFILE ?= images/multi-platform/Dockerfile
-IMAGE_NAMESPACE = docker.io/hyperledger
+TEST_NODE_DOCKERFILE ?= node/examples/all-in-one/Dockerfile
+IMAGE_NAMESPACE = icr.io/cbdc
 IMAGE_NAME = fabric-x-orderer
+TEST_NODE_IMAGE_NAME = fabric-x-orderer-test-node
 VERSION = latest
 ORDERER_REVISION = $(shell git rev-parse HEAD)
 ORDERER_CREATED = $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -188,3 +192,15 @@ build-image:
 build-multiplatform-image:
 	@echo "Building the multiplatform image ${IMAGE_NAMESPACE}/${IMAGE_NAME}:${VERSION}..."
 	@./scripts/build_image.sh -t ${IMAGE_NAMESPACE}/${IMAGE_NAME}:${VERSION} -f ${DOCKERFILE} --multiplatform --build-arg REVISION=$(ORDERER_REVISION) --build-arg CREATED=$(ORDERER_CREATED)
+
+# Build the all-in-one test-node image
+.PHONY: build-test-node-image
+build-test-node-image:
+	@echo "Building the image ${IMAGE_NAMESPACE}/${TEST_NODE_IMAGE_NAME}:${VERSION}..."
+	@./scripts/build_image.sh -t ${IMAGE_NAMESPACE}/${TEST_NODE_IMAGE_NAME}:${VERSION} -f ${TEST_NODE_DOCKERFILE} --build-arg REVISION=$(ORDERER_REVISION) --build-arg CREATED=$(ORDERER_CREATED)
+
+# Build the all-in-one test-node multiplatform image
+.PHONY: build-multiplatform-test-node-image
+build-multiplatform-test-node-image:
+	@echo "Building the multiplatform image ${IMAGE_NAMESPACE}/${TEST_NODE_IMAGE_NAME}:${VERSION}..."
+	@./scripts/build_image.sh -t ${IMAGE_NAMESPACE}/${TEST_NODE_IMAGE_NAME}:${VERSION} -f ${TEST_NODE_DOCKERFILE} --multiplatform --build-arg REVISION=$(ORDERER_REVISION) --build-arg CREATED=$(ORDERER_CREATED)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 # Docker image vars
 DOCKERFILE ?= images/multi-platform/Dockerfile
 TEST_NODE_DOCKERFILE ?= node/examples/all-in-one/Dockerfile
-IMAGE_NAMESPACE = icr.io/cbdc
+IMAGE_NAMESPACE = docker.io/hyperledger
 IMAGE_NAME = fabric-x-orderer
 TEST_NODE_IMAGE_NAME = fabric-x-orderer-test-node
 VERSION = latest

--- a/node/examples/all-in-one/Dockerfile
+++ b/node/examples/all-in-one/Dockerfile
@@ -38,18 +38,17 @@ ARG REVISION=1.0
 WORKDIR /src
 COPY --from=builder /src /src
 
-# binaries already cross-compiled → just move them
-RUN cp /src/bin/arma /usr/local/bin/arma && \
-    cp /src/bin/armageddon /usr/local/bin/armageddon
+# binaries already cross-compiled → place them directly (no RUN, so no foreign-arch
+# exec under QEMU: only RUN invokes a process in the emulated target platform)
+COPY --from=builder /src/bin/arma /usr/local/bin/arma
+COPY --from=builder /src/bin/armageddon /usr/local/bin/armageddon
 
 # scripts
-COPY node/examples/all-in-one/entrypoint.sh /entrypoint.sh
-COPY node/examples/all-in-one/run_all.sh /run_all.sh
+COPY --chmod=755 node/examples/all-in-one/entrypoint.sh /entrypoint.sh
+COPY --chmod=755 node/examples/all-in-one/run_all.sh /run_all.sh
 
 # network topology, so the image runs standalone without a /config mount
 COPY node/examples/all-in-one/config /config
-
-RUN chmod +x /entrypoint.sh /run_all.sh
 
 # OCI metadata labels
 LABEL org.opencontainers.image.created="${CREATED}" \

--- a/node/examples/all-in-one/Dockerfile
+++ b/node/examples/all-in-one/Dockerfile
@@ -5,17 +5,40 @@
 
 ARG GO_VERSION=1.26.5
 
-FROM golang:${GO_VERSION}
+###########################################
+# Stage 1: cross-compiling builder
+###########################################
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:${GO_VERSION} AS builder
+
+# Build arguments used for cross-compiling
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+ENV CGO_ENABLED=0
 
 WORKDIR /src
 COPY . .
 
-ENV CGO_ENABLED=0
-ENV GOOS=linux
-
 RUN make binary
 
-# 🔥 binaries already built → just move them
+###########################################
+# Stage 2: all-in-one test runtime
+###########################################
+FROM docker.io/library/golang:${GO_VERSION}
+
+ARG VERSION=1.0
+ARG CREATED
+ARG REVISION=1.0
+
+# armageddon's sampleConfigPath auto-detection resolves testutil/fabric/sampleconfig
+# relative to `go env GOMOD`, so the source tree (with go.mod) must be present at
+# runtime, with WORKDIR set to it.
+WORKDIR /src
+COPY --from=builder /src /src
+
+# binaries already cross-compiled → just move them
 RUN cp /src/bin/arma /usr/local/bin/arma && \
     cp /src/bin/armageddon /usr/local/bin/armageddon
 
@@ -23,6 +46,20 @@ RUN cp /src/bin/arma /usr/local/bin/arma && \
 COPY node/examples/all-in-one/entrypoint.sh /entrypoint.sh
 COPY node/examples/all-in-one/run_all.sh /run_all.sh
 
+# network topology, so the image runs standalone without a /config mount
+COPY node/examples/all-in-one/config /config
+
 RUN chmod +x /entrypoint.sh /run_all.sh
+
+# OCI metadata labels
+LABEL org.opencontainers.image.created="${CREATED}" \
+    org.opencontainers.image.description="Hyperledger Fabric-X Orderer all-in-one test node: a 4-party, 1-shard Arma network plus the armageddon test client in a single container." \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.ref.name="library/golang" \
+    org.opencontainers.image.revision="${REVISION}" \
+    org.opencontainers.image.source="https://github.com/hyperledger/fabric-x-orderer" \
+    org.opencontainers.image.title="fabric-x-orderer-test-node" \
+    org.opencontainers.image.url="https://github.com/hyperledger/fabric-x-orderer" \
+    org.opencontainers.image.version="${VERSION}"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/node/examples/all-in-one/README.md
+++ b/node/examples/all-in-one/README.md
@@ -5,12 +5,14 @@
 This example builds a single Docker image that runs a full Arma network consisting of 4 parties and 1 shard within a single container.
 
 Each party includes:
+
 - Router
 - Batcher
 - Consenter
 - Assembler
 
 The container is responsible for:
+
 - running the Arma services
 - executing the test using `armageddon load` and `armageddon receive`
 
@@ -30,6 +32,30 @@ All communication is done via **localhost + ports**, without DNS or `/etc/hosts`
 
 - Docker installed
 - Linux environment (tested on RHEL)
+
+---
+
+## Published Image
+
+On every tagged release, this image is published to Docker Hub and GHCR for `linux/amd64`, `linux/arm64`, and `linux/s390x`:
+
+```text
+docker.io/hyperledger/fabric-x-orderer-test-node:<version>
+ghcr.io/hyperledger/fabric-x-orderer-test-node:<version>
+```
+
+(`:latest` is also published alongside each versioned tag.)
+
+The network topology config is baked into the image, so it runs standalone — no `/config` bind mount required:
+
+```bash
+docker run -d \
+  -p 6022:6022 -p 6023:6023 -p 6024:6024 -p 6025:6025 \
+  -p 6122:6122 -p 6123:6123 -p 6124:6124 -p 6125:6125 \
+  -p 6222:6222 -p 6223:6223 -p 6224:6224 -p 6225:6225 \
+  -p 6322:6322 -p 6323:6323 -p 6324:6324 -p 6325:6325 \
+  docker.io/hyperledger/fabric-x-orderer-test-node:<version>
+```
 
 ---
 
@@ -84,12 +110,12 @@ What the scripts do:
 
 Each party uses fixed ports:
 
-| Component   | Party 1 | Party 2 | Party 3 | Party 4 |
-|------------|--------|--------|--------|--------|
-| Router     | 6022   | 6122   | 6222   | 6322   |
-| Assembler  | 6023   | 6123   | 6223   | 6323   |
-| Batcher    | 6024   | 6124   | 6224   | 6324   |
-| Consenter  | 6025   | 6125   | 6225   | 6325   |
+| Component | Party 1 | Party 2 | Party 3 | Party 4 |
+| --------- | ------- | ------- | ------- | ------- |
+| Router    | 6022    | 6122    | 6222    | 6322    |
+| Assembler | 6023    | 6123    | 6223    | 6323    |
+| Batcher   | 6024    | 6124    | 6224    | 6324    |
+| Consenter | 6025    | 6125    | 6225    | 6325    |
 
 Ports are exposed from the container to the host to allow the test client (armageddon) to connect.
 
@@ -133,6 +159,7 @@ Container path:
 ```
 
 Roles:
+
 - router
 - assembler
 - batcher
@@ -155,6 +182,7 @@ Current test configuration:
 Equivalent commands executed inside container:
 
 ### Receiver
+
 ```bash
 armageddon receive \
   --config=/tmp/arma-all-in-one/config/party1/user_config.yaml \
@@ -164,6 +192,7 @@ armageddon receive \
 ```
 
 ### Loader
+
 ```bash
 armageddon load \
   --config=/tmp/arma-all-in-one/config/party1/user_config.yaml \
@@ -219,6 +248,7 @@ Important files:
 - All communication is done via localhost ports
 - Loader may print connection closing or retry messages — this is expected
 - Configuration is generated under:
+
 ```
 /tmp/arma-all-in-one/config/
 ```


### PR DESCRIPTION
## PR Description

This PR introduces the build for multiple platforms of the `fabric-x-orderer-test-node` image, which can be used by people to quickly run a 4-party 1-shard ARMA network on their machines.

It removes the burden of building the image locally, which can be demanding and also slows down the tests.