### PR TITLE
Add NodeStatus to batcher

### DIFF
--- a/node/batcher/batcher.go
+++ b/node/batcher/batcher.go
@@ -87,8 +87,7 @@ type Batcher struct {
 	running                            sync.WaitGroup // maybe change the name, it is only for state replicator
 	stopChan                           chan struct{}
 	mainExitChan                       chan struct{}
-	isStopped                          bool
-	isSoftStopped                      bool
+	status                             node_utils.NodeStatus
 	configAcker                        configack.Sender
 
 	primaryLock sync.RWMutex
@@ -144,9 +143,6 @@ func (b *Batcher) Run() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.isStopped = false
-	b.isSoftStopped = false
-
 	b.stopChan = make(chan struct{})
 	b.stateChan = make(chan *state.State, 1)
 
@@ -166,30 +162,27 @@ func (b *Batcher) Run() {
 	b.logger.Infof("Health check serving on URL: %s", operations.HealthCheckServiceURL(b.opsSystem, b.logger))
 	b.logger.Infof("Logging spec service serving on URL: %s", operations.LogSpecServiceURL(b.opsSystem, b.logger))
 	b.logger.Infof("Version info serving on URL: %s", operations.VersionInfoServiceURL(b.opsSystem, b.logger))
+
+	b.status.Set(node_utils.StateRunning, b.config.Bundle.ConfigtxValidator().Sequence())
 }
 
-func (b *Batcher) GetStatus() string {
+func (b *Batcher) GetStatus() node_utils.NodeStatus {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	if b.isSoftStopped && !b.isStopped {
-		return "Soft Stopped"
-	}
-	if b.isSoftStopped && b.isStopped {
-		return "Stopped"
-	}
-	return "Running"
+	return b.status
 }
 
 func (b *Batcher) Stop() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	if b.isStopped {
+	state := b.status.GetState()
+	if state == node_utils.StateStopped {
 		return
 	}
 
 	b.logger.Infof("Stopping batcher node")
-	if !b.isSoftStopped {
+	if state != node_utils.StateSoftStopped && state != node_utils.StatePendingAdmin {
 		close(b.stopChan)
 		b.controlEventBroadcaster.Stop()
 		b.batcher.Stop()
@@ -210,19 +203,19 @@ func (b *Batcher) Stop() {
 
 	close(b.mainExitChan)
 
-	b.isStopped = true
-	b.isSoftStopped = true
+	b.status.SetState(node_utils.StateStopped)
 }
 
 func (b *Batcher) SoftStop() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	if b.isSoftStopped || b.isStopped {
+	state := b.status.GetState()
+	if state == node_utils.StateSoftStopped || state == node_utils.StateStopped || state == node_utils.StatePendingAdmin {
 		return
 	}
 
-	b.isSoftStopped = true
+	b.status.SetState(node_utils.StateSoftStopped)
 
 	b.logger.Infof("Soft stopping batcher node")
 	close(b.stopChan)
@@ -316,6 +309,9 @@ func (b *Batcher) processNewConfigBlock(configBlock *common.Block) {
 	}
 	if isAdminOperationRequired {
 		b.logger.Warnf("Pending admin action to apply new config")
+		b.lock.Lock()
+		b.status.SetState(node_utils.StatePendingAdmin)
+		b.lock.Unlock()
 		return
 	}
 }

--- a/node/batcher/batcher.go
+++ b/node/batcher/batcher.go
@@ -163,7 +163,7 @@ func (b *Batcher) Run() {
 	b.logger.Infof("Logging spec service serving on URL: %s", operations.LogSpecServiceURL(b.opsSystem, b.logger))
 	b.logger.Infof("Version info serving on URL: %s", operations.VersionInfoServiceURL(b.opsSystem, b.logger))
 
-	b.status.Set(node_utils.StateRunning, b.config.Bundle.ConfigtxValidator().Sequence())
+	b.status.SetState(node_utils.StateRunning)
 }
 
 func (b *Batcher) GetStatus() node_utils.NodeStatus {
@@ -176,13 +176,13 @@ func (b *Batcher) Stop() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	state := b.status.GetState()
-	if state == node_utils.StateStopped {
+	currentState := b.status.GetState()
+	if currentState == node_utils.StateStopped {
 		return
 	}
 
 	b.logger.Infof("Stopping batcher node")
-	if state != node_utils.StateSoftStopped && state != node_utils.StatePendingAdmin {
+	if currentState != node_utils.StateSoftStopped && currentState != node_utils.StatePendingAdmin {
 		close(b.stopChan)
 		b.controlEventBroadcaster.Stop()
 		b.batcher.Stop()
@@ -421,21 +421,22 @@ func (b *Batcher) stopAndReconfigure(newConfig *config.Configuration, newBatcher
 	b.fullConfig = newConfig
 	b.configureBatcher(&ConsenterControlEventSenderFactory{}, b.batcher.MemPool, lastKnownDecisionNum)
 	newConfigSeq := newBatcherConfig.Bundle.ConfigtxValidator().Sequence()
+	b.status.Set(node_utils.StateInitializing, newConfigSeq)
 	b.lock.Unlock()
 
 	// prune mempool
 	b.logger.Infof("Pruning memory pool")
-	var droppedTxCount uint32
+	var droppedTxCount atomic.Uint32
 	verifyOnReconfig := func(req []byte) error {
 		if err := b.requestsInspectorVerifier.VerifyRequest(req); err != nil {
-			atomic.AddUint32(&droppedTxCount, 1)
+			droppedTxCount.Add(1)
 			b.logger.Warnf("Mempool Pruning: failed verifying request with req ID: %s; err: %v", b.requestsInspectorVerifier.RequestID(req), err)
 			return err
 		}
 		return nil
 	}
 	b.batcher.MemPool.Prune(verifyOnReconfig)
-	b.logger.Infof("Mempool pruning completed: %d transactions were dropped", atomic.LoadUint32(&droppedTxCount))
+	b.logger.Infof("Mempool pruning completed: %d transactions were dropped", droppedTxCount.Load())
 
 	// init batcher again
 	b.logger.Infof("Initialize new batcher")

--- a/node/batcher/batcher_builder.go
+++ b/node/batcher/batcher_builder.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/node/crypto"
 	node_ledger "github.com/hyperledger/fabric-x-orderer/node/ledger"
 	protos "github.com/hyperledger/fabric-x-orderer/node/protos/comm"
+	node_utils "github.com/hyperledger/fabric-x-orderer/node/utils"
 	"github.com/hyperledger/fabric-x-orderer/request"
 )
 
@@ -53,6 +54,10 @@ func CreateBatcher(nodeConfig *node_config.BatcherNodeConfig, fullConfig *config
 		ConfigStore:                        configStore,
 		wal:                                batcherWAL,
 		mainExitChan:                       mainExitChan,
+		status: node_utils.NodeStatus{
+			State:                node_utils.StateInitializing,
+			ConfigSequenceNumber: nodeConfig.Bundle.ConfigtxValidator().Sequence(),
+		},
 	}
 
 	b.configureBatcher(senderCreator, nil, lastKnownDecisionNum)

--- a/node/batcher/batcher_reconfig_test.go
+++ b/node/batcher/batcher_reconfig_test.go
@@ -96,7 +96,7 @@ func TestBatcherReceivesConfigBlockFromConsensusAndApplyConfig_ChangeBatchTimeou
 	// wait for the batcher to soft stop
 	for j := range parties {
 		require.Eventually(t, func() bool {
-			return batchers[j].GetStatus() == "Soft Stopped"
+			return batchers[j].GetStatus().GetState() == node_utils.StateSoftStopped
 		}, 60*time.Second, 10*time.Millisecond)
 	}
 
@@ -117,7 +117,7 @@ func TestBatcherReceivesConfigBlockFromConsensusAndApplyConfig_ChangeBatchTimeou
 	//// wait for the batcher to initialize
 	//for j := range parties {
 	//	require.Eventually(t, func() bool {
-	//		return batchers[j].GetStatus() == "Running"
+	//		return batchers[j].GetStatus().GetState() == node_utils.StateRunning
 	//	}, 60*time.Second, 10*time.Millisecond)
 	//}
 	//

--- a/node/batcher/batcher_test.go
+++ b/node/batcher/batcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/comm/tlsgen"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
+	node_utils "github.com/hyperledger/fabric-x-orderer/node/utils"
 	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/hyperledger/fabric-x-orderer/testutil/block"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
@@ -46,6 +47,13 @@ func TestBatcherRun(t *testing.T) {
 
 	batchers, loggers, configs, cleanBatchers := createBatchers(t, numParties, shardID, batcherNodes, batchersInfo, consentersInfo, stubConsenters)
 	defer cleanBatchers()
+
+	// running batchers report a running status carrying the bootstrap config sequence
+	for _, b := range batchers {
+		status := b.GetStatus()
+		require.Equal(t, node_utils.StateRunning, status.GetState())
+		require.Equal(t, uint64(0), status.ConfigSequenceNumber)
+	}
 
 	batchers[0].Submit(context.Background(), tx.CreateStructuredRequest([]byte{1}))
 
@@ -96,6 +104,7 @@ func TestBatcherRun(t *testing.T) {
 	// stop and recover secondary
 	t.Logf("Stop and recover secondary")
 	batchers[3].Stop()
+	require.Equal(t, node_utils.StateStopped, batchers[3].GetStatus().GetState())
 	batchers[3] = recoverBatcher(t, ca, loggers[3], configs[3], batcherNodes[3], stubConsenters[3])
 	stubConsenters[3].UpdateState(termChangeState)
 
@@ -609,6 +618,7 @@ func TestPullBatchFromSoftStoppedBatcher(t *testing.T) {
 	for i, b := range batchers {
 		if i != 1 {
 			b.SoftStop()
+			require.Equal(t, node_utils.StateSoftStopped, b.GetStatus().GetState())
 		}
 	}
 


### PR DESCRIPTION
## What

Adds a lifecycle status to the batcher, mirroring the other node roles (assembler, router, consensus).

The batcher was the only role not using the shared `node/utils.NodeStatus` type: it tracked lifecycle with two ad-hoc booleans (`isStopped`, `isSoftStopped`) and `GetStatus()` returned a bespoke `string`. This made it impossible to observe the applied config sequence — the signal the batcher reconfiguration tests need.

## Changes

- Add a `status node_utils.NodeStatus` field, initialized to `StateInitializing` with the bootstrap config sequence in `CreateBatcher`.
- Transition through `StateRunning` (carrying the current config sequence, so a dynamic reconfig updates it), `StateSoftStopped`, `StatePendingAdmin` (when a config change requires an admin action), and `StateStopped`.
- `GetStatus()` now returns `node_utils.NodeStatus` instead of `string`.
- Update the reconfig test to the new API and add status assertions (`Running` after `Run`, `Stopped` after `Stop`, `SoftStopped` after `SoftStop`) to the batcher unit tests.

No new proto/gRPC/HTTP endpoint — `NodeStatus` is an in-memory field read via `GetStatus()`, exactly as the other roles do it.

## Testing

`make unit-tests-batcher` passes (with `-race`).

Fixes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)