### PR TITLE
filerepo: validate baseName to prevent path escape

### DIFF
--- a/common/filerepo/filerepo.go
+++ b/common/filerepo/filerepo.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/hyperledger/fabric-x-common/tools/fileutil"
 	"github.com/pkg/errors"
@@ -82,6 +83,10 @@ func New(repoParentDir, fileSuffix string) (*Repo, error) {
 // to a tmp file marked by the transientFileMarker and then moves the file to the final
 // destination indicated by the FileSuffix.
 func (r *Repo) Save(baseName string, content []byte) error {
+	if err := validateBaseName(baseName); err != nil {
+		return err
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -102,6 +107,10 @@ func (r *Repo) Save(baseName string, content []byte) error {
 
 // Remove removes the file associated with baseName from the file system.
 func (r *Repo) Remove(baseName string) error {
+	if err := validateBaseName(baseName); err != nil {
+		return err
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -116,6 +125,10 @@ func (r *Repo) Remove(baseName string) error {
 
 // Read reads the file in the fileRepo associated with baseName's contents.
 func (r *Repo) Read(baseName string) ([]byte, error) {
+	if err := validateBaseName(baseName); err != nil {
+		return nil, err
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -170,6 +183,28 @@ func validateFileSuffix(fileSuffix string) error {
 
 	if strings.Contains(fileSuffix, string(os.PathSeparator)) {
 		return errors.Errorf("fileSuffix [%s] illegal, cannot contain os path separator", fileSuffix)
+	}
+
+	return nil
+}
+
+func validateBaseName(baseName string) error {
+	if len(baseName) == 0 {
+		return errors.New("baseName illegal, cannot be empty")
+	}
+
+	if baseName == "." || baseName == ".." {
+		return errors.Errorf("baseName [%s] illegal, cannot be '.' or '..'", baseName)
+	}
+
+	if strings.Contains(baseName, "/") || strings.Contains(baseName, "\\") {
+		return errors.Errorf("baseName [%s] illegal, cannot contain os path separator", baseName)
+	}
+
+	for _, r := range baseName {
+		if unicode.IsControl(r) {
+			return errors.Errorf("baseName [%s] illegal, cannot contain control characters", baseName)
+		}
 	}
 
 	return nil

--- a/common/filerepo/filerepo.go
+++ b/common/filerepo/filerepo.go
@@ -194,16 +194,16 @@ func validateBaseName(baseName string) error {
 	}
 
 	if baseName == "." || baseName == ".." {
-		return errors.Errorf("baseName [%s] illegal, cannot be '.' or '..'", baseName)
+		return errors.Errorf("baseName %q illegal, cannot be '.' or '..'", baseName)
 	}
 
 	if strings.Contains(baseName, "/") || strings.Contains(baseName, "\\") {
-		return errors.Errorf("baseName [%s] illegal, cannot contain os path separator", baseName)
+		return errors.Errorf("baseName %q illegal, cannot contain path separator", baseName)
 	}
 
 	for _, r := range baseName {
 		if unicode.IsControl(r) {
-			return errors.Errorf("baseName [%s] illegal, cannot contain control characters", baseName)
+			return errors.Errorf("baseName %q illegal, cannot contain control characters", baseName)
 		}
 	}
 

--- a/common/filerepo/filerepo_test.go
+++ b/common/filerepo/filerepo_test.go
@@ -179,3 +179,68 @@ func TestFileRepo_FileToBaseName(t *testing.T) {
 	channelName := r.FileToBaseName(filePath)
 	require.Equal(t, "mychannel", channelName)
 }
+
+func TestFileRepo_InvalidBaseName(t *testing.T) {
+	r, err := filerepo.New("testdata", "join")
+	require.NoError(t, err)
+
+	tests := []struct {
+		testName    string
+		baseName    string
+		expectedErr string
+	}{
+		{
+			testName:    "empty",
+			baseName:    "",
+			expectedErr: "baseName illegal, cannot be empty",
+		},
+		{
+			testName:    "dot",
+			baseName:    ".",
+			expectedErr: "baseName [.] illegal, cannot be '.' or '..'",
+		},
+		{
+			testName:    "dot-dot",
+			baseName:    "..",
+			expectedErr: "baseName [..] illegal, cannot be '.' or '..'",
+		},
+		{
+			testName:    "slash",
+			baseName:    "foo/bar",
+			expectedErr: "baseName [foo/bar] illegal, cannot contain os path separator",
+		},
+		{
+			testName:    "backslash",
+			baseName:    `foo\bar`,
+			expectedErr: `baseName [foo\bar] illegal, cannot contain os path separator`,
+		},
+		{
+			testName:    "control character",
+			baseName:    "foo\nbar",
+			expectedErr: "baseName [foo\nbar] illegal, cannot contain control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			err := r.Save(tt.baseName, []byte("payload"))
+			require.EqualError(t, err, tt.expectedErr)
+
+			err = r.Remove(tt.baseName)
+			require.EqualError(t, err, tt.expectedErr)
+
+			_, err = r.Read(tt.baseName)
+			require.EqualError(t, err, tt.expectedErr)
+		})
+	}
+
+	t.Run("dot-dot does not write outside the repo", func(t *testing.T) {
+		parentMarker := filepath.Join("testdata", "..join")
+		_, statErr := os.Stat(parentMarker)
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+
+		err := r.Save("..", []byte("escaped"))
+		require.EqualError(t, err, "baseName [..] illegal, cannot be '.' or '..'")
+		require.NoFileExists(t, parentMarker)
+	})
+}

--- a/common/filerepo/filerepo_test.go
+++ b/common/filerepo/filerepo_test.go
@@ -234,13 +234,15 @@ func TestFileRepo_InvalidBaseName(t *testing.T) {
 		})
 	}
 
-	t.Run("dot-dot does not write outside the repo", func(t *testing.T) {
-		parentMarker := filepath.Join("testdata", "..join")
-		_, statErr := os.Stat(parentMarker)
-		require.ErrorIs(t, statErr, os.ErrNotExist)
+	t.Run("separator in baseName cannot write outside the repo", func(t *testing.T) {
+		parent := t.TempDir()
+		repo, err := filerepo.New(parent, "join")
+		require.NoError(t, err)
 
-		err := r.Save("..", []byte("escaped"))
-		require.EqualError(t, err, "baseName [..] illegal, cannot be '.' or '..'")
-		require.NoFileExists(t, parentMarker)
+		escaped := filepath.Join(parent, "escaped.join")
+
+		err = repo.Save("../escaped", []byte("payload"))
+		require.EqualError(t, err, "baseName [../escaped] illegal, cannot contain os path separator")
+		require.NoFileExists(t, escaped)
 	})
 }

--- a/common/filerepo/filerepo_test.go
+++ b/common/filerepo/filerepo_test.go
@@ -197,27 +197,27 @@ func TestFileRepo_InvalidBaseName(t *testing.T) {
 		{
 			testName:    "dot",
 			baseName:    ".",
-			expectedErr: "baseName [.] illegal, cannot be '.' or '..'",
+			expectedErr: "baseName \".\" illegal, cannot be '.' or '..'",
 		},
 		{
 			testName:    "dot-dot",
 			baseName:    "..",
-			expectedErr: "baseName [..] illegal, cannot be '.' or '..'",
+			expectedErr: "baseName \"..\" illegal, cannot be '.' or '..'",
 		},
 		{
 			testName:    "slash",
 			baseName:    "foo/bar",
-			expectedErr: "baseName [foo/bar] illegal, cannot contain os path separator",
+			expectedErr: "baseName \"foo/bar\" illegal, cannot contain path separator",
 		},
 		{
 			testName:    "backslash",
 			baseName:    `foo\bar`,
-			expectedErr: `baseName [foo\bar] illegal, cannot contain os path separator`,
+			expectedErr: "baseName \"foo\\\\bar\" illegal, cannot contain path separator",
 		},
 		{
 			testName:    "control character",
 			baseName:    "foo\nbar",
-			expectedErr: "baseName [foo\nbar] illegal, cannot contain control characters",
+			expectedErr: "baseName \"foo\\nbar\" illegal, cannot contain control characters",
 		},
 	}
 
@@ -242,7 +242,7 @@ func TestFileRepo_InvalidBaseName(t *testing.T) {
 		escaped := filepath.Join(parent, "escaped.join")
 
 		err = repo.Save("../escaped", []byte("payload"))
-		require.EqualError(t, err, "baseName [../escaped] illegal, cannot contain os path separator")
+		require.EqualError(t, err, "baseName \"../escaped\" illegal, cannot contain path separator")
 		require.NoFileExists(t, escaped)
 	})
 }

--- a/common/filerepo/filerepo_test.go
+++ b/common/filerepo/filerepo_test.go
@@ -181,7 +181,7 @@ func TestFileRepo_FileToBaseName(t *testing.T) {
 }
 
 func TestFileRepo_InvalidBaseName(t *testing.T) {
-	r, err := filerepo.New("testdata", "join")
+	r, err := filerepo.New(t.TempDir(), "join")
 	require.NoError(t, err)
 
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Reject empty, `.`/`..`, path separators, and control characters in `filerepo` `Save`/`Remove`/`Read` so a `baseName` cannot resolve outside the repo directory.
- Cover the rejected names (and a `..` write-outside check) in unit tests.

Fixes #1071

## Test plan
- [x] `go test -race ./common/filerepo/...`