### PR TITLE
Fix data race and flaky failure in TestBFTSynchronizer/synchronizer_can_be_stopped

### DIFF
--- a/node/consensus/synchronizer/synchronizer_bft_test.go
+++ b/node/consensus/synchronizer/synchronizer_bft_test.go
@@ -1255,7 +1255,9 @@ func TestBFTSynchronizer(t *testing.T) {
 			}
 		})
 
+		syncDoneCh := make(chan struct{})
 		go func() {
+			defer close(syncDoneCh)
 			resp := bftSynchronizer.Sync()
 			require.NotNil(t, resp)
 			require.Equal(t, *decision, resp)
@@ -1276,6 +1278,10 @@ func TestBFTSynchronizer(t *testing.T) {
 		close(pauseDeliverCh)
 		<-doneDeliverCh
 
+		// wait for the synchronizer goroutine to return, so no more WriteBlockSync
+		// calls can be in flight when we sample the ledger and the call count below.
+		<-syncDoneCh
+
 		require.Eventually(t, func() bool {
 			ledgerLock.Lock()
 			defer ledgerLock.Unlock()
@@ -1283,7 +1289,10 @@ func TestBFTSynchronizer(t *testing.T) {
 			return len(ledger) >= 101
 		}, 10*time.Second, 10*time.Millisecond)
 
-		require.Equal(t, len(ledger)-100, fakeCS.WriteBlockSyncCallCount())
+		ledgerLock.Lock()
+		ledgerLen := len(ledger)
+		ledgerLock.Unlock()
+		require.Equal(t, ledgerLen-100, fakeCS.WriteBlockSyncCallCount())
 		require.Equal(t, 0, fakeCS.WriteConfigBlockCallCount())
 		require.Eventually(t, func() bool { return fakeBFTDeliverer.StopCallCount() == 1 }, 10*time.Second, time.Millisecond)
 	})


### PR DESCRIPTION
## Problem

`TestBFTSynchronizer/synchronizer_can_be_stopped` intermittently fails under `-race`, seen in CI (`unit-tests-consensus`) with both a `WARNING: DATA RACE` and an assertion mismatch `expected: 1, actual: 2`.

The test asserts on the ledger and `WriteBlockSync` call count after only waiting for the *deliverer* goroutine (`doneDeliverCh`) to finish — not the *synchronizer* goroutine running `Sync()`. Two defects result:

- The synchronizer can still be mid-`getBlocksFromSyncBuffer`, with counterfeiter's `WriteBlockSyncCallCount()` already incremented on call entry but the guarded ledger `append` not yet executed. This yields the intermittent `expected: 1, actual: 2` mismatch.
- The final `len(ledger)` read (line 1286) was the one `ledger` access not guarded by `ledgerLock`, which the race detector flags against the guarded `append` in the `WriteBlockSync` stub.

## Fix

- Close a `syncDoneCh` when the `Sync()` goroutine returns, and wait on it before the final assertions — once `Sync()` has returned, no `WriteBlockSync` call can be in flight, so the call count and ledger length are mutually consistent.
- Read `len(ledger)` under `ledgerLock`.

## Testing

`go test -race -count=20 -run '^TestBFTSynchronizer$/^synchronizer_can_be_stopped$' ./node/consensus/synchronizer/...` — passes consistently (previously flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)