### PR TITLE
Add verify txs to determinstic and random failure tests

### DIFF
--- a/.github/workflows/deterministic-failure-test.yml
+++ b/.github/workflows/deterministic-failure-test.yml
@@ -156,7 +156,9 @@ jobs:
         if: failure()
         id: failure_reason
         run: |
-          if [ -f test-results/startup_failure.txt ]; then
+          if [ -f test-results/failure_reason.txt ]; then
+            echo "reason=$(cat test-results/failure_reason.txt)" >> $GITHUB_OUTPUT
+          elif [ -f test-results/startup_failure.txt ]; then
             echo "reason=$(cat test-results/startup_failure.txt)" >> $GITHUB_OUTPUT
           else
             echo "reason=The test job failed to run (possibly due to insufficient runner resources or an infrastructure issue)" >> $GITHUB_OUTPUT

--- a/.github/workflows/fully-randomized-failure-test.yml
+++ b/.github/workflows/fully-randomized-failure-test.yml
@@ -170,7 +170,9 @@ jobs:
         if: failure()
         id: failure_reason
         run: |
-          if [ -f test-results/startup_failure.txt ]; then
+          if [ -f test-results/failure_reason.txt ]; then
+            echo "reason=$(cat test-results/failure_reason.txt)" >> $GITHUB_OUTPUT
+          elif [ -f test-results/startup_failure.txt ]; then
             echo "reason=$(cat test-results/startup_failure.txt)" >> $GITHUB_OUTPUT
           else
             echo "reason=The test job failed to run (possibly due to insufficient runner resources or an infrastructure issue)" >> $GITHUB_OUTPUT

--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package armageddon
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/csv"
 	"encoding/pem"
 	"fmt"
@@ -111,6 +113,28 @@ func (pm *protectedMap) IsEmpty() bool {
 	return len(pm.keyValMap) == 0
 }
 
+func (pm *protectedMap) Size() int {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+	return len(pm.keyValMap)
+}
+
+func (pm *protectedMap) Keys() []string {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+	keys := make([]string, 0, len(pm.keyValMap))
+	for k := range pm.keyValMap {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (pm *protectedMap) Contains(key string) bool {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+	return pm.keyValMap[key]
+}
+
 type CLI struct {
 	app      *kingpin.Application
 	commands map[string]*kingpin.CmdClause
@@ -131,11 +155,13 @@ type CLI struct {
 	loadRate           *string
 	loadTxSize         *int
 	loadSignedMode     *string
+	loadTxidsFile      *string
 	// receive command flags
 	receiveUserConfigFile   **os.File
 	receiveExpectedNumOfTxs *int
 	receiveOutputDir        *string
 	pullFromPartyId         *int
+	receiveTxidsFile        *string
 	// createSharedConfigProto command flags
 	sharedConfigYamlPath *string
 	sharedConfigProtoDir *string
@@ -182,6 +208,7 @@ func (cli *CLI) configureCommands() {
 	cli.loadRate = load.Flag("rate", "The rate specifies the number of transactions per second to be sent as one or more rate numbers separated by space").String()
 	cli.loadTxSize = load.Flag("txSize", "The required transaction size in bytes").Int()
 	cli.loadSignedMode = load.Flag("signedMode", "Signing mode has three option: none = unsigned, full = sign including the full certificate, short = sign using known certificate").String()
+	cli.loadTxidsFile = load.Flag("txidsFile", "(Optional) path to write the binary TX-ID file — when set, the loader writes one 8-byte big-endian txNumber per TX after all transactions are sent").Default("").String()
 	commands["load"] = load
 
 	receive := cli.app.Command("receive", "Pull txs from some assembler and report statistics")
@@ -189,6 +216,7 @@ func (cli *CLI) configureCommands() {
 	cli.receiveExpectedNumOfTxs = receive.Flag("expectedTxs", "The expected number of transactions the assembler should received").Default("-1").Int()
 	cli.receiveOutputDir = receive.Flag("output", "The output directory in which to place statistics file").Default(".").String()
 	cli.pullFromPartyId = receive.Flag("pullFromPartyId", "The party id of the assembler to pull blocks from").Int()
+	cli.receiveTxidsFile = receive.Flag("txidsFile", "(Optional) path to the binary TX-ID file written by the loader — when set, the receiver verifies every TX-ID was received; exits 1 and writes missing_txids.txt if any are missing").Default("").String()
 	commands["receive"] = receive
 
 	createSharedConfigProto := cli.app.Command("createSharedConfigProto", "Create a shared config binary from a shared configuration YAML file")
@@ -228,11 +256,11 @@ func (cli *CLI) Run(args []string) {
 
 	// "load" command
 	case cli.commands["load"].FullCommand():
-		load(cli.loadUserConfigFile, cli.loadTransactions, cli.loadRate, cli.loadTxSize, cli.loadSignedMode)
+		load(cli.loadUserConfigFile, cli.loadTransactions, cli.loadRate, cli.loadTxSize, cli.loadSignedMode, cli.loadTxidsFile)
 
 	// "receive" command
 	case cli.commands["receive"].FullCommand():
-		receive(cli.receiveUserConfigFile, cli.pullFromPartyId, cli.receiveOutputDir, cli.receiveExpectedNumOfTxs)
+		receive(cli.receiveUserConfigFile, cli.pullFromPartyId, cli.receiveOutputDir, cli.receiveExpectedNumOfTxs, cli.receiveTxidsFile)
 
 	// "createSharedConfigProto" command
 	case cli.commands["createSharedConfigProto"].FullCommand():
@@ -515,7 +543,7 @@ func submit(userConfigFile **os.File, transactions *int, rate *int, txSize *int)
 }
 
 // load command makes txs and sends them to all routers
-func load(userConfigFile **os.File, transactions *int, rate *string, txSize *int, signedMode *string) {
+func load(userConfigFile **os.File, transactions *int, rate *string, txSize *int, signedMode *string, txidsFile *string) {
 	rates := strings.Fields(*rate)
 	// check transaction size
 	txMinimumSize := 16 + 8 + 8
@@ -547,6 +575,20 @@ func load(userConfigFile **os.File, transactions *int, rate *string, txSize *int
 		SendTxsToAllAvailableRouters(userConfig, *transactions, convertedRates[i], *txSize, nil, *signedMode)
 		elapsed := time.Since(start)
 		reportLoadResults(*transactions, elapsed, *txSize)
+	}
+
+	// TX-ID verification: write the binary txids file when --txidsFile is set.
+	// The file contains one 8-byte big-endian txNumber per transaction (0-based).
+	// When multiple rates are provided the same N transactions are sent for each
+	// rate, so we write the IDs for *transactions entries (0..N-1) once.
+	if txidsFile != nil && *txidsFile != "" {
+		if err := writeTxidsFile(*txidsFile, *transactions); err != nil {
+			// All transactions were already sent successfully; this exit is for
+			// a file-write failure only (e.g. disk full).  Acceptable for a test tool.
+			fmt.Fprintf(os.Stderr, "failed to write txids file: %v\n", err)
+			os.Exit(3)
+		}
+		logger.Infof("TX-IDs written to %s (%d transactions)", *txidsFile, *transactions)
 	}
 }
 
@@ -650,7 +692,7 @@ func SendTxsToAllAvailableRouters(userConfig *UserConfig, numOfTxs int, rate int
 }
 
 // receive command pull blocks from the assembler and report statistics
-func receive(userConfigFile **os.File, pullFromPartyId *int, receiveOutputDir *string, expectedNumOfTxs *int) {
+func receive(userConfigFile **os.File, pullFromPartyId *int, receiveOutputDir *string, expectedNumOfTxs *int, txidsFile *string) {
 	// get user config file content given as argument
 	userConfig, err := ReadUserConfig(userConfigFile)
 	if err != nil {
@@ -658,9 +700,82 @@ func receive(userConfigFile **os.File, pullFromPartyId *int, receiveOutputDir *s
 		os.Exit(-1)
 	}
 
-	// pull blocks from the assembler and report statistics to a timestamped CSV file
-	pullBlocksFromAssemblerAndCollectStatistics(userConfig, *pullFromPartyId, *receiveOutputDir, *expectedNumOfTxs)
+	// TX-ID verification: pull blocks immediately (preserving concurrent pulling
+	// and correct latency statistics), accumulating every received tx number into
+	// receivedSet.  After the pull loop finishes we load txids.bin — with a
+	// bounded 60-second wait so a loader that was killed before writing the file
+	// yields a clean "skipped" outcome rather than hanging forever.
+	//
+	// nil / empty txidsFile means verification is disabled — no behaviour change.
+	var receivedSet *protectedMap
+	if txidsFile != nil && *txidsFile != "" {
+		receivedSet = &protectedMap{keyValMap: make(map[string]bool)}
+	}
+
+	// pull blocks from the assembler and report statistics to a timestamped CSV file.
+	// When receivedSet is non-nil, every received tx number is added to it as blocks arrive.
+	pullBlocksFromAssemblerAndCollectStatistics(userConfig, *pullFromPartyId, *receiveOutputDir, *expectedNumOfTxs, receivedSet)
 	logger.Infof("Receive command finished, statistics can be found in the output directory: %v\n", *receiveOutputDir)
+
+	// TX-ID verification: now that pulling is done, load txids.bin and compare.
+	if receivedSet != nil {
+		// Wait up to 60 s for the loader to write txids.bin.  The loader writes
+		// the file only after its send loop completes.  On a normal run the file
+		// is already present by the time we reach here; on a run where the loader
+		// was killed before finishing (e.g. duration-limited failure tests) the
+		// file will never appear and we skip verification rather than blocking.
+		const txidsWaitTimeout = 60 * time.Second
+		deadline := time.Now().Add(txidsWaitTimeout)
+		fileFound := false
+		for time.Now().Before(deadline) {
+			if _, statErr := os.Stat(*txidsFile); statErr == nil {
+				fileFound = true
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		if !fileFound {
+			logger.Infof("⚠️  TX-ID verification skipped: loader did not write %s within %s (loader may have been stopped before finishing)", *txidsFile, txidsWaitTimeout)
+			return
+		}
+
+		expectedMap, loadErr := loadTxidsFile(*txidsFile)
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to load txids file %s: %v\n", *txidsFile, loadErr)
+			os.Exit(3)
+		}
+		logger.Infof("TX-ID verification: loaded %d expected TX-IDs from %s, received %d unique TX-IDs", expectedMap.Size(), *txidsFile, receivedSet.Size())
+
+		// Find expected IDs that were never seen in any received block.
+		var missingKeys []string
+		for _, key := range expectedMap.Keys() {
+			if !receivedSet.Contains(key) {
+				missingKeys = append(missingKeys, key)
+			}
+		}
+
+		if len(missingKeys) == 0 {
+			logger.Infof("✅ TX-ID verification passed: all transactions were received")
+		} else {
+			missingFile := path.Join(*receiveOutputDir, "missing_txids.txt")
+			if writeErr := writeMissingTxidsFile(missingFile, missingKeys); writeErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to write missing txids file: %v\n", writeErr)
+			}
+			fmt.Fprintf(os.Stderr, "❌ TX-ID verification FAILED: %d transactions were not received — see %s\n", len(missingKeys), missingFile)
+			// Print a sample of missing TX-IDs directly to stderr so they appear in the
+			// receiver log and can be searched across component logs (grep for the tx number).
+			sampleSize := 10
+			if len(missingKeys) < sampleSize {
+				sampleSize = len(missingKeys)
+			}
+			fmt.Fprintf(os.Stderr, "   First %d missing TX-IDs (search these in component logs):\n", sampleSize)
+			for _, k := range missingKeys[:sampleSize] {
+				fmt.Fprintf(os.Stderr, "   missing txid: %s\n", k)
+			}
+			os.Exit(1)
+		}
+	}
 }
 
 func nextSeekInfo(startSeq uint64) *ab.SeekInfo {
@@ -752,7 +867,7 @@ func sendTxToRouters(userConfig *UserConfig, numOfTxs int, rate int, txSize int,
 	}
 }
 
-func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFromPartyId int, receiveOutputDir string, expectedNumOfTxs int) {
+func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFromPartyId int, receiveOutputDir string, expectedNumOfTxs int, receivedSet *protectedMap) {
 	serverRootCAs := append([][]byte{}, userConfig.TLSCACerts...)
 
 	// create a gRPC connection to the assembler
@@ -944,6 +1059,11 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 				}
 				logger.Debugf("tx %x was received from the assembler", data)
 
+				// TX-ID verification: record this tx number in the received set (when enabled)
+				if receivedSet != nil {
+					receivedSet.Add(extractTxNumber(data))
+				}
+
 				// extract the tx size, sending time and calculate the delay, add the delay to sumOfDelayTimes
 				sumOfTxsSize += len(protoutil.MarshalOrPanic(env))
 				delay := calculateDelayOfTx(data, blockWithTime.acceptedTime)
@@ -952,6 +1072,21 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 			statisticsAggregator.Add(txs, 1, sumOfDelayTimes, sumOfTxsSize)
 
 			if expectedNumOfTxs > 0 && expectedNumOfTxs <= txsTotal {
+				// Drain any blocks already queued in the channel before stopping,
+				// so every pulled TX is recorded in receivedSet before verification runs.
+				for len(blockChan) > 0 {
+					remaining := <-blockChan
+					for j := 0; j < len(remaining.block.Data.Data); j++ {
+						if receivedSet != nil {
+							env, envErr := protoutil.GetEnvelopeFromBlock(remaining.block.Data.Data[j])
+							if envErr == nil {
+								if d, dErr := tx.GetDataFromEnvelope(env); dErr == nil {
+									receivedSet.Add(extractTxNumber(d))
+								}
+							}
+						}
+					}
+				}
 				logger.Infof("%d txs were expected and overall %d were successfully received", expectedNumOfTxs, txsTotal)
 				close(stopChan)
 				waitToFinish.Done()
@@ -962,6 +1097,80 @@ func pullBlocksFromAssemblerAndCollectStatistics(userConfig *UserConfig, pullFro
 
 	waitToFinish.Wait()
 	logger.Debugf("exit pulling blocks from the assembler")
+}
+
+// ---------------------------------------------------------------------------
+// TX-ID verification helpers
+// ---------------------------------------------------------------------------
+
+// writeTxidsFile writes txCount 8-byte big-endian txNumbers (0..txCount-1) to path.
+// Uses a buffered writer to avoid one syscall per transaction.
+func writeTxidsFile(filePath string, txCount int) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	buf := make([]byte, 8)
+	for i := 0; i < txCount; i++ {
+		binary.BigEndian.PutUint64(buf, uint64(i))
+		if _, err := w.Write(buf); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// loadTxidsFile reads a binary txids file (8 bytes per txNumber) into a protectedMap.
+// The map key is the decimal string representation of the txNumber.
+// Uses a buffered reader to avoid one syscall per transaction.
+func loadTxidsFile(filePath string) (*protectedMap, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r := bufio.NewReader(f)
+	pm := &protectedMap{keyValMap: make(map[string]bool)}
+	buf := make([]byte, 8)
+	for {
+		_, err := io.ReadFull(r, buf)
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		txNum := binary.BigEndian.Uint64(buf)
+		pm.Add(strconv.FormatUint(txNum, 10))
+	}
+	return pm, nil
+}
+
+// extractTxNumber reads the first 8 bytes of payload.Data as a big-endian uint64
+// and returns its decimal string — used as the map key matching writeTxidsFile.
+func extractTxNumber(data []byte) string {
+	if len(data) < 8 {
+		return ""
+	}
+	return strconv.FormatUint(binary.BigEndian.Uint64(data[:8]), 10)
+}
+
+// writeMissingTxidsFile writes the remaining (un-received) txNumber strings to a
+// human-readable text file, one decimal number per line.
+func writeMissingTxidsFile(filePath string, keys []string) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, k := range keys {
+		if _, err := fmt.Fprintln(f, k); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func pullBlock(stream ab.AtomicBroadcast_DeliverClient, endpointToPullFrom string) (*common.Block, error) {

--- a/common/tools/armageddon/armageddon_test.go
+++ b/common/tools/armageddon/armageddon_test.go
@@ -1093,3 +1093,98 @@ func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
+
+// Scenario:
+//  1. Create a config YAML file to be an input to armageddon
+//  2. Run armageddon generate command to create config files in a folder structure
+//  3. Run arma with the generated config files to run each of the nodes for all parties
+//  4. Run armageddon load command with --txidsFile — sends 1000 txs and writes the binary TX-ID file
+//  5. In parallel, run armageddon receive command with --txidsFile — reads the TX-ID file and verifies all TXs were received
+//  6. Assert that the TX-ID file exists and has the correct size (1000 × 8 bytes)
+//  7. Assert that missing_txids.txt does NOT exist (all TXs received)
+//
+// This test verifies the end-to-end TX-ID verification flow on a straight happy-path run
+// (no failures injected). It runs against a 4-party 2-shard network without TLS.
+func TestLoadAndReceiveWithTxIDVerification(t *testing.T) {
+	dir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// 1.
+	configPath := filepath.Join(dir, "config.yaml")
+	netInfo := testutil.CreateNetwork(t, configPath, 4, 2, "none", "none")
+	defer netInfo.CleanUp()
+
+	// 2.
+	armageddonCLI := armageddon.NewCLI()
+	sampleConfigPath := fabric.GetDevConfigDir()
+	armageddonCLI.Run([]string{"generate", "--config", configPath, "--output", dir, "--sampleConfigPath", sampleConfigPath})
+
+	// 3.
+	armaBinaryPath, err := gexec.BuildWithEnvironment("github.com/hyperledger/fabric-x-orderer/cmd/arma", []string{"GOPRIVATE=" + os.Getenv("GOPRIVATE")})
+	require.NoError(t, err)
+	require.NotNil(t, armaBinaryPath)
+
+	readyChan := make(chan string, 20)
+	armaNetwork := testutil.RunArmaNodes(t, dir, armaBinaryPath, readyChan, netInfo)
+	defer armaNetwork.Stop()
+
+	testutil.WaitReady(t, readyChan, 20, 10)
+
+	// 4. + 5.
+	userConfigPath := path.Join(dir, "config", fmt.Sprintf("party%d", 1), "user_config.yaml")
+	txidsFilePath := filepath.Join(dir, "txids.bin")
+	outputDir := filepath.Join(dir, "receiver_output")
+	require.NoError(t, os.MkdirAll(outputDir, 0o755))
+
+	const numTxs = 1000
+	txs := fmt.Sprintf("%d", numTxs)
+	rate := "500"
+	txSize := "300"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Use separate CLI instances to avoid a data race on shared flag destinations
+	// when load and receive run concurrently (cli.app.Parse writes to shared fields).
+	loaderCLI := armageddon.NewCLI()
+	receiverCLI := armageddon.NewCLI()
+
+	// load writes txids.bin after all transactions are sent
+	go func() {
+		defer wg.Done()
+		loaderCLI.Run([]string{
+			"load",
+			"--config", userConfigPath,
+			"--transactions", txs,
+			"--rate", rate,
+			"--txSize", txSize,
+			"--txidsFile", txidsFilePath,
+		})
+	}()
+
+	// receive pulls blocks immediately; verifies TX-IDs after pulling is done
+	go func() {
+		defer wg.Done()
+		receiverCLI.Run([]string{
+			"receive",
+			"--config", userConfigPath,
+			"--pullFromPartyId", "1",
+			"--expectedTxs", txs,
+			"--output", outputDir,
+			"--txidsFile", txidsFilePath,
+		})
+	}()
+
+	wg.Wait()
+
+	// 6. TX-ID file must exist and contain exactly numTxs × 8 bytes
+	info, err := os.Stat(txidsFilePath)
+	require.NoError(t, err, "txids.bin should have been written by the loader")
+	require.Equal(t, int64(numTxs*8), info.Size(), "txids.bin should contain exactly %d × 8 bytes", numTxs)
+
+	// 7. missing_txids.txt must NOT exist — all transactions were received
+	missingFile := filepath.Join(outputDir, "missing_txids.txt")
+	_, statErr := os.Stat(missingFile)
+	require.True(t, os.IsNotExist(statErr), "missing_txids.txt should not exist when all TXs are received")
+}

--- a/docs/cli/armageddon.md
+++ b/docs/cli/armageddon.md
@@ -125,6 +125,9 @@ Flags:
   --signedMode=SIGNEDMODE      Signing mode has three option: none = unsigned,
                                full = sign including the full certificate,
                                short = sign using known certificate
+  --txidsFile=""               (Optional) path to write the binary TX-ID file —
+                               when set, the loader writes one 8-byte big-endian
+                               txNumber per TX after all transactions are sent
 ```
 
 
@@ -143,6 +146,10 @@ Flags:
   --output="."      The output directory in which to place statistics file
   --pullFromPartyId=PULLFROMPARTYID
                     The party id of the assembler to pull blocks from
+  --txidsFile=""    (Optional) path to the binary TX-ID file written by the
+                    loader — when set, the receiver verifies every TX-ID was
+                    received; exits 1 and writes missing_txids.txt if any are
+                    missing
 ```
 
 

--- a/test/deterministic-failure-test/README.md
+++ b/test/deterministic-failure-test/README.md
@@ -25,7 +25,7 @@ It defines the following internal functions, then calls `main`:
 - **`start_arma_network`** — Starts all ARMA network components in the correct order: consenters first, then batchers, assemblers, and routers. Stores each process PID under the test directory.
 - **`run_failure_runner`** — Stops and restarts ARMA components one party at a time in a continuous loop until the stop signal is received. For each party it kills and restarts: assembler, consenter, router, then all batchers in shard order. After each full party cycle it writes a signal file so `monitor_completion` knows to print a status snapshot.
 - **`monitor_completion`** — Monitors test execution. In failure runner mode: prints a status snapshot after each party's full failure cycle completes. Without failure runner: prints a status snapshot every 5 minutes. Always stops when the configured duration is reached or when the loader and all receivers finish early. After duration expires, stops the loader immediately then gives receivers a 30-second drain window to pull remaining blocks from the assemblers before killing them.
-- **`collect_results`** — Cleans the `test-results/` directory from any previous run, then extracts loader and receiver statistics, copies all component and loader/receiver logs into `test-results/logs/` and compresses them with gzip, collects receiver statistics CSV files, and creates a summary report.
+- **`collect_results`** — Cleans the `test-results/` directory from any previous run, then extracts loader and receiver statistics, copies all component and loader/receiver logs into `test-results/logs/` and compresses them with gzip, collects receiver statistics CSV files, creates a summary report, and performs TX-ID verification (see [TX-ID Verification](#tx-id-verification)).
 - **`main`** — Reads configuration from environment variables, removes stale log files from previous runs, generates the network config YAML, runs `armageddon generate` to produce all crypto and config files, patches the generated FileStore `Location` and consenter `WALDir` paths to writable temp directories, then calls the functions above in order.
 
 ## Prerequisites
@@ -200,7 +200,28 @@ Steps:
 5. Sets configuration via environment variables.
 6. Runs `test/deterministic-failure-test/deterministic-failure-test.sh`.
 7. Publishes the test summary directly to the workflow run's Summary tab (plain text, no download needed).
-8. Uploads `test-results/` artifacts (statistics and logs — as separate CI artifacts).
+8. Uploads `test-results/` artifacts (statistics, logs, and any `missing_txids_party*.txt` files — as separate CI artifacts).
+9. On failure, reports the reason to Slack — TX-ID verification failures include the per-party missing-TX count and a reference to the artifact.
+
+## TX-ID Verification
+
+At the end of each run the test verifies that every transaction sent by the loader was received by every party's assembler.
+
+**How it works:**
+
+- The loader writes a compact binary file (`txids.bin`) to the test directory after sending all transactions. The file contains one 8-byte big-endian integer per transaction (the 0-based transaction number), making it `N × 8` bytes total.
+- Each receiver pulls blocks immediately (concurrently with the loader, preserving latency statistics). After pulling finishes it waits up to 60 seconds for `txids.bin` to appear, then compares the set of received tx numbers against the expected set. Any tx number in the file but never seen in a block is reported as missing. If `txids.bin` never appears (e.g. the loader was killed before finishing), verification is skipped rather than blocking.
+- `collect_results` checks for `missing_txids.txt` per party and reports one of three outcomes:
+
+| Outcome | Condition | Summary line |
+| ------- | --------- | ------------ |
+| ✅ Verified | Receiver completed and no missing TXs | `TX-IDs verified` |
+| ❌ Failed | Receiver completed but missing TXs found | `N TX-IDs missing → see missing_txids_party<N>.txt` |
+| ⚠️ Unverified | Receiver was stopped by timeout before completing | `TX-IDs skipped` |
+
+A TX-ID verification failure overrides the overall test status to `❌ FAILED` regardless of transaction counts, and the `failure_reason.txt` file is written with the per-party detail so the Slack notification includes the exact cause.
+
+**This feature is opt-in for manual use:** the `--txidsFile` flag on both `armageddon load` and `armageddon receive` is optional with no default. Not passing it preserves identical behavior to previous versions.
 
 ## Manual Workflow Trigger
 

--- a/test/deterministic-failure-test/deterministic-failure-test.sh
+++ b/test/deterministic-failure-test/deterministic-failure-test.sh
@@ -662,104 +662,112 @@ collect_results() {
 
   # Create summary report
   echo "Creating summary report..."
-  cat > test-results/summary.txt <<EOF
-========================================
-Deterministic Failure Test Summary
-========================================
-Date: $(date)
-Duration: ${DURATION} minutes
-TX Rate: ${TX_RATE} tx/s
-TX Size: ${TX_SIZE} bytes
-Total TXs Expected: $((DURATION * 60 * TX_RATE))
-Parties: ${NUM_PARTIES}
-Shards: ${NUM_SHARDS}
-Failure Runner Enabled: ${FAILURE_RUNNER_ENABLED}
 
-========================================
-Loader Results
-========================================
-EOF
-
-  # Use pre-extracted statistics
-  if [ "$LOADER_STATUS" = "completed" ]; then
-    echo "✅ Loader completed" >> test-results/summary.txt
-    echo "Sent: ${SENT:-unknown} transactions" >> test-results/summary.txt
-  else
-    echo "⏰ Loader stopped by timeout" >> test-results/summary.txt
-    echo "Sent: ${SENT:-0} transactions (incomplete)" >> test-results/summary.txt
-  fi
-
-  cat >> test-results/summary.txt <<EOF
-
-========================================
-Receiver Results
-========================================
-EOF
-
-  # Use pre-extracted receiver statistics
-  local TOTAL_RECEIVED=0
-  local REPRESENTATIVE_RECEIVED
-  for i in $(seq 1 $NUM_PARTIES); do
-    echo "Party ${i}:" >> test-results/summary.txt
-
-    local RECEIVED="${RECEIVER_STATS[$i]}"
-    local STATUS="${RECEIVER_STATUS[$i]}"
-
-    if [ "$STATUS" = "completed" ]; then
-      echo "  ✅ Completed - Received: ${RECEIVED} txs" >> test-results/summary.txt
-      if [ -n "$RECEIVED" ] && [ "$RECEIVED" != "unknown" ] && [ "$RECEIVED" -gt 0 ] 2>/dev/null; then
-        TOTAL_RECEIVED=$((TOTAL_RECEIVED + RECEIVED))
-      fi
-    elif [ "$STATUS" = "timeout" ]; then
-      # Get block count from CSV
-      if [ -f "${TEST_DIR}/output${i}/statistics.csv" ]; then
-        local BLOCKS=$(tail -n +2 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | wc -l)
-        echo "  ⏰ Stopped by timeout - Received: ${RECEIVED} txs in ${BLOCKS} blocks" >> test-results/summary.txt
-      else
-        echo "  ⏰ Stopped by timeout - Received: ${RECEIVED} txs" >> test-results/summary.txt
-      fi
-      if [ -n "$RECEIVED" ] && [ "$RECEIVED" -gt 0 ] 2>/dev/null; then
-        TOTAL_RECEIVED=$((TOTAL_RECEIVED + RECEIVED))
-      fi
-    else
-      echo "  ❌ No statistics available" >> test-results/summary.txt
-    fi
-  done
-
-  # Overall statistics: each party independently receives all sent txs, so the
-  # meaningful metric is per-party success rate, not a cross-party sum.
+  # Compute representative received count (first party with non-zero data)
   local PARTY_SUCCESS_RATE=0
-  REPRESENTATIVE_RECEIVED=${RECEIVER_STATS[1]:-0}
+  local REPRESENTATIVE_RECEIVED=${RECEIVER_STATS[1]:-0}
   if [ -n "$SENT" ] && [ "$SENT" -gt 0 ]; then
-    # Use the first party as representative received count
     if [ -n "$REPRESENTATIVE_RECEIVED" ] && [ "$REPRESENTATIVE_RECEIVED" -gt 0 ] 2>/dev/null; then
       PARTY_SUCCESS_RATE=$((REPRESENTATIVE_RECEIVED * 100 / SENT))
     fi
   fi
 
-  cat >> test-results/summary.txt <<EOF
+  # TX-ID verification — check each party's missing_txids.txt written by armageddon
+  local TX_VERIFY_FAILED=false
+  declare -a TX_VERIFY_LINES
+  for i in $(seq 1 $NUM_PARTIES); do
+    local STATUS="${RECEIVER_STATUS[$i]}"
+    if [ "$STATUS" = "completed" ]; then
+      local MISSING_FILE="${TEST_DIR}/output${i}/missing_txids.txt"
+      if [ -f "$MISSING_FILE" ] && [ -s "$MISSING_FILE" ]; then
+        local MISSING_COUNT=$(wc -l < "$MISSING_FILE")
+        TX_VERIFY_FAILED=true
+        cp "$MISSING_FILE" test-results/missing_txids_party${i}.txt
+        TX_VERIFY_LINES[$i]="  ❌  ${MISSING_COUNT} TX-IDs missing → see missing_txids_party${i}.txt"
+      else
+        TX_VERIFY_LINES[$i]="verified"
+      fi
+    else
+      TX_VERIFY_LINES[$i]="skipped"
+    fi
+  done
 
-========================================
-Overall Statistics
-========================================
-Sent: ${SENT:-0} transactions
-Expected per party: ${SENT:-0} transactions
-Received per party: ${REPRESENTATIVE_RECEIVED:-0} transactions
-Success Rate: ${PARTY_SUCCESS_RATE}%
-EOF
-
-  # Create a simple pass/fail indicator
-  echo "" >> test-results/summary.txt
-  echo "========================================" >> test-results/summary.txt
-  echo "Test Status" >> test-results/summary.txt
-  echo "========================================" >> test-results/summary.txt
-
-  if [ -n "$SENT" ] && [ "$SENT" -gt 0 ] && [ "${REPRESENTATIVE_RECEIVED:-0}" -gt 0 ] 2>/dev/null; then
-    echo "✅ PASSED - Test ran for ${DURATION} minutes" >> test-results/summary.txt
-    echo "   Sent: ${SENT} txs, each party received: ${REPRESENTATIVE_RECEIVED} txs (${PARTY_SUCCESS_RATE}%)" >> test-results/summary.txt
-  else
-    echo "❌ FAILED - No transactions processed" >> test-results/summary.txt
+  # Write machine-readable failure reason when TX verification fails (consumed by Slack step)
+  if [ "$TX_VERIFY_FAILED" = "true" ]; then
+    local REASON_PARTS=""
+    for i in $(seq 1 $NUM_PARTIES); do
+      if [ -f "test-results/missing_txids_party${i}.txt" ]; then
+        local CNT=$(wc -l < "test-results/missing_txids_party${i}.txt")
+        REASON_PARTS="${REASON_PARTS}party ${i}: ${CNT} missing TXs; "
+      fi
+    done
+    echo "TX-ID verification failed: ${REASON_PARTS}(see missing_txids_party*.txt artifacts)" \
+      > test-results/failure_reason.txt
   fi
+
+  # Determine loader status label
+  local LOADER_LABEL
+  if [ "$LOADER_STATUS" = "completed" ]; then
+    LOADER_LABEL="✅ ${SENT:-unknown} transactions sent"
+  else
+    LOADER_LABEL="⏰ ${SENT:-0} transactions sent (incomplete)"
+  fi
+
+  # Determine final verdict line
+  local VERDICT_LINE
+  if [ "$TX_VERIFY_FAILED" = "true" ]; then
+    VERDICT_LINE="❌ FAILED — TX-ID verification failed (see missing_txids_party*.txt artifacts)"
+  elif [ -n "$SENT" ] && [ "$SENT" -gt 0 ] && [ "${REPRESENTATIVE_RECEIVED:-0}" -gt 0 ] 2>/dev/null; then
+    VERDICT_LINE="✅ PASSED — Test ran for ${DURATION} minutes"
+  else
+    VERDICT_LINE="❌ FAILED — No transactions processed"
+  fi
+
+  {
+    echo "=========================================="
+    echo "Deterministic Failure Test — Summary"
+    echo "=========================================="
+    echo "Date     : $(date)"
+    echo "Duration : ${DURATION} minutes  |  Rate: ${TX_RATE} tx/s  |  Size: ${TX_SIZE} bytes"
+    echo "Network  : ${NUM_PARTIES} parties, ${NUM_SHARDS} shards  |  Failure runner: ${FAILURE_RUNNER_ENABLED}"
+    echo ""
+    echo "Sent: ${SENT:-0} transactions"
+    echo ""
+    for i in $(seq 1 $NUM_PARTIES); do
+      local RECEIVED="${RECEIVER_STATS[$i]}"
+      local STATUS="${RECEIVER_STATUS[$i]}"
+      local TXID_LINE="${TX_VERIFY_LINES[$i]}"
+      local STATUS_ICON RECEIVED_LABEL TXID_SUFFIX
+      if [ "$STATUS" = "completed" ]; then
+        if [ "$TXID_LINE" = "verified" ] || [ "$TXID_LINE" = "skipped" ]; then
+          STATUS_ICON="✅"
+          RECEIVED_LABEL="received: ${RECEIVED}  sent: ${SENT:-0}  (${PARTY_SUCCESS_RATE}%)"
+          if [ "$TXID_LINE" = "verified" ]; then
+            TXID_SUFFIX="  TX-IDs verified"
+          else
+            TXID_SUFFIX="  TX-IDs skipped"
+          fi
+        else
+          # TX-ID verification failed — omit the misleading percentage
+          STATUS_ICON="❌"
+          RECEIVED_LABEL="received: ${RECEIVED}  sent: ${SENT:-0}"
+          TXID_SUFFIX="  ${TXID_LINE}"
+        fi
+      elif [ "$STATUS" = "timeout" ]; then
+        STATUS_ICON="⏰"
+        RECEIVED_LABEL="received: ${RECEIVED}  sent: ${SENT:-0}  (incomplete)"
+        TXID_SUFFIX="  TX-IDs skipped"
+      else
+        STATUS_ICON="❌"
+        RECEIVED_LABEL="no data"
+        TXID_SUFFIX=""
+      fi
+      echo "  Party ${i}  ${STATUS_ICON}  ${RECEIVED_LABEL}${TXID_SUFFIX}"
+    done
+    echo ""
+    echo "${VERDICT_LINE}"
+    echo "=========================================="
+  } > test-results/summary.txt
 
   echo "=========================================="
   echo "✅ Results collected in test-results/"
@@ -893,6 +901,7 @@ EOF
       --pullFromPartyId=${i} \
       --expectedTxs=${TOTAL_TXS} \
       --output=${TEST_DIR}/output${i} \
+      --txidsFile=${TEST_DIR}/txids.bin \
       >> receiver${i}.log 2>&1 &
     echo "Started receiver for party ${i} (PID: $!)"
   done
@@ -904,6 +913,7 @@ EOF
     --transactions=${TOTAL_TXS} \
     --rate=${TX_RATE} \
     --txSize=${TX_SIZE} \
+    --txidsFile=${TEST_DIR}/txids.bin \
     >> loader.log 2>&1 &
   local LOADER_PID=$!
   echo "Started loader (PID: ${LOADER_PID})"
@@ -945,6 +955,17 @@ EOF
   echo "Cleaning up processes..."
   pkill -f "arma " || true
   pkill -f "armageddon" || true
+
+  # Remove log files from the working directory — they are already preserved
+  # under test-results/logs/ (gzipped) so the originals are no longer needed.
+  rm -f loader.log
+  for i in $(seq 1 $NUM_PARTIES); do
+    rm -f receiver${i}.log
+    rm -f consenter${i}.log assembler${i}.log router${i}.log
+    for j in $(seq 1 $NUM_SHARDS); do
+      rm -f batcher${i}-${j}.log
+    done
+  done
 
   echo "=========================================="
   echo "✅ Deterministic failure test completed successfully!"

--- a/test/fully-randomized-failure-test/README.md
+++ b/test/fully-randomized-failure-test/README.md
@@ -27,7 +27,7 @@ It defines the following internal functions, then calls `main`:
 - **`start_arma_network`** — Starts all ARMA network components in the correct order: consenters first, then batchers, assemblers, and routers. Stores each process PID under the test directory.
 - **`run_failure_runner`** — Builds a flat pool of every component across all parties (`NUM_PARTIES × (3 + NUM_SHARDS)` entries). On each iteration, picks one entry at random using `$RANDOM`, kills it, waits `FAILURE_RUNNER_STOP_DURATION` seconds, restarts it, then waits `FAILURE_RUNNER_RESTART_WAIT` seconds. After every `N = 3 + NUM_SHARDS` kills a signal file is written so `monitor_completion` knows to print a status snapshot. A running kill counter is maintained in the test directory.
 - **`monitor_completion`** — Monitors test execution. In failure runner mode: prints a status snapshot after every `N = 3 + NUM_SHARDS` kills. Without failure runner: prints a status snapshot every 5 minutes. Always stops when the configured duration is reached or when the loader and all receivers finish early. After duration expires, stops the loader immediately then gives receivers a 30-second drain window to pull remaining blocks from the assemblers before killing them.
-- **`collect_results`** — Cleans the `test-results/` directory from any previous run, then extracts loader and receiver statistics, copies all component and loader/receiver logs into `test-results/logs/` and compresses them with gzip, collects receiver statistics CSV files, creates `summary.txt`, and creates `summary-kills.txt` with a per-component and total kill count report.
+- **`collect_results`** — Cleans the `test-results/` directory from any previous run, then extracts loader and receiver statistics, copies all component and loader/receiver logs into `test-results/logs/` and compresses them with gzip, collects receiver statistics CSV files, creates `summary.txt`, creates `summary-kills.txt` with a per-component and total kill count report, and performs TX-ID verification (see [TX-ID Verification](#tx-id-verification)).
 - **`main`** — Reads configuration from environment variables, removes stale log files from previous runs, generates the network config YAML, runs `armageddon generate` to produce all crypto and config files, patches the generated FileStore `Location` and consenter `WALDir` paths to writable temp directories, then calls the functions above in order.
 
 ## Prerequisites
@@ -187,11 +187,32 @@ Result artifacts are written to (cleaned at the start of each run):
 
 ```text
 test-results/
-├── logs/              # component and loader/receiver logs (gzipped)
-├── statistics/        # per-party statistics CSV files
-├── summary.txt        # pass/fail, tx counts, and total kill count
-└── summary-kills.txt  # per-component kill counts and overall total
+├── logs/                        # component and loader/receiver logs (gzipped)
+├── statistics/                  # per-party statistics CSV files
+├── summary.txt                  # pass/fail, tx counts, TX-ID verification results, and total kill count
+├── summary-kills.txt            # per-component kill counts and overall total
+└── missing_txids_party<N>.txt   # (only present on TX-ID verification failure) un-received TX numbers
 ```
+
+## TX-ID Verification
+
+At the end of each run the test verifies that every transaction sent by the loader was received by every party's assembler.
+
+**How it works:**
+
+- The loader writes a compact binary file (`txids.bin`) to the test directory after sending all transactions. The file contains one 8-byte big-endian integer per transaction (the 0-based transaction number), making it `N × 8` bytes total.
+- Each receiver pulls blocks immediately (concurrently with the loader, preserving latency statistics). After pulling finishes it waits up to 60 seconds for `txids.bin` to appear, then compares the set of received tx numbers against the expected set. Any tx number in the file but never seen in a block is reported as missing. If `txids.bin` never appears (e.g. the loader was killed before finishing), verification is skipped rather than blocking.
+- `collect_results` checks for `missing_txids.txt` per party and reports one of three outcomes:
+
+| Outcome | Condition | Summary line |
+| ------- | --------- | ------------ |
+| ✅ Verified | Receiver completed and no missing TXs | `TX-IDs verified` |
+| ❌ Failed | Receiver completed but missing TXs found | `N TX-IDs missing → see missing_txids_party<N>.txt` |
+| ⚠️ Unverified | Receiver was stopped by timeout before completing | `TX-IDs skipped` |
+
+A TX-ID verification failure overrides the overall test status to `❌ FAILED` regardless of transaction counts, and the `failure_reason.txt` file is written with the per-party detail so the Slack notification includes the exact cause.
+
+**This feature is opt-in for manual use:** the `--txidsFile` flag on both `armageddon load` and `armageddon receive` is optional with no default. Not passing it preserves identical behavior to previous versions.
 
 ### `summary-kills.txt`
 

--- a/test/fully-randomized-failure-test/fully-randomized-failure-test.sh
+++ b/test/fully-randomized-failure-test/fully-randomized-failure-test.sh
@@ -766,69 +766,8 @@ collect_results() {
   # Create main summary report
   # ---------------------------------------------------------------------------
   echo "Creating summary report..."
-  cat > test-results/summary.txt <<EOF
-========================================
-Fully Randomized Failure Test Summary
-========================================
-Date: $(date)
-Duration: ${DURATION} minutes
-TX Rate: ${TX_RATE} tx/s
-TX Size: ${TX_SIZE} bytes
-Total TXs Expected: $((DURATION * 60 * TX_RATE))
-Parties: ${NUM_PARTIES}
-Shards: ${NUM_SHARDS}
-Failure Runner Enabled: ${FAILURE_RUNNER_ENABLED}
 
-========================================
-Loader Results
-========================================
-EOF
-
-  if [ "$LOADER_STATUS" = "completed" ]; then
-    echo "✅ Loader completed" >> test-results/summary.txt
-    echo "Sent: ${SENT:-unknown} transactions" >> test-results/summary.txt
-  else
-    echo "⏰ Loader stopped by timeout" >> test-results/summary.txt
-    echo "Sent: ${SENT:-0} transactions (incomplete)" >> test-results/summary.txt
-  fi
-
-  cat >> test-results/summary.txt <<EOF
-
-========================================
-Receiver Results
-========================================
-EOF
-
-  local TOTAL_RECEIVED=0
-  local REPRESENTATIVE_RECEIVED
-  for i in $(seq 1 $NUM_PARTIES); do
-    echo "Party ${i}:" >> test-results/summary.txt
-
-    local RECEIVED="${RECEIVER_STATS[$i]}"
-    local STATUS="${RECEIVER_STATUS[$i]}"
-
-    if [ "$STATUS" = "completed" ]; then
-      echo "  ✅ Completed - Received: ${RECEIVED} txs" >> test-results/summary.txt
-      if [ -n "$RECEIVED" ] && [ "$RECEIVED" != "unknown" ] && [ "$RECEIVED" -gt 0 ] 2>/dev/null; then
-        TOTAL_RECEIVED=$((TOTAL_RECEIVED + RECEIVED))
-      fi
-    elif [ "$STATUS" = "timeout" ]; then
-      if [ -f "${TEST_DIR}/output${i}/statistics.csv" ]; then
-        local BLOCKS=$(tail -n +4 "${TEST_DIR}/output${i}/statistics.csv" 2>/dev/null | awk -F',' '{sum+=$3} END {print sum+0}')
-        echo "  ⏰ Stopped by timeout - Received: ${RECEIVED} txs in ${BLOCKS} blocks" >> test-results/summary.txt
-      else
-        echo "  ⏰ Stopped by timeout - Received: ${RECEIVED} txs" >> test-results/summary.txt
-      fi
-      if [ -n "$RECEIVED" ] && [ "$RECEIVED" -gt 0 ] 2>/dev/null; then
-        TOTAL_RECEIVED=$((TOTAL_RECEIVED + RECEIVED))
-      fi
-    else
-      echo "  ❌ No statistics available" >> test-results/summary.txt
-    fi
-  done
-
-  # Overall statistics: use the first party that has a non-zero received count
-  # as the representative value (party 1 may have no data if it was mid-kill).
+  # Compute representative received count (first party with non-zero data)
   local PARTY_SUCCESS_RATE=0
   local REPRESENTATIVE_RECEIVED=0
   for i in $(seq 1 $NUM_PARTIES); do
@@ -844,79 +783,145 @@ EOF
     fi
   fi
 
-  cat >> test-results/summary.txt <<EOF
-
-========================================
-Overall Statistics
-========================================
-Sent: ${SENT:-0} transactions
-Expected per party: ${SENT:-0} transactions
-Received per party: ${REPRESENTATIVE_RECEIVED:-0} transactions
-Success Rate: ${PARTY_SUCCESS_RATE}%
-EOF
-
-  echo "" >> test-results/summary.txt
-  echo "========================================" >> test-results/summary.txt
-  echo "Kill Summary (see summary-kills.txt for full detail)" >> test-results/summary.txt
-  echo "========================================" >> test-results/summary.txt
-  echo "Total kills during run: $(cat "${TEST_DIR}/kill_counter" 2>/dev/null || echo "${TOTAL_KILLS}")" >> test-results/summary.txt
-
-  echo "" >> test-results/summary.txt
-  echo "========================================" >> test-results/summary.txt
-  echo "Test Status" >> test-results/summary.txt
-  echo "========================================" >> test-results/summary.txt
-
-  if [ -n "$SENT" ] && [ "$SENT" -gt 0 ] && [ "${REPRESENTATIVE_RECEIVED:-0}" -gt 0 ] 2>/dev/null; then
-    echo "✅ PASSED - Test ran for ${DURATION} minutes" >> test-results/summary.txt
-    echo "   Sent: ${SENT} txs, representative party received: ${REPRESENTATIVE_RECEIVED} txs (${PARTY_SUCCESS_RATE}%)" >> test-results/summary.txt
-  elif [ -n "$SENT" ] && [ "$SENT" -gt 0 ]; then
-    echo "⚠️  PARTIAL - Loader sent ${SENT} txs but no receiver completed (all were mid-kill at drain time)" >> test-results/summary.txt
-  else
-    echo "❌ FAILED - No transactions processed" >> test-results/summary.txt
-  fi
-
-  # ---------------------------------------------------------------------------
-  # Create kill report: summary-kills.txt
-  # ---------------------------------------------------------------------------
-  echo "Creating kill report..."
-  cat > test-results/summary-kills.txt <<EOF
-========================================
-Fully Randomized Failure Test — Kill Report
-========================================
-Date: $(date)
-Duration: ${DURATION} minutes
-Total components in pool: $((NUM_PARTIES * (3 + NUM_SHARDS))) (${NUM_PARTIES} parties × $((3 + NUM_SHARDS)) components each)
-
-========================================
-Per-Component Kill Counts
-========================================
-EOF
-
+  # TX-ID verification — check each party's missing_txids.txt written by armageddon
+  local TX_VERIFY_FAILED=false
+  declare -a TX_VERIFY_LINES
   for i in $(seq 1 $NUM_PARTIES); do
-    echo "Party ${i}:" >> test-results/summary-kills.txt
-    echo "  assembler  party ${i}:          ${KILL_COUNTS[assembler_party${i}]:-0} kills" >> test-results/summary-kills.txt
-    echo "  consenter  party ${i}:          ${KILL_COUNTS[consenter_party${i}]:-0} kills" >> test-results/summary-kills.txt
-    echo "  router     party ${i}:          ${KILL_COUNTS[router_party${i}]:-0} kills" >> test-results/summary-kills.txt
-    for j in $(seq 1 $NUM_SHARDS); do
-      echo "  batcher    party ${i} shard ${j}: ${KILL_COUNTS[batcher_party${i}_shard${j}]:-0} kills" >> test-results/summary-kills.txt
-    done
+    local STATUS="${RECEIVER_STATUS[$i]}"
+    if [ "$STATUS" = "completed" ]; then
+      local MISSING_FILE="${TEST_DIR}/output${i}/missing_txids.txt"
+      if [ -f "$MISSING_FILE" ] && [ -s "$MISSING_FILE" ]; then
+        local MISSING_COUNT=$(wc -l < "$MISSING_FILE")
+        TX_VERIFY_FAILED=true
+        cp "$MISSING_FILE" test-results/missing_txids_party${i}.txt
+        TX_VERIFY_LINES[$i]="  ❌  ${MISSING_COUNT} TX-IDs missing → see missing_txids_party${i}.txt"
+      else
+        TX_VERIFY_LINES[$i]="verified"
+      fi
+    else
+      TX_VERIFY_LINES[$i]="skipped"
+    fi
   done
 
-  cat >> test-results/summary-kills.txt <<EOF
+  # Write machine-readable failure reason when TX verification fails (consumed by Slack step)
+  if [ "$TX_VERIFY_FAILED" = "true" ]; then
+    local REASON_PARTS=""
+    for i in $(seq 1 $NUM_PARTIES); do
+      if [ -f "test-results/missing_txids_party${i}.txt" ]; then
+        local CNT=$(wc -l < "test-results/missing_txids_party${i}.txt")
+        REASON_PARTS="${REASON_PARTS}party ${i}: ${CNT} missing TXs; "
+      fi
+    done
+    echo "TX-ID verification failed: ${REASON_PARTS}(see missing_txids_party*.txt artifacts)" \
+      > test-results/failure_reason.txt
+  fi
 
-========================================
-Total kills: ${TOTAL_KILLS}
-========================================
-EOF
+  # Determine final verdict line
+  local VERDICT_LINE
+  if [ "$TX_VERIFY_FAILED" = "true" ]; then
+    VERDICT_LINE="❌ FAILED — TX-ID verification failed (see missing_txids_party*.txt artifacts)"
+  elif [ -n "$SENT" ] && [ "$SENT" -gt 0 ] && [ "${REPRESENTATIVE_RECEIVED:-0}" -gt 0 ] 2>/dev/null; then
+    VERDICT_LINE="✅ PASSED — Test ran for ${DURATION} minutes"
+  elif [ -n "$SENT" ] && [ "$SENT" -gt 0 ]; then
+    VERDICT_LINE="⚠️  PARTIAL — Loader sent ${SENT} txs but no receiver completed (all were mid-kill at drain time)"
+  else
+    VERDICT_LINE="❌ FAILED — No transactions processed"
+  fi
+
+  {
+    echo "=========================================="
+    echo "Fully Randomized Failure Test — Summary"
+    echo "=========================================="
+    echo "Date     : $(date)"
+    echo "Duration : ${DURATION} minutes  |  Rate: ${TX_RATE} tx/s  |  Size: ${TX_SIZE} bytes"
+    echo "Network  : ${NUM_PARTIES} parties, ${NUM_SHARDS} shards  |  Failure runner: ${FAILURE_RUNNER_ENABLED}"
+    echo "Kills    : ${TOTAL_KILLS} total  (details → test-results/summary-kills.txt)"
+    echo ""
+    echo "Per-component kill counts:"
+    for i in $(seq 1 $NUM_PARTIES); do
+      echo "  Party ${i}:"
+      echo "    assembler : ${KILL_COUNTS[assembler_party${i}]:-0} kills"
+      echo "    consenter : ${KILL_COUNTS[consenter_party${i}]:-0} kills"
+      echo "    router    : ${KILL_COUNTS[router_party${i}]:-0} kills"
+      for j in $(seq 1 $NUM_SHARDS); do
+        echo "    batcher-${j} : ${KILL_COUNTS[batcher_party${i}_shard${j}]:-0} kills"
+      done
+    done
+    echo ""
+    echo "Sent: ${SENT:-0} transactions"
+    echo ""
+    for i in $(seq 1 $NUM_PARTIES); do
+      local RECEIVED="${RECEIVER_STATS[$i]}"
+      local STATUS="${RECEIVER_STATUS[$i]}"
+      local TXID_LINE="${TX_VERIFY_LINES[$i]}"
+      local STATUS_ICON RECEIVED_LABEL TXID_SUFFIX
+      if [ "$STATUS" = "completed" ]; then
+        if [ "$TXID_LINE" = "verified" ] || [ "$TXID_LINE" = "skipped" ]; then
+          STATUS_ICON="✅"
+          RECEIVED_LABEL="received: ${RECEIVED}  sent: ${SENT:-0}  (${PARTY_SUCCESS_RATE}%)"
+          if [ "$TXID_LINE" = "verified" ]; then
+            TXID_SUFFIX="  TX-IDs verified"
+          else
+            TXID_SUFFIX="  TX-IDs skipped"
+          fi
+        else
+          # TX-ID verification failed — omit the misleading percentage
+          STATUS_ICON="❌"
+          RECEIVED_LABEL="received: ${RECEIVED}  sent: ${SENT:-0}"
+          TXID_SUFFIX="  ${TXID_LINE}"
+        fi
+      elif [ "$STATUS" = "timeout" ]; then
+        STATUS_ICON="⏰"
+        RECEIVED_LABEL="received: ${RECEIVED}  sent: ${SENT:-0}  (incomplete)"
+        TXID_SUFFIX="  TX-IDs skipped"
+      else
+        STATUS_ICON="❌"
+        RECEIVED_LABEL="no data"
+        TXID_SUFFIX=""
+      fi
+      echo "  Party ${i}  ${STATUS_ICON}  ${RECEIVED_LABEL}${TXID_SUFFIX}"
+    done
+    echo ""
+    echo "${VERDICT_LINE}"
+    echo "=========================================="
+  } > test-results/summary.txt
+
+  # ---------------------------------------------------------------------------
+  # Create kill report: summary-kills.txt (artifact only, not printed to stdout)
+  # ---------------------------------------------------------------------------
+  echo "Creating kill report..."
+  {
+    echo "========================================"
+    echo "Fully Randomized Failure Test — Kill Report"
+    echo "========================================"
+    echo "Date: $(date)"
+    echo "Duration: ${DURATION} minutes"
+    echo "Total components in pool: $((NUM_PARTIES * (3 + NUM_SHARDS))) (${NUM_PARTIES} parties × $((3 + NUM_SHARDS)) components each)"
+    echo ""
+    echo "========================================"
+    echo "Per-Component Kill Counts"
+    echo "========================================"
+    for i in $(seq 1 $NUM_PARTIES); do
+      echo "Party ${i}:"
+      echo "  assembler  party ${i}:          ${KILL_COUNTS[assembler_party${i}]:-0} kills"
+      echo "  consenter  party ${i}:          ${KILL_COUNTS[consenter_party${i}]:-0} kills"
+      echo "  router     party ${i}:          ${KILL_COUNTS[router_party${i}]:-0} kills"
+      for j in $(seq 1 $NUM_SHARDS); do
+        echo "  batcher    party ${i} shard ${j}: ${KILL_COUNTS[batcher_party${i}_shard${j}]:-0} kills"
+      done
+    done
+    echo ""
+    echo "========================================"
+    echo "Total kills: ${TOTAL_KILLS}"
+    echo "========================================"
+  } > test-results/summary-kills.txt
 
   echo "=========================================="
   echo "✅ Results collected in test-results/"
   echo "=========================================="
 
-  # Display both summaries
+  # Display summary only (kill detail is in summary-kills.txt artifact)
   cat test-results/summary.txt
-  echo ""
-  cat test-results/summary-kills.txt
 }
 
 # ---------------------------------------------------------------------------
@@ -1045,6 +1050,7 @@ EOF
       --pullFromPartyId=${i} \
       --expectedTxs=${TOTAL_TXS} \
       --output=${TEST_DIR}/output${i} \
+      --txidsFile=${TEST_DIR}/txids.bin \
       >> receiver${i}.log 2>&1 &
     echo "Started receiver for party ${i} (PID: $!)"
   done
@@ -1056,6 +1062,7 @@ EOF
     --transactions=${TOTAL_TXS} \
     --rate=${TX_RATE} \
     --txSize=${TX_SIZE} \
+    --txidsFile=${TEST_DIR}/txids.bin \
     >> loader.log 2>&1 &
   local LOADER_PID=$!
   echo "Started loader (PID: ${LOADER_PID})"
@@ -1066,7 +1073,7 @@ EOF
     echo "Starting fully randomized failure runner..."
     # Write marker so monitor_completion knows failure runner mode is active
     touch "${TEST_DIR}/failure_runner_enabled"
-    { run_failure_runner "${TEST_DIR}" "${NUM_PARTIES}" "${NUM_SHARDS}" 2>&1 | tee -a failure_runner.log; true; } &
+    run_failure_runner "${TEST_DIR}" "${NUM_PARTIES}" "${NUM_SHARDS}" >> failure_runner.log 2>&1 &
     FAILURE_RUNNER_PID=$!
     echo "Started failure runner (PID: ${FAILURE_RUNNER_PID})"
   fi
@@ -1100,6 +1107,17 @@ EOF
   echo "Cleaning up processes..."
   pkill -f "/bin/arma " 2>/dev/null
   pkill -f "armageddon" 2>/dev/null
+
+  # Remove log files from the working directory — they are already preserved
+  # under test-results/logs/ (gzipped) so the originals are no longer needed.
+  rm -f loader.log failure_runner.log
+  for i in $(seq 1 $NUM_PARTIES); do
+    rm -f receiver${i}.log
+    rm -f consenter${i}.log assembler${i}.log router${i}.log
+    for j in $(seq 1 $NUM_SHARDS); do
+      rm -f batcher${i}-${j}.log
+    done
+  done
 
   echo "=========================================="
   echo "✅ Fully randomized failure test completed successfully!"


### PR DESCRIPTION
related to #925 

Final fix to both the determistic and the random failure tests:
1. the main fix is to add a validation step that will really understand if all sent txs are trully recived (chages in armageddon).
2. added unit test for armageddon to check the validation part only (no failure tests here).
3. clean up replicated text in summary for both the determinstic and the fully random test.
4. removed duplicated log files to save space in local machine and in github