### PR TITLE
Invalidate authorized cluster streams on node identity change

### DIFF
--- a/node/comm/clusterservice.go
+++ b/node/comm/clusterservice.go
@@ -37,8 +37,16 @@ type ClusterStepStream interface {
 
 type MembersConfig struct {
 	MemberMapping     map[uint64][]byte
-	AuthorizedStreams sync.Map // Stream ID --> node identifier
-	nextStreamID      uint64
+	AuthorizedStreams sync.Map // Stream ID --> authorizedStream
+	nextStreamID      atomic.Uint64
+}
+
+// authorizedStream records the node and the identity (cert) a stream
+// authenticated under, so a later identity rotation for that node can
+// invalidate the stream and force re-authentication.
+type authorizedStream struct {
+	nodeID   uint64
+	identity []byte
 }
 
 // ClusterService implements the server API for ClusterNodeService service
@@ -80,15 +88,18 @@ func (s *ClusterService) Step(stream orderer.ClusterNodeService_StepServer) erro
 	}
 
 	s.Lock.RLock()
-	authReq, err := s.VerifyAuthRequest(stream, request)
+	authReq, fromIdentity, err := s.VerifyAuthRequest(stream, request)
 	if err != nil {
 		s.Lock.RUnlock()
 		s.Logger.Warnf("service authentication of %s failed with error: %v", addr, err)
 		return status.Errorf(codes.Unauthenticated, "access denied")
 	}
 
-	streamID := atomic.AddUint64(&s.Membership.nextStreamID, 1)
-	s.Membership.AuthorizedStreams.Store(streamID, authReq.FromId)
+	streamID := s.Membership.nextStreamID.Add(1)
+	s.Membership.AuthorizedStreams.Store(streamID, authorizedStream{
+		nodeID:   authReq.FromId,
+		identity: fromIdentity,
+	})
 	s.Lock.RUnlock()
 
 	defer s.Logger.Debugf("Closing connection from %s(%s)", commonName, addr)
@@ -111,21 +122,21 @@ func (s *ClusterService) Step(stream orderer.ClusterNodeService_StepServer) erro
 	}
 }
 
-func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_StepServer, request *orderer.ClusterNodeServiceStepRequest) (*orderer.NodeAuthRequest, error) {
+func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_StepServer, request *orderer.ClusterNodeServiceStepRequest) (*orderer.NodeAuthRequest, []byte, error) {
 	authReq := request.GetNodeAuthrequest()
 	if authReq == nil {
-		return nil, errors.New("invalid request object")
+		return nil, nil, errors.New("invalid request object")
 	}
 
 	bindingFieldsHash := GetSessionBindingHash(authReq)
 
 	tlsBinding, err := GetTLSSessionBinding(stream.Context(), bindingFieldsHash)
 	if err != nil {
-		return nil, errors.Wrap(err, "session binding read failed")
+		return nil, nil, errors.Wrap(err, "session binding read failed")
 	}
 
 	if !bytes.Equal(tlsBinding, authReq.SessionBinding) {
-		return nil, errors.New("session binding mismatch")
+		return nil, nil, errors.New("session binding mismatch")
 	}
 
 	msg, err := asn1.Marshal(AuthRequestSignature{
@@ -136,34 +147,34 @@ func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_Ste
 		SessionBinding: tlsBinding,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "ASN encoding failed")
+		return nil, nil, errors.Wrap(err, "ASN encoding failed")
 	}
 
 	membership := s.Membership
 	if membership == nil {
-		return nil, errors.Errorf("channel %s not found in config", authReq.Channel)
+		return nil, nil, errors.Errorf("channel %s not found in config", authReq.Channel)
 	}
 
 	fromIdentity := membership.MemberMapping[authReq.FromId]
 	if fromIdentity == nil {
-		return nil, errors.Errorf("node %d is not member of channel %s", authReq.FromId, authReq.Channel)
+		return nil, nil, errors.Errorf("node %d is not member of channel %s", authReq.FromId, authReq.Channel)
 	}
 
 	toIdentity := membership.MemberMapping[authReq.ToId]
 	if toIdentity == nil {
-		return nil, errors.Errorf("node %d is not member of channel %s", authReq.ToId, authReq.Channel)
+		return nil, nil, errors.Errorf("node %d is not member of channel %s", authReq.ToId, authReq.Channel)
 	}
 
 	if !bytes.Equal(toIdentity, s.NodeIdentity) {
-		return nil, errors.Errorf("node id mismatch")
+		return nil, nil, errors.Errorf("node id mismatch")
 	}
 
 	err = VerifySignature(fromIdentity, SHA256Digest(msg), authReq.Signature)
 	if err != nil {
-		return nil, errors.Wrap(err, "signature mismatch")
+		return nil, nil, errors.Wrap(err, "signature mismatch")
 	}
 
-	return authReq, nil
+	return authReq, fromIdentity, nil
 }
 
 func (s *ClusterService) handleMessage(stream ClusterStepStream, addr string, exp *certificateExpirationCheck, channel string, sender uint64, streamID uint64) error {
@@ -242,9 +253,18 @@ func (c *ClusterService) ConfigureNodeCerts(newNodes []*common.Consenter) error 
 		c.Membership.MemberMapping[uint64(nodeIdentity.Id)] = nodeIdentity.Identity
 	}
 
-	// Iterate over existing streams and prune those that should not be there anymore
-	c.Membership.AuthorizedStreams.Range(func(streamID, nodeID interface{}) bool {
-		if _, exists := c.Membership.MemberMapping[nodeID.(uint64)]; !exists {
+	// Iterate over existing streams and prune those that should not be there
+	// anymore: either the node ID was removed, or its identity (cert) was
+	// rotated. In the latter case the stream authenticated under the old cert
+	// and must re-authenticate against the new one.
+	c.Membership.AuthorizedStreams.Range(func(streamID, stream any) bool {
+		as, ok := stream.(authorizedStream)
+		if !ok {
+			c.Membership.AuthorizedStreams.Delete(streamID.(uint64))
+			return true
+		}
+		currentIdentity, exists := c.Membership.MemberMapping[as.nodeID]
+		if !exists || !bytes.Equal(currentIdentity, as.identity) {
 			c.Membership.AuthorizedStreams.Delete(streamID.(uint64))
 		}
 		return true

--- a/node/comm/clusterservice.go
+++ b/node/comm/clusterservice.go
@@ -37,8 +37,16 @@ type ClusterStepStream interface {
 
 type MembersConfig struct {
 	MemberMapping     map[uint64][]byte
-	AuthorizedStreams sync.Map // Stream ID --> node identifier
-	nextStreamID      uint64
+	AuthorizedStreams sync.Map // Stream ID --> authorizedStream
+	nextStreamID      atomic.Uint64
+}
+
+// authorizedStream records the node and the identity (cert) a stream
+// authenticated under, so a later identity rotation for that node can
+// invalidate the stream and force re-authentication.
+type authorizedStream struct {
+	nodeID   uint64
+	identity []byte
 }
 
 // ClusterService implements the server API for ClusterNodeService service
@@ -80,15 +88,18 @@ func (s *ClusterService) Step(stream orderer.ClusterNodeService_StepServer) erro
 	}
 
 	s.Lock.RLock()
-	authReq, err := s.VerifyAuthRequest(stream, request)
+	authReq, fromIdentity, err := s.VerifyAuthRequest(stream, request)
 	if err != nil {
 		s.Lock.RUnlock()
 		s.Logger.Warnf("service authentication of %s failed with error: %v", addr, err)
 		return status.Errorf(codes.Unauthenticated, "access denied")
 	}
 
-	streamID := atomic.AddUint64(&s.Membership.nextStreamID, 1)
-	s.Membership.AuthorizedStreams.Store(streamID, authReq.FromId)
+	streamID := s.Membership.nextStreamID.Add(1)
+	s.Membership.AuthorizedStreams.Store(streamID, authorizedStream{
+		nodeID:   authReq.FromId,
+		identity: fromIdentity,
+	})
 	s.Lock.RUnlock()
 
 	defer s.Logger.Debugf("Closing connection from %s(%s)", commonName, addr)
@@ -111,21 +122,21 @@ func (s *ClusterService) Step(stream orderer.ClusterNodeService_StepServer) erro
 	}
 }
 
-func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_StepServer, request *orderer.ClusterNodeServiceStepRequest) (*orderer.NodeAuthRequest, error) {
+func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_StepServer, request *orderer.ClusterNodeServiceStepRequest) (*orderer.NodeAuthRequest, []byte, error) {
 	authReq := request.GetNodeAuthrequest()
 	if authReq == nil {
-		return nil, errors.New("invalid request object")
+		return nil, nil, errors.New("invalid request object")
 	}
 
 	bindingFieldsHash := GetSessionBindingHash(authReq)
 
 	tlsBinding, err := GetTLSSessionBinding(stream.Context(), bindingFieldsHash)
 	if err != nil {
-		return nil, errors.Wrap(err, "session binding read failed")
+		return nil, nil, errors.Wrap(err, "session binding read failed")
 	}
 
 	if !bytes.Equal(tlsBinding, authReq.SessionBinding) {
-		return nil, errors.New("session binding mismatch")
+		return nil, nil, errors.New("session binding mismatch")
 	}
 
 	msg, err := asn1.Marshal(AuthRequestSignature{
@@ -136,34 +147,34 @@ func (s *ClusterService) VerifyAuthRequest(stream orderer.ClusterNodeService_Ste
 		SessionBinding: tlsBinding,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "ASN encoding failed")
+		return nil, nil, errors.Wrap(err, "ASN encoding failed")
 	}
 
 	membership := s.Membership
 	if membership == nil {
-		return nil, errors.Errorf("channel %s not found in config", authReq.Channel)
+		return nil, nil, errors.Errorf("channel %s not found in config", authReq.Channel)
 	}
 
 	fromIdentity := membership.MemberMapping[authReq.FromId]
 	if fromIdentity == nil {
-		return nil, errors.Errorf("node %d is not member of channel %s", authReq.FromId, authReq.Channel)
+		return nil, nil, errors.Errorf("node %d is not member of channel %s", authReq.FromId, authReq.Channel)
 	}
 
 	toIdentity := membership.MemberMapping[authReq.ToId]
 	if toIdentity == nil {
-		return nil, errors.Errorf("node %d is not member of channel %s", authReq.ToId, authReq.Channel)
+		return nil, nil, errors.Errorf("node %d is not member of channel %s", authReq.ToId, authReq.Channel)
 	}
 
 	if !bytes.Equal(toIdentity, s.NodeIdentity) {
-		return nil, errors.Errorf("node id mismatch")
+		return nil, nil, errors.Errorf("node id mismatch")
 	}
 
 	err = VerifySignature(fromIdentity, SHA256Digest(msg), authReq.Signature)
 	if err != nil {
-		return nil, errors.Wrap(err, "signature mismatch")
+		return nil, nil, errors.Wrap(err, "signature mismatch")
 	}
 
-	return authReq, nil
+	return authReq, fromIdentity, nil
 }
 
 func (s *ClusterService) handleMessage(stream ClusterStepStream, addr string, exp *certificateExpirationCheck, channel string, sender uint64, streamID uint64) error {
@@ -242,9 +253,14 @@ func (c *ClusterService) ConfigureNodeCerts(newNodes []*common.Consenter) error 
 		c.Membership.MemberMapping[uint64(nodeIdentity.Id)] = nodeIdentity.Identity
 	}
 
-	// Iterate over existing streams and prune those that should not be there anymore
-	c.Membership.AuthorizedStreams.Range(func(streamID, nodeID interface{}) bool {
-		if _, exists := c.Membership.MemberMapping[nodeID.(uint64)]; !exists {
+	// Iterate over existing streams and prune those that should not be there
+	// anymore: either the node ID was removed, or its identity (cert) was
+	// rotated. In the latter case the stream authenticated under the old cert
+	// and must re-authenticate against the new one.
+	c.Membership.AuthorizedStreams.Range(func(streamID, stream any) bool {
+		as := stream.(authorizedStream)
+		currentIdentity, exists := c.Membership.MemberMapping[as.nodeID]
+		if !exists || !bytes.Equal(currentIdentity, as.identity) {
 			c.Membership.AuthorizedStreams.Delete(streamID.(uint64))
 		}
 		return true

--- a/node/comm/clusterservice_test.go
+++ b/node/comm/clusterservice_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package comm
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+)
+
+// TestConfigureNodeCerts_PruneOnIdentityChange asserts that when an existing
+// node keeps its ID but rotates its identity (cert), any stream that was
+// already authorized under the old identity is de-authorized, forcing
+// re-authentication against the new cert.
+func TestConfigureNodeCerts_PruneOnIdentityChange(t *testing.T) {
+	oldIdentity := []byte("old-cert")
+	newIdentity := []byte("new-cert")
+
+	tests := []struct {
+		name             string
+		configuredCert   []byte
+		expectAuthorized bool
+	}{
+		{
+			name:             "identity unchanged keeps stream authorized",
+			configuredCert:   oldIdentity,
+			expectAuthorized: true,
+		},
+		{
+			name:             "identity rotated de-authorizes stream",
+			configuredCert:   newIdentity,
+			expectAuthorized: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := &ClusterService{
+				Logger: flogging.MustGetLogger("test"),
+				Membership: &MembersConfig{
+					MemberMapping: map[uint64][]byte{5: oldIdentity},
+				},
+			}
+
+			// Simulate a stream that authenticated under the old identity.
+			const streamID = uint64(1)
+			cs.Membership.AuthorizedStreams.Store(streamID, authorizedStream{nodeID: 5, identity: oldIdentity})
+
+			err := cs.ConfigureNodeCerts([]*common.Consenter{{Id: 5, Identity: tc.configuredCert}})
+			if err != nil {
+				t.Fatalf("ConfigureNodeCerts returned error: %v", err)
+			}
+
+			_, authorized := cs.Membership.AuthorizedStreams.Load(streamID)
+			if authorized != tc.expectAuthorized {
+				t.Fatalf("stream authorized = %v, want %v", authorized, tc.expectAuthorized)
+			}
+		})
+	}
+}
+
+// TestConfigureNodeCerts_PruneOnRemovedID asserts that a stream whose node ID
+// is no longer a member is de-authorized.
+func TestConfigureNodeCerts_PruneOnRemovedID(t *testing.T) {
+	identity := []byte("cert")
+
+	cs := &ClusterService{
+		Logger: flogging.MustGetLogger("test"),
+		Membership: &MembersConfig{
+			MemberMapping: map[uint64][]byte{5: identity},
+		},
+	}
+
+	const streamID = uint64(1)
+	cs.Membership.AuthorizedStreams.Store(streamID, authorizedStream{nodeID: 5, identity: identity})
+
+	// Reconfigure with node 5 removed (only node 6 remains).
+	err := cs.ConfigureNodeCerts([]*common.Consenter{{Id: 6, Identity: identity}})
+	if err != nil {
+		t.Fatalf("ConfigureNodeCerts returned error: %v", err)
+	}
+
+	if _, authorized := cs.Membership.AuthorizedStreams.Load(streamID); authorized {
+		t.Fatalf("stream for removed node ID should be de-authorized")
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #1102.

In `node/comm/clusterservice.go`, an incoming cluster stream is authenticated once at establishment (`VerifyAuthRequest` checks the sender's identity + signature) and then recorded in `AuthorizedStreams` as `streamID → nodeID`. Subsequent messages are accepted based only on stream authorization, without re-verifying identity per message.

`ConfigureNodeCerts` rebuilds `MemberMapping` and prunes authorized streams, but only removed streams whose **node ID was no longer present**. It did **not** remove streams whose **identity (cert) changed** for a still-present ID. As a result, if an existing node kept its `uint64` ID but rotated its cert via a config update, any stream already authorized under the **old** cert survived reconfiguration and kept being accepted — even though it authenticated with a now-invalid identity.

## Fix

- Record the identity each stream authenticated under. `AuthorizedStreams` now maps `streamID → authorizedStream{nodeID, identity}`.
- `VerifyAuthRequest` now also returns the validated `fromIdentity`, so the stored identity is the exact value that was verified (single source of truth, no second map lookup).
- The prune in `ConfigureNodeCerts` now de-authorizes a stream if its node ID was removed **or** its stored identity no longer matches the current `MemberMapping` entry — forcing re-authentication against the rotated cert.

## Tests

- `TestConfigureNodeCerts_PruneOnIdentityChange` — table-driven: unchanged identity keeps the stream authorized; a rotated identity for the same ID de-authorizes it (the core acceptance criterion).
- `TestConfigureNodeCerts_PruneOnRemovedID` — the pre-existing removed-ID pruning still holds.

Verified locally: `go test -race ./node/comm/`, `go build ./...`, `go vet`, and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)