### PR TITLE
Fix flaky nil-pointer panic in TestBFTDeliverer_FatalErrors

### DIFF
--- a/common/deliverclient/blocksprovider/bft_deliverer_test.go
+++ b/common/deliverclient/blocksprovider/bft_deliverer_test.go
@@ -280,6 +280,15 @@ func (s *bftDelivererTestSetup) assertEventuallyMonitorCallCount(n int) {
 			s.mutex.Lock()
 			defer s.mutex.Unlock()
 
+			// The monitor is created asynchronously by the factory: the fake records the
+			// Create invocation (bumping CreateCallCount) before the stub assigns
+			// s.fakeCensorshipMon. A caller that only waited on CreateCallCount can reach
+			// here while the field is still nil, so return a sentinel and let Eventually
+			// retry rather than dereferencing nil and panicking.
+			if s.fakeCensorshipMon == nil {
+				return -1
+			}
+
 			return s.fakeCensorshipMon.MonitorCallCount()
 		}, eventuallyTO,
 	).Should(Equal(n))


### PR DESCRIPTION
## Problem

`TestBFTDeliverer_FatalErrors/Fails_to_sign_seek_request` intermittently crashes the whole test process with a `SIGSEGV` (nil-pointer dereference), failing `make unit-tests-other` in CI:

```
panic: runtime error: invalid memory address or nil pointer dereference
...
fake.(*CensorshipDetector).MonitorCallCount(0x0)
    common/deliverclient/blocksprovider/fake/censorship_detector.go:99
blocksprovider_test.(*bftDelivererTestSetup).assertEventuallyMonitorCallCount.func1()
    common/deliverclient/blocksprovider/bft_deliverer_test.go:283
```

## Root cause

The censorship monitor is created asynchronously. In the generated counterfeiter fake `CensorshipDetectorFactory.Create`, the call is **recorded** (so `CreateCallCount()` returns 1) and its mutex released **before** the user-supplied `CreateCalls` stub runs — and that stub is what assigns `s.fakeCensorshipMon = mon`.

The test waited only on `CreateCallCount() == 1` and then immediately dereferenced `s.fakeCensorshipMon` inside the `Eventually` poller. If the poller won the race against the stub, the field was still `nil` → `MonitorCallCount(0x0)` panic. Because a panic inside a gomega `Eventually` poller propagates immediately (it is not retried), the test process crashed instead of the assertion simply polling again.

## Fix

Make the shared `assertEventuallyMonitorCallCount` poller nil-safe: return a sentinel (`-1`) when `s.fakeCensorshipMon` is still `nil`, so `Eventually` keeps polling until the stub assigns it, instead of dereferencing nil. This is the single common helper used by all call sites.

## Verification

Ran the previously flaky test 50× under `-race`, all green:

```
go test -race -run '^TestBFTDeliverer_FatalErrors$' -count=50 ./common/deliverclient/blocksprovider/
ok  github.com/hyperledger/fabric-x-orderer/common/deliverclient/blocksprovider  41.526s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)