### PR TITLE
Fix flaky TestConsensusFullReplacement: sync on rejoin from advanced config block

### DIFF
--- a/node/consensus/consensus_builder.go
+++ b/node/consensus/consensus_builder.go
@@ -92,8 +92,10 @@ func (c *Consensus) configureConsensus(nodeConfig *node_config.ConsenterNodeConf
 
 	initialState, metadata, lastProposal, lastSigs, decisionNumOfLastConfigBlock, prevHash := getInitialStateAndMetadata(c.Logger, nodeConfig, lastConfigBlock, consLedger)
 	txCount := getTxCount(consLedger)
-	// indicate that sync is required on startup when new consensus node joins the cluster
-	if consLedger.Height() == 0 && lastConfigBlock.Header.Number > 0 {
+	// Indicate that a sync is required on startup when the node is behind the cluster: either a
+	// brand-new node joining an established cluster, or a node rejoining from a join config block
+	// that is more advanced than its own ledger.
+	if shouldSyncOnStart(c.Logger, lastConfigBlock, consLedger.Height()) {
 		nodeConfig.BFTConfig.SyncOnStart = true
 	}
 
@@ -227,6 +229,33 @@ func buildVerifier(consenterInfos []node_config.ConsenterInfo, shardInfo []node_
 	}
 
 	return verifier
+}
+
+// shouldSyncOnStart reports whether the node must synchronize with the cluster before it starts
+// participating in consensus, given the join config block it booted from and its current ledger
+// height. It returns true when the join config block's decision number is ahead of the ledger
+// height, which covers two cases:
+//   - a brand-new node joining with an empty ledger from a non-genesis config block, and
+//   - a node rejoining with a stale, non-empty ledger from a more-advanced config block.
+//
+// The genesis block (decision number 0) with an empty ledger yields false, as does a node whose
+// ledger is already current with (or ahead of) the join config block.
+func shouldSyncOnStart(logger *flogging.FabricLogger, lastConfigBlock *common.Block, height uint64) bool {
+	if lastConfigBlock.Header.Number == 0 {
+		// Genesis config block: only a fresh node (empty ledger) could be here, and it starts
+		// from genesis rather than syncing.
+		return false
+	}
+
+	_, ordInfo, _, err := ledger.AssemblerBatchIdOrderingInfoAndTxCountFromBlock(lastConfigBlock)
+	if err != nil {
+		// A non-genesis join config block must carry ordering info; failing to read it means the
+		// block is malformed and we cannot safely decide whether to sync.
+		logger.Panicf("Failed to extract ordering info from join config block number %d: %v",
+			lastConfigBlock.Header.Number, err)
+	}
+
+	return uint64(ordInfo.DecisionNum) > height
 }
 
 func getInitialStateAndMetadata(logger *flogging.FabricLogger, config *node_config.ConsenterNodeConfig, lastConfigBlock *common.Block, consLedger *ledger.ConsensusLedger) (*state.State, *smartbftprotos.ViewMetadata, *smartbft_types.Proposal, []smartbft_types.Signature, arma_types.DecisionNum, []byte) {

--- a/node/consensus/consensus_builder.go
+++ b/node/consensus/consensus_builder.go
@@ -233,13 +233,14 @@ func buildVerifier(consenterInfos []node_config.ConsenterInfo, shardInfo []node_
 
 // shouldSyncOnStart reports whether the node must synchronize with the cluster before it starts
 // participating in consensus, given the join config block it booted from and its current ledger
-// height. It returns true when the join config block's decision number is ahead of the ledger
-// height, which covers two cases:
+// height. The ledger height equals the last committed decision number plus one, so the node has
+// committed every decision below height. It returns true when the join config block's decision
+// number is at or beyond height (i.e. a decision the node has not yet committed), which covers:
 //   - a brand-new node joining with an empty ledger from a non-genesis config block, and
 //   - a node rejoining with a stale, non-empty ledger from a more-advanced config block.
 //
 // The genesis block (decision number 0) with an empty ledger yields false, as does a node whose
-// ledger is already current with (or ahead of) the join config block.
+// ledger already contains the join config block's decision.
 func shouldSyncOnStart(logger *flogging.FabricLogger, lastConfigBlock *common.Block, height uint64) bool {
 	if lastConfigBlock.Header.Number == 0 {
 		// Genesis config block: only a fresh node (empty ledger) could be here, and it starts
@@ -255,7 +256,7 @@ func shouldSyncOnStart(logger *flogging.FabricLogger, lastConfigBlock *common.Bl
 			lastConfigBlock.Header.Number, err)
 	}
 
-	return uint64(ordInfo.DecisionNum) > height
+	return uint64(ordInfo.DecisionNum) >= height
 }
 
 func getInitialStateAndMetadata(logger *flogging.FabricLogger, config *node_config.ConsenterNodeConfig, lastConfigBlock *common.Block, consLedger *ledger.ConsensusLedger) (*state.State, *smartbftprotos.ViewMetadata, *smartbft_types.Proposal, []smartbft_types.Signature, arma_types.DecisionNum, []byte) {

--- a/node/consensus/consensus_builder_sync_test.go
+++ b/node/consensus/consensus_builder_sync_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package consensus
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
+	"github.com/hyperledger/fabric-x-orderer/node/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// makeConfigBlockWithDecisionNum builds a config block whose ORDERER metadata encodes the given
+// decision number, so that ledger.AssemblerBatchIdOrderingInfoAndTxCountFromBlock can recover it.
+func makeConfigBlockWithDecisionNum(t *testing.T, blockNumber uint64, decisionNum types.DecisionNum) *common.Block {
+	t.Helper()
+
+	batchedRequests := types.BatchedRequests{[]byte("tx1"), []byte("tx2")}
+	fb := ledger.NewFabricBatchFromRequests(1, 1, 1, batchedRequests, batchedRequests.Digest(), 0, []byte("prev"), nil)
+	require.NotNil(t, fb)
+
+	oi := &state.OrderingInformation{
+		CommonBlock: &common.Block{
+			Header: &common.BlockHeader{Number: blockNumber, DataHash: fb.Digest()},
+		},
+		DecisionNum: decisionNum,
+		BatchIndex:  0,
+		BatchCount:  1,
+	}
+
+	mdBytes, err := ledger.AssemblerBlockMetadataToBytes(fb, oi, uint64(len(batchedRequests)))
+	require.NoError(t, err)
+
+	block := &common.Block{
+		Header: &common.BlockHeader{Number: blockNumber, DataHash: fb.Digest()},
+		Data:   &common.BlockData{Data: [][]byte{[]byte("data")}},
+		Metadata: &common.BlockMetadata{
+			Metadata: make([][]byte, common.BlockMetadataIndex_ORDERER+1),
+		},
+	}
+	block.Metadata.Metadata[common.BlockMetadataIndex_ORDERER] = mdBytes
+	return block
+}
+
+func TestShouldSyncOnStart(t *testing.T) {
+	logger := flogging.MustGetLogger("test")
+
+	t.Run("fresh join with empty ledger and non-genesis config block requires sync", func(t *testing.T) {
+		// A brand-new node joins from a join config block (number > 0) with an empty ledger.
+		joinConfigBlock := makeConfigBlockWithDecisionNum(t, 5, 5)
+		require.True(t, shouldSyncOnStart(logger, joinConfigBlock, 0))
+	})
+
+	t.Run("rejoin from a more-advanced config block requires sync", func(t *testing.T) {
+		// Party rejoins with a non-empty stale ledger (height 14) but boots from a join config
+		// block whose decision number (24) is ahead of the ledger height. This is the flaky
+		// TestConsensusFullReplacement scenario: without sync the node would resume as a stale
+		// leader of its old view and never catch up.
+		joinConfigBlock := makeConfigBlockWithDecisionNum(t, 12, 24)
+		require.True(t, shouldSyncOnStart(logger, joinConfigBlock, 14))
+	})
+
+	t.Run("up-to-date node recovering from its own ledger does not sync", func(t *testing.T) {
+		// The join config block's decision number is not ahead of the ledger height, so the node
+		// is already current and must not force a sync on start.
+		joinConfigBlock := makeConfigBlockWithDecisionNum(t, 12, 10)
+		require.False(t, shouldSyncOnStart(logger, joinConfigBlock, 14))
+	})
+
+	t.Run("genesis start does not sync", func(t *testing.T) {
+		// Starting from the genesis config block (number 0) with an empty ledger: no sync.
+		genesisBlock := &common.Block{Header: &common.BlockHeader{Number: 0}}
+		require.False(t, shouldSyncOnStart(logger, genesisBlock, 0))
+	})
+
+	t.Run("panics when the join config block ordering info cannot be read", func(t *testing.T) {
+		// A non-genesis config block whose ordering metadata is missing/corrupt is unexpected and
+		// must not be silently ignored.
+		corruptBlock := &common.Block{Header: &common.BlockHeader{Number: 12}}
+		require.Panics(t, func() {
+			shouldSyncOnStart(logger, corruptBlock, 14)
+		})
+	})
+}

--- a/node/consensus/consensus_builder_sync_test.go
+++ b/node/consensus/consensus_builder_sync_test.go
@@ -67,10 +67,19 @@ func TestShouldSyncOnStart(t *testing.T) {
 		require.True(t, shouldSyncOnStart(logger, joinConfigBlock, 14))
 	})
 
+	t.Run("rejoin behind by exactly one decision requires sync", func(t *testing.T) {
+		// The ledger height is 14, meaning the node has committed decisions up to number 13
+		// (height == last committed decision + 1). A join config block at decision 14 is the very
+		// next decision the node has NOT yet committed, so it is behind and must sync. This is the
+		// boundary between "behind" and "current".
+		joinConfigBlock := makeConfigBlockWithDecisionNum(t, 12, 14)
+		require.True(t, shouldSyncOnStart(logger, joinConfigBlock, 14))
+	})
+
 	t.Run("up-to-date node recovering from its own ledger does not sync", func(t *testing.T) {
-		// The join config block's decision number is not ahead of the ledger height, so the node
-		// is already current and must not force a sync on start.
-		joinConfigBlock := makeConfigBlockWithDecisionNum(t, 12, 10)
+		// The node has committed decisions up to 13 (height 14). The join config block's decision
+		// number (13) is one the node already has, so it is current and must not force a sync.
+		joinConfigBlock := makeConfigBlockWithDecisionNum(t, 12, 13)
 		require.False(t, shouldSyncOnStart(logger, joinConfigBlock, 14))
 	})
 


### PR DESCRIPTION
## What

Fixes the flaky `TestConsensusFullReplacement` (`node/consensus`, run via `make unit-tests-consensus-full-replacement`).

A consenter rejoining the cluster from a join/bootstrap config block more advanced than its own stale ledger did **not** trigger a sync on start. It resumed from its WAL as the leader of its last-known (now stale) view and never caught up — SmartBFT's self-heal path only calls `Sync()` after collecting commit votes from ≥ f+1 distinct peers, and in the failing runs only a single peer could reach the rejoined node before the 60s assertion timed out.

## Root cause

The existing `SyncOnStart` gate in `node/consensus/consensus_builder.go` only fired for a **fresh** join:

```go
if consLedger.Height() == 0 && lastConfigBlock.Header.Number > 0 {
    nodeConfig.BFTConfig.SyncOnStart = true
}
```

A rejoining node has a non-empty ledger, so the gate was `false` and no sync was requested — even though `config.ReadConfig` had already detected the rejoin and selected the more-advanced bootstrap block as `lastConfigBlock`.

## Change

Replace the gate with `shouldSyncOnStart(logger, lastConfigBlock, height)`, which returns true when the join config block's **decision number** is ahead of the ledger height. This covers both:
- fresh join (empty ledger, non-genesis config block), and
- rejoin from a more-advanced config block (the bug).

`DecisionNum` is in consensus-decision units and is comparable to height; `lastConfigBlock.Header.Number` is Fabric config-block numbering and is **not**, which is why we extract `DecisionNum` via `ledger.AssemblerBatchIdOrderingInfoAndTxCountFromBlock`. It panics on a malformed join config block (consistent with the existing extraction call on the fresh-join path). This keys off the same "bootstrap ahead of ledger" signal `config.ReadConfig` already uses.

When `SyncOnStart` is true, SmartBFT's `Controller.Start` runs `Sync()` (block-puller / deliver path, which works even when the consensus egress is wedged) **before** the node proposes, so the rejoining node catches up instead of leading a stale view.

Behavior is unchanged for the two previously-handled cases (fresh join → sync; normal recover from own ledger → no sync); only the missing rejoin-from-advanced-config case is added.

## Tests

- New white-box unit test `TestShouldSyncOnStart` (`node/consensus/consensus_builder_sync_test.go`): fresh join, rejoin-from-advanced-config, up-to-date recover (no sync), genesis (no sync), and panic on a malformed join config block.
- Regression (all pass): `TestNonLeaderNodeFailureRecovery`, `TestSyncFromSoftStoppedNodes`, `TestConsensusWithConsenterSyncAfterMissingConfigTx`.
- End-to-end: `TestConsensusFullReplacement` re-run with the fix — passes (`ok ... 725s`).

Fixes #1110