### PR TITLE
Fix data race on grpclog global in TestBatcherRun

### DIFF
--- a/node/batcher/batcher_test.go
+++ b/node/batcher/batcher_test.go
@@ -29,9 +29,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestBatcherRun(t *testing.T) {
+func init() {
+	// grpclog.SetLoggerV2 mutates process-global state in gRPC and is not
+	// thread-safe, so it must run once before any gRPC code, not per test.
 	grpclog.SetLoggerV2(&testutil.SilentLogger{})
+}
 
+func TestBatcherRun(t *testing.T) {
 	shardID := types.ShardID(0)
 	numParties := 4
 	ca, err := tlsgen.NewCA()


### PR DESCRIPTION
## Problem

CI flagged a `DATA RACE` in the batcher unit tests (`-race`). `TestBatcherRun` calls `grpclog.SetLoggerV2(...)` inside the test body:

- **Write** (`TestBatcherRun` goroutine): `grpclog.SetLoggerV2` at `node/batcher/batcher_test.go:33`
- **Read** (lingering gRPC goroutine): a prior test's (`TestVerifyBatch`) gRPC client connection still logging via `channelz` → `grpclog.InfoDepth` during connection teardown

`grpclog.SetLoggerV2` mutates process-global variables in gRPC and is documented as **not thread-safe** — it must run once before any other gRPC code. Calling it per-test races against gRPC goroutines from the previous test that are still alive.

## Fix

Move the call into a package-level `init()` so it runs exactly once, before any gRPC activity. This matches the pattern already used in the consensus and router test packages (`consensus_recover_test.go`, `router_test.go`, `shard_router_test.go`).

## Testing

```
$ go test -race -run '^(TestVerifyBatch|TestBatcherRun)$' ./node/batcher/
ok  github.com/hyperledger/fabric-x-orderer/node/batcher	8.252s
```

Runs both tests in the same binary (the ordering that triggered the race) with `-race` — clean pass, no data race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)