### PR TITLE
Pruned blocks errors

### DIFF
--- a/common/ledger/blkstorage/block_stream.go
+++ b/common/ledger/blkstorage/block_stream.go
@@ -55,6 +55,10 @@ type blockPlacementInfo struct {
 // /////////////////////////////////
 // blockfileStream functions
 // //////////////////////////////////
+
+// newBlockfileStream creates a new blockfile stream that reads blocks sequentially from a file, starting
+// from the given offset and continuing to the end of the file. It returns an error if the file cannot be
+// opened, or cannot be seeked to the given offset.
 func newBlockfileStream(rootDir string, fileNum int, startOffset int64) (*blockfileStream, error) {
 	filePath := deriveBlockfilePath(rootDir, fileNum)
 	logger.Debugf("newBlockfileStream(): filePath=[%s], startOffset=[%d]", filePath, startOffset)
@@ -150,12 +154,21 @@ func (s *blockfileStream) close() error {
 // /////////////////////////////////
 // blockStream functions
 // //////////////////////////////////
+
+// newBlockStream creates a new block stream that reads blocks sequentially, starting from the given file
+// number and offset and continuing to the end of the last file segment (`endFileNum`). It returns an error
+// if the first file cannot be opened, or cannot be seeked to the given offset.
 func newBlockStream(rootDir string, startFileNum int, startOffset int64, endFileNum int) (*blockStream, error) {
 	startFileStream, err := newBlockfileStream(rootDir, startFileNum, startOffset)
 	if err != nil {
 		return nil, err
 	}
-	return &blockStream{rootDir: rootDir, currentFileNum: startFileNum, endFileNum: endFileNum, currentFileStream: startFileStream}, nil
+	return &blockStream{
+		rootDir:           rootDir,
+		currentFileNum:    startFileNum,
+		endFileNum:        endFileNum,
+		currentFileStream: startFileStream,
+	}, nil
 }
 
 func (s *blockStream) moveToNextBlockfileStream() error {

--- a/common/ledger/blkstorage/block_stream.go
+++ b/common/ledger/blkstorage/block_stream.go
@@ -34,10 +34,14 @@ type blockfileStream struct {
 // it starts from a given file offset and continues with the next
 // file segment until the end of the last segment (`endFileNum`)
 type blockStream struct {
-	rootDir           string
-	currentFileNum    int
-	endFileNum        int
+	rootDir        string
+	currentFileNum int
+	endFileNum     int
+	// currentFileStream is nil once advancing to the next block file has failed, in which case advanceErr
+	// holds why. The stream owns no file from that point on, and every further read reports the same
+	// failure rather than dereferencing what it no longer has.
 	currentFileStream *blockfileStream
+	advanceErr        error
 }
 
 // blockPlacementInfo captures the information related
@@ -151,18 +155,25 @@ func newBlockStream(rootDir string, startFileNum int, startOffset int64, endFile
 	if err != nil {
 		return nil, err
 	}
-	return &blockStream{rootDir, startFileNum, endFileNum, startFileStream}, nil
+	return &blockStream{rootDir: rootDir, currentFileNum: startFileNum, endFileNum: endFileNum, currentFileStream: startFileStream}, nil
 }
 
 func (s *blockStream) moveToNextBlockfileStream() error {
-	var err error
-	if err = s.currentFileStream.close(); err != nil {
+	if err := s.currentFileStream.close(); err != nil {
 		return err
 	}
+	// The previous file is closed, so the stream owns nothing until the next one opens. Opening it can
+	// fail once pruning is in play, since a reader that falls behind may reach a removed file, and the
+	// caller still closes the stream afterwards.
+	s.currentFileStream = nil
 	s.currentFileNum++
-	if s.currentFileStream, err = newBlockfileStream(s.rootDir, s.currentFileNum, 0); err != nil {
+
+	next, err := newBlockfileStream(s.rootDir, s.currentFileNum, 0)
+	if err != nil {
+		s.advanceErr = err
 		return err
 	}
+	s.currentFileStream = next
 	return nil
 }
 
@@ -172,6 +183,10 @@ func (s *blockStream) nextBlockBytes() ([]byte, error) {
 }
 
 func (s *blockStream) nextBlockBytesAndPlacementInfo() ([]byte, *blockPlacementInfo, error) {
+	if s.advanceErr != nil {
+		return nil, nil, s.advanceErr
+	}
+
 	var blockBytes []byte
 	var blockPlacementInfo *blockPlacementInfo
 	var err error
@@ -191,6 +206,9 @@ func (s *blockStream) nextBlockBytesAndPlacementInfo() ([]byte, *blockPlacementI
 }
 
 func (s *blockStream) close() error {
+	if s.currentFileStream == nil {
+		return nil
+	}
 	return s.currentFileStream.close()
 }
 

--- a/common/ledger/blkstorage/blockfile_helper.go
+++ b/common/ledger/blkstorage/blockfile_helper.go
@@ -56,6 +56,9 @@ func constructBlockfilesInfo(rootDir string) (*blockfilesInfo, error) {
 		return nil, err
 	}
 
+	// Note this stays safe on a pruned ledger: if the last file holds no complete block it is the active
+	// file, so lastPersistedBlock lives in the file directly below it. Pruning never removes the
+	// file holding lastPersistedBlock, so that predecessor is always present.
 	if numBlocksInFile == 0 && lastFileNum > 0 {
 		secondLastFileNum := lastFileNum - 1
 		fileInfo := getFileInfoOrPanic(rootDir, secondLastFileNum)
@@ -87,13 +90,17 @@ func constructBlockfilesInfo(rootDir string) (*blockfilesInfo, error) {
 // binarySearchFileNumForBlock locates the file number that contains the given block number.
 // This function assumes that the caller invokes this function with a block number that has been committed
 // For any uncommitted block, this function returns the last file present
-func binarySearchFileNumForBlock(rootDir string, blockNum uint64) (int, error) {
+//
+// firstFileNum bounds the search below and must be the lowest block file still on disk: on a pruned
+// ledger the files no longer start at 0, and probing a removed file would fail the search outright.
+// Pass 0 for a ledger that has not been pruned.
+func binarySearchFileNumForBlock(rootDir string, firstFileNum int, blockNum uint64) (int, error) {
 	blkfilesInfo, err := constructBlockfilesInfo(rootDir)
 	if err != nil {
 		return -1, err
 	}
 
-	beginFile := 0
+	beginFile := firstFileNum
 	endFile := blkfilesInfo.latestFileNumber
 
 	for endFile != beginFile {

--- a/common/ledger/blkstorage/blockfile_helper.go
+++ b/common/ledger/blkstorage/blockfile_helper.go
@@ -9,6 +9,7 @@ package blkstorage
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -164,6 +165,27 @@ func retrieveLastFileSuffix(rootDir string) (int, error) {
 	}
 	logger.Debugf("retrieveLastFileSuffix() - biggestFileNum = %d", biggestFileNum)
 	return biggestFileNum, err
+}
+
+// blockfileNumsIn returns the suffix numbers of the block files present in rootDir, ascending.
+func blockfileNumsIn(rootDir string) ([]int, error) {
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading dir %s", rootDir)
+	}
+	nums := make([]int, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !isBlockFileName(e.Name()) {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimPrefix(e.Name(), blockfilePrefix))
+		if err != nil {
+			return nil, errors.Wrapf(err, "unexpected block file name %s", e.Name())
+		}
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+	return nums, nil
 }
 
 func isBlockFileName(name string) bool {

--- a/common/ledger/blkstorage/blockfile_helper_test.go
+++ b/common/ledger/blkstorage/blockfile_helper_test.go
@@ -107,13 +107,45 @@ func TestBinarySearchBlockFileNum(t *testing.T) {
 	require.Len(t, files, 11)
 
 	for i := uint64(0); i < 100; i++ {
-		fileNum, err := binarySearchFileNumForBlock(ledgerDir, i)
+		fileNum, err := binarySearchFileNumForBlock(ledgerDir, 0, i)
 		require.NoError(t, err)
 		locFromIndex, err := blkfileMgr.index.getBlockLocByBlockNum(i)
 		require.NoError(t, err)
 		expectedFileNum := locFromIndex.fileSuffixNum
 		require.Equal(t, expectedFileNum, fileNum)
 	}
+
+	// Scenario:
+	//  1. Delete block files 0..2, so the ledger starts at file 3.
+	//  2. For every block from the first one in file 3 onward, expect the bounded search to return the
+	//     file number the index reports.
+	//  3. For a block below the first surviving one, expect the bounded search to return file 3 and the
+	//     unbounded search to fail.
+	t.Run("with a lower bound after the lowest files are removed", func(t *testing.T) {
+		const firstFileNum = 3
+		firstSurvivingBlock, err := retrieveFirstBlockNumFromFile(ledgerDir, firstFileNum)
+		require.NoError(t, err)
+		for f := 0; f < firstFileNum; f++ {
+			require.NoError(t, os.Remove(deriveBlockfilePath(ledgerDir, f)))
+		}
+
+		for i := firstSurvivingBlock; i < 100; i++ {
+			fileNum, err := binarySearchFileNumForBlock(ledgerDir, firstFileNum, i)
+			require.NoError(t, err)
+			locFromIndex, err := blkfileMgr.index.getBlockLocByBlockNum(i)
+			require.NoError(t, err)
+			require.Equal(t, locFromIndex.fileSuffixNum, fileNum)
+		}
+
+		belowFrontier := firstSurvivingBlock - 1
+
+		fileNum, err := binarySearchFileNumForBlock(ledgerDir, firstFileNum, belowFrontier)
+		require.NoError(t, err)
+		require.Equal(t, firstFileNum, fileNum)
+
+		_, err = binarySearchFileNumForBlock(ledgerDir, 0, belowFrontier)
+		require.Error(t, err)
+	})
 }
 
 func TestIsBootstrappedFromSnapshot(t *testing.T) {

--- a/common/ledger/blkstorage/blockfile_helper_test.go
+++ b/common/ledger/blkstorage/blockfile_helper_test.go
@@ -214,3 +214,47 @@ func checkBlockfilesInfoFromFS(t *testing.T, blkStoreDir string, expected *block
 	require.NoError(t, err)
 	require.Equal(t, expected, blkfilesInfo)
 }
+
+// Scenario:
+//  1. Create a directory holding three block files, a subdirectory, and the four non-block artefacts the
+//     engine can leave in a ledger directory.
+//  2. Expect blockfileNumsIn to return only the block file numbers, ascending.
+//  3. Add a file whose name starts with the block file prefix but does not end in a number.
+//  4. Expect an error naming it, rather than that file being skipped.
+func TestBlockfileNumsIn(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		blockfilePrefix + "000002",
+		blockfilePrefix + "000000",
+		blockfilePrefix + "000010",
+		bootstrappingSnapshotInfoFile,
+		bootstrappingSnapshotInfoTempFile,
+		"__backupGenesisBlockBytes",
+		fileNamePreRestHt,
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o644))
+	}
+	// Archive mode may move pruned files into a subdirectory of the ledger, so directories must be skipped.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "pruned"), 0o755))
+
+	nums, err := blockfileNumsIn(dir)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 2, 10}, nums)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, blockfilePrefix+"bogus"), nil, 0o644))
+
+	_, err = blockfileNumsIn(dir)
+	require.ErrorContains(t, err, "unexpected block file name "+blockfilePrefix+"bogus")
+}
+
+// Scenario:
+//  1. Call blockfileNumsIn on an empty directory and expect no numbers and no error.
+//  2. Call it on a directory that does not exist and expect an error.
+func TestBlockfileNumsInEdgeCases(t *testing.T) {
+	nums, err := blockfileNumsIn(t.TempDir())
+	require.NoError(t, err)
+	require.Empty(t, nums)
+
+	_, err = blockfileNumsIn(filepath.Join(t.TempDir(), "missing"))
+	require.ErrorContains(t, err, "error reading dir")
+}

--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -410,12 +410,29 @@ func (mgr *blockfileMgr) syncIndex() error {
 		return nil
 	}
 
-	startFileNum := 0
+	// On a pruned ledger the block files no longer start at blockfile_000000, so the rebuild scan has to
+	// begin at the first file that survived pruning.
+	startFileNum := mgr.pruner.firstStoredBlockfileNum()
 	startOffset := 0
 	skipFirstBlock := false
 	endFileNum := mgr.blockfilesInfo.latestFileNumber
 
-	firstAvailableBlkNum, err := retrieveFirstBlockNumFromFile(mgr.rootDir, 0)
+	// If that file is absent, the marker and the files disagree.  This is unrecoverable, the pruned blocks
+	// are gone, so return an error. Note the opposite skew is benign: files below the marker are orphans
+	// left by a crash mid-prune, and removing them again is the next prune's job.
+	exists, _, err := fileutil.FileExists(deriveBlockfilePath(mgr.rootDir, startFileNum))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errors.Errorf(
+			"cannot sync index with block files. block file [%d] is missing; the blockstore is pruned "+
+				"up to block [%d] but its block files do not start there",
+			startFileNum, mgr.pruner.firstReadableBlockNum(),
+		)
+	}
+
+	firstAvailableBlkNum, err := retrieveFirstBlockNumFromFile(mgr.rootDir, startFileNum)
 	if err != nil {
 		return err
 	}

--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -618,6 +618,8 @@ func (mgr *blockfileMgr) retrieveBlocks(startNum uint64) (*blocksItr, error) {
 	return newBlockItr(mgr, startNum), nil
 }
 
+// txIDExists reports whether the txID is present in the index. A transaction in a pruned block reads the
+// same as one that never existed, so false does not mean "never committed".
 func (mgr *blockfileMgr) txIDExists(txID string) (bool, error) {
 	return mgr.index.txIDExists(txID)
 }
@@ -682,12 +684,12 @@ func (mgr *blockfileMgr) fetchTransactionEnvelope(lp *fileLocPointer) (*common.E
 func (mgr *blockfileMgr) fetchBlockBytes(lp *fileLocPointer) ([]byte, error) {
 	stream, err := newBlockfileStream(mgr.rootDir, lp.fileSuffixNum, int64(lp.offset))
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedFileRead(lp.fileSuffixNum, err)
 	}
 	defer stream.close()
 	b, err := stream.nextBlockBytes()
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedFileRead(lp.fileSuffixNum, err)
 	}
 	return b, nil
 }
@@ -696,12 +698,12 @@ func (mgr *blockfileMgr) fetchRawBytes(lp *fileLocPointer) ([]byte, error) {
 	filePath := deriveBlockfilePath(mgr.rootDir, lp.fileSuffixNum)
 	reader, err := newBlockfileReader(filePath)
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedFileRead(lp.fileSuffixNum, err)
 	}
 	defer reader.close()
 	b, err := reader.read(lp.offset, lp.bytesLength)
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedFileRead(lp.fileSuffixNum, err)
 	}
 	return b, nil
 }
@@ -736,6 +738,21 @@ func (mgr *blockfileMgr) saveBlkfilesInfo(i *blockfilesInfo, sync bool) error {
 func (mgr *blockfileMgr) errAfterFailedRead(blockNum uint64, err error) error {
 	if unavailable := mgr.checkBlockAvailable(blockNum); unavailable != nil {
 		return unavailable
+	}
+	return err
+}
+
+// errAfterFailedFileRead re-checks the prune marker after reading a block file failed. A file below
+// firstStoredBlockfileNum is one the marker has already given up, and no file is unlinked before the
+// marker records it as gone, so any failure to read it is pruning rather than a fault.
+//
+// This is the classification available to reads keyed by hash or transaction ID: their block number is
+// only known after the lookup that failed, so they have nothing to compare against the marker, but the
+// location they resolved names a file.
+func (mgr *blockfileMgr) errAfterFailedFileRead(fileNum int, err error) error {
+	if firstStored := mgr.pruner.firstStoredBlockfileNum(); fileNum < firstStored {
+		return errors.WithMessagef(ErrPruned,
+			"cannot serve block file [%d]. First stored block file = [%d]", fileNum, firstStored)
 	}
 	return err
 }

--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -45,7 +45,7 @@ type blockfileMgr struct {
 	bcInfo                    atomic.Value
 	cache                     *cache
 
-	// pruner owns the prune marker (see prune.go).
+	// pruner owns the prune marker and the pruning operation (see prune.go).
 	pruner *pruneMgr
 }
 
@@ -146,7 +146,7 @@ func newBlockfileMgr(id string, conf *Conf, indexConfig *IndexConfig, indexStore
 
 	// Construct the pruner before syncIndex: on a pruned ledger the block files no longer start at
 	// blockfile_000000, and the recovery paths need to know where they do start.
-	if mgr.pruner, err = newPruneMgr(indexStore); err != nil {
+	if mgr.pruner, err = newPruneMgr(rootDir, indexStore, mgr.index); err != nil {
 		return nil, err
 	}
 
@@ -558,9 +558,13 @@ func (mgr *blockfileMgr) retrieveBlockByNumber(blockNum uint64) (*common.Block, 
 	}
 	loc, err := mgr.index.getBlockLocByBlockNum(blockNum)
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedRead(blockNum, err)
 	}
-	return mgr.fetchBlock(loc)
+	block, err := mgr.fetchBlock(loc)
+	if err != nil {
+		return nil, mgr.errAfterFailedRead(blockNum, err)
+	}
+	return block, nil
 }
 
 func (mgr *blockfileMgr) retrieveBlockByTxID(txID string) (*common.Block, error) {
@@ -597,11 +601,11 @@ func (mgr *blockfileMgr) retrieveBlockHeaderByNumber(blockNum uint64) (*common.B
 	}
 	loc, err := mgr.index.getBlockLocByBlockNum(blockNum)
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedRead(blockNum, err)
 	}
 	blockBytes, err := mgr.fetchBlockBytes(loc)
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedRead(blockNum, err)
 	}
 
 	return extractSerializedBlockHeader(blockBytes)
@@ -640,9 +644,13 @@ func (mgr *blockfileMgr) retrieveTransactionByBlockNumTranNum(blockNum uint64, t
 	}
 	loc, err := mgr.index.getTXLocByBlockNumTranNum(blockNum, tranNum)
 	if err != nil {
-		return nil, err
+		return nil, mgr.errAfterFailedRead(blockNum, err)
 	}
-	return mgr.fetchTransactionEnvelope(loc)
+	envelope, err := mgr.fetchTransactionEnvelope(loc)
+	if err != nil {
+		return nil, mgr.errAfterFailedRead(blockNum, err)
+	}
+	return envelope, nil
 }
 
 func (mgr *blockfileMgr) fetchBlock(lp *fileLocPointer) (*common.Block, error) {
@@ -721,6 +729,17 @@ func (mgr *blockfileMgr) saveBlkfilesInfo(i *blockfilesInfo, sync bool) error {
 	return nil
 }
 
+// errAfterFailedRead re-checks availability after a read that had already passed the availability check
+// failed. Pruning deletes index entries and unlinks block files while readers run, so a read can resolve
+// a block, lose a race, and trip over the debris; the caller must hear that the block was pruned rather
+// than that a file is missing.
+func (mgr *blockfileMgr) errAfterFailedRead(blockNum uint64, err error) error {
+	if unavailable := mgr.checkBlockAvailable(blockNum); unavailable != nil {
+		return unavailable
+	}
+	return err
+}
+
 // checkBlockAvailable reports whether the store can serve the given block number, returning nil when
 // it can. It distinguishes the two reasons a ledger may not start at block 0: pruning, which yields
 // ErrPruned, and a snapshot bootstrap. When both apply, the snapshot takes precedence for the range it explains.
@@ -753,6 +772,22 @@ func (mgr *blockfileMgr) checkBlockAvailable(blockNum uint64) error {
 // trip the "bootstrapped from a snapshot" error path in syncIndex on every pruned ledger.
 func (mgr *blockfileMgr) firstAvailableBlockNum() uint64 {
 	return max(mgr.firstBlockNumAfterSnapshotBootstrap(), mgr.pruner.firstReadableBlockNum())
+}
+
+// pruneBefore snapshots the tail pointer and hands the work to the pruner. The snapshot is taken
+// here because the lock that guards blockfilesInfo lives here, and it is released before any file I/O.
+func (mgr *blockfileMgr) pruneBefore(blockNum uint64) error {
+	return mgr.pruner.pruneBefore(blockNum, mgr.blockfilesInfoSnapshot())
+}
+
+// blockfilesInfoSnapshot copies the tail pointer so that a caller can reason about a stable view of it.
+// The lock is held only for the copy: appends update blockfilesInfo under it, and holding it across file
+// I/O would stall every blocking iterator.
+func (mgr *blockfileMgr) blockfilesInfoSnapshot() *blockfilesInfo {
+	mgr.blkfilesInfoCond.L.Lock()
+	defer mgr.blkfilesInfoCond.L.Unlock()
+	info := *mgr.blockfilesInfo
+	return &info
 }
 
 // firstBlockNumAfterSnapshotBootstrap is the lowest block number that a snapshot bootstrap left for

--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -44,6 +44,9 @@ type blockfileMgr struct {
 	currentFileWriter         *blockfileWriter
 	bcInfo                    atomic.Value
 	cache                     *cache
+
+	// pruner owns the prune marker (see prune.go).
+	pruner *pruneMgr
 }
 
 /*
@@ -140,6 +143,12 @@ func newBlockfileMgr(id string, conf *Conf, indexConfig *IndexConfig, indexStore
 	mgr.bootstrappingSnapshotInfo = bsi
 	mgr.currentFileWriter = currentFileWriter
 	mgr.blkfilesInfoCond = sync.NewCond(&sync.Mutex{})
+
+	// Construct the pruner before syncIndex: on a pruned ledger the block files no longer start at
+	// blockfile_000000, and the recovery paths need to know where they do start.
+	if mgr.pruner, err = newPruneMgr(indexStore); err != nil {
+		return nil, err
+	}
 
 	if err := mgr.syncIndex(); err != nil {
 		return nil, err
@@ -387,7 +396,7 @@ func (mgr *blockfileMgr) syncIndex() error {
 		// bootstrapping the ledger from a snapshot or the index is dropped/corrupted afterward
 		return errors.Errorf(
 			"cannot sync index with block files. blockstore is bootstrapped from a snapshot and first available block=[%d]",
-			mgr.firstPossibleBlockNumberInBlockFiles(),
+			mgr.firstBlockNumAfterSnapshotBootstrap(),
 		)
 	}
 
@@ -527,11 +536,8 @@ func (mgr *blockfileMgr) retrieveBlockByNumber(blockNum uint64) (*common.Block, 
 	if blockNum == math.MaxUint64 {
 		blockNum = mgr.getBlockchainInfo().Height - 1
 	}
-	if blockNum < mgr.firstPossibleBlockNumberInBlockFiles() {
-		return nil, errors.Errorf(
-			"cannot serve block [%d]. The ledger is bootstrapped from a snapshot. First available block = [%d]",
-			blockNum, mgr.firstPossibleBlockNumberInBlockFiles(),
-		)
+	if err := mgr.checkBlockAvailable(blockNum); err != nil {
+		return nil, err
 	}
 	loc, err := mgr.index.getBlockLocByBlockNum(blockNum)
 	if err != nil {
@@ -546,7 +552,7 @@ func (mgr *blockfileMgr) retrieveBlockByTxID(txID string) (*common.Block, error)
 	if err == errNilValue {
 		return nil, errors.Errorf(
 			"details for the TXID [%s] not available. Ledger bootstrapped from a snapshot. First available block = [%d]",
-			txID, mgr.firstPossibleBlockNumberInBlockFiles(),
+			txID, mgr.firstAvailableBlockNum(),
 		)
 	}
 	if err != nil {
@@ -561,7 +567,7 @@ func (mgr *blockfileMgr) retrieveTxValidationCodeByTxID(txID string) (peer.TxVal
 	if err == errNilValue {
 		return peer.TxValidationCode(-1), 0, errors.Errorf(
 			"details for the TXID [%s] not available. Ledger bootstrapped from a snapshot. First available block = [%d]",
-			txID, mgr.firstPossibleBlockNumberInBlockFiles(),
+			txID, mgr.firstAvailableBlockNum(),
 		)
 	}
 	return validationCode, blkNum, err
@@ -569,11 +575,8 @@ func (mgr *blockfileMgr) retrieveTxValidationCodeByTxID(txID string) (peer.TxVal
 
 func (mgr *blockfileMgr) retrieveBlockHeaderByNumber(blockNum uint64) (*common.BlockHeader, error) {
 	logger.Debugf("retrieveBlockHeaderByNumber() - blockNum = [%d]", blockNum)
-	if blockNum < mgr.firstPossibleBlockNumberInBlockFiles() {
-		return nil, errors.Errorf(
-			"cannot serve block [%d]. The ledger is bootstrapped from a snapshot. First available block = [%d]",
-			blockNum, mgr.firstPossibleBlockNumberInBlockFiles(),
-		)
+	if err := mgr.checkBlockAvailable(blockNum); err != nil {
+		return nil, err
 	}
 	loc, err := mgr.index.getBlockLocByBlockNum(blockNum)
 	if err != nil {
@@ -588,11 +591,8 @@ func (mgr *blockfileMgr) retrieveBlockHeaderByNumber(blockNum uint64) (*common.B
 }
 
 func (mgr *blockfileMgr) retrieveBlocks(startNum uint64) (*blocksItr, error) {
-	if startNum < mgr.firstPossibleBlockNumberInBlockFiles() {
-		return nil, errors.Errorf(
-			"cannot serve block [%d]. The ledger is bootstrapped from a snapshot. First available block = [%d]",
-			startNum, mgr.firstPossibleBlockNumberInBlockFiles(),
-		)
+	if err := mgr.checkBlockAvailable(startNum); err != nil {
+		return nil, err
 	}
 	return newBlockItr(mgr, startNum), nil
 }
@@ -607,7 +607,7 @@ func (mgr *blockfileMgr) retrieveTransactionByID(txID string) (*common.Envelope,
 	if err == errNilValue {
 		return nil, errors.Errorf(
 			"details for the TXID [%s] not available. Ledger bootstrapped from a snapshot. First available block = [%d]",
-			txID, mgr.firstPossibleBlockNumberInBlockFiles(),
+			txID, mgr.firstAvailableBlockNum(),
 		)
 	}
 	if err != nil {
@@ -618,11 +618,8 @@ func (mgr *blockfileMgr) retrieveTransactionByID(txID string) (*common.Envelope,
 
 func (mgr *blockfileMgr) retrieveTransactionByBlockNumTranNum(blockNum uint64, tranNum uint64) (*common.Envelope, error) {
 	logger.Debugf("retrieveTransactionByBlockNumTranNum() - blockNum = [%d], tranNum = [%d]", blockNum, tranNum)
-	if blockNum < mgr.firstPossibleBlockNumberInBlockFiles() {
-		return nil, errors.Errorf(
-			"cannot serve block [%d]. The ledger is bootstrapped from a snapshot. First available block = [%d]",
-			blockNum, mgr.firstPossibleBlockNumberInBlockFiles(),
-		)
+	if err := mgr.checkBlockAvailable(blockNum); err != nil {
+		return nil, err
 	}
 	loc, err := mgr.index.getTXLocByBlockNumTranNum(blockNum, tranNum)
 	if err != nil {
@@ -707,7 +704,48 @@ func (mgr *blockfileMgr) saveBlkfilesInfo(i *blockfilesInfo, sync bool) error {
 	return nil
 }
 
-func (mgr *blockfileMgr) firstPossibleBlockNumberInBlockFiles() uint64 {
+// checkBlockAvailable reports whether the store can serve the given block number, returning nil when
+// it can. It distinguishes the two reasons a ledger may not start at block 0: pruning, which yields
+// ErrPruned, and a snapshot bootstrap. When both apply, the snapshot takes precedence for the range it explains.
+// A request above lastPersistedBlock passes here and fails in the index with "no such block number".
+func (mgr *blockfileMgr) checkBlockAvailable(blockNum uint64) error {
+	// Read the marker once: a concurrent prune must not be able to land between the check and the
+	// error message and have us report a bound other than the one that made the decision.
+	snapshotFirst := mgr.firstBlockNumAfterSnapshotBootstrap()
+	prunedTo := mgr.pruner.firstReadableBlockNum()
+	first := max(snapshotFirst, prunedTo)
+
+	if blockNum < snapshotFirst {
+		return errors.Errorf(
+			"cannot serve block [%d]. The ledger is bootstrapped from a snapshot. First available block = [%d]",
+			blockNum, first,
+		)
+	}
+	if blockNum < prunedTo {
+		return errors.WithMessagef(ErrPruned,
+			"cannot serve block [%d]. First available block = [%d]", blockNum, first)
+	}
+	return nil
+}
+
+// firstReadableBlockNum is the combined lower bound for reads: the highest of the snapshot-bootstrap
+// frontier and the prune marker.
+//
+// Note that this is deliberately NOT folded into firstBlockNumAfterSnapshotBootstrap(), which is the
+// definition of bootstrappedFromSnapshot(). Making that function non-zero on a pruned ledger would
+// trip the "bootstrapped from a snapshot" error path in syncIndex on every pruned ledger.
+func (mgr *blockfileMgr) firstAvailableBlockNum() uint64 {
+	return max(mgr.firstBlockNumAfterSnapshotBootstrap(), mgr.pruner.firstReadableBlockNum())
+}
+
+// firstBlockNumAfterSnapshotBootstrap is the lowest block number that a snapshot bootstrap left for
+// the block files to hold: blocks below it were covered by the snapshot and were never written here.
+// It is 0 on a ledger that was not bootstrapped from a snapshot.
+//
+// This is a bound contributed by snapshot bootstrap alone. on a pruned ledger it still reports 0
+// while the lowest block actually on disk is firstReadableBlockNum().
+// For the bound that reads are guarded against, use firstAvailableBlockNum(), which combines both.
+func (mgr *blockfileMgr) firstBlockNumAfterSnapshotBootstrap() uint64 {
 	if mgr.bootstrappingSnapshotInfo == nil {
 		return 0
 	}
@@ -715,7 +753,7 @@ func (mgr *blockfileMgr) firstPossibleBlockNumberInBlockFiles() uint64 {
 }
 
 func (mgr *blockfileMgr) bootstrappedFromSnapshot() bool {
-	return mgr.firstPossibleBlockNumberInBlockFiles() > 0
+	return mgr.bootstrappingSnapshotInfo != nil
 }
 
 // scanForLastCompleteBlock scan a given block file and detects the last offset in the file

--- a/common/ledger/blkstorage/blocks_itr.go
+++ b/common/ledger/blkstorage/blocks_itr.go
@@ -88,7 +88,7 @@ func (itr *blocksItr) Next() (ledger.QueryResult, error) {
 	if itr.stream == nil {
 		logger.Debugf("Initializing block stream for iterator. itr.maxBlockNumAvailable=%d", itr.maxBlockNumAvailable)
 		if err := itr.initStream(); err != nil {
-			return nil, err
+			return nil, itr.mgr.errAfterFailedRead(itr.blockNumToRetrieve, err)
 		}
 	}
 
@@ -96,7 +96,7 @@ func (itr *blocksItr) Next() (ledger.QueryResult, error) {
 
 	nextBlockBytes, err := itr.stream.nextBlockBytes()
 	if err != nil {
-		return nil, err
+		return nil, itr.mgr.errAfterFailedRead(itr.blockNumToRetrieve, err)
 	}
 	itr.blockNumToRetrieve++
 	return deserializeBlock(nextBlockBytes)

--- a/common/ledger/blkstorage/blockstore.go
+++ b/common/ledger/blkstorage/blockstore.go
@@ -74,6 +74,13 @@ func (store *BlockStore) RetrieveBlockByNumber(blockNum uint64) (*common.Block, 
 	return store.fileMgr.retrieveBlockByNumber(blockNum)
 }
 
+// PruneBefore removes block files whose blocks are all below blockNum, advancing a durable marker so
+// that reads below it fail with ErrPruned. blockNum is an upper bound: files are removed on whole-file
+// boundaries, so the marker lands at or below it. Height() is unchanged. Idempotent and monotone.
+func (store *BlockStore) PruneBefore(blockNum uint64) error {
+	return store.fileMgr.pruneBefore(blockNum)
+}
+
 // FirstAvailableBlockNumber returns the lowest block number this store can serve. It is 0 unless the
 // ledger has been pruned or bootstrapped from a snapshot. Reads below it fail -- with ErrPruned when
 // pruning is the reason.

--- a/common/ledger/blkstorage/blockstore.go
+++ b/common/ledger/blkstorage/blockstore.go
@@ -74,6 +74,13 @@ func (store *BlockStore) RetrieveBlockByNumber(blockNum uint64) (*common.Block, 
 	return store.fileMgr.retrieveBlockByNumber(blockNum)
 }
 
+// FirstAvailableBlockNumber returns the lowest block number this store can serve. It is 0 unless the
+// ledger has been pruned or bootstrapped from a snapshot. Reads below it fail -- with ErrPruned when
+// pruning is the reason.
+func (store *BlockStore) FirstAvailableBlockNumber() uint64 {
+	return store.fileMgr.firstAvailableBlockNum()
+}
+
 // TxIDExists returns true if a transaction with the txID is ever committed
 func (store *BlockStore) TxIDExists(txID string) (bool, error) {
 	return store.fileMgr.txIDExists(txID)

--- a/common/ledger/blkstorage/blockstore.go
+++ b/common/ledger/blkstorage/blockstore.go
@@ -61,7 +61,13 @@ func (store *BlockStore) GetBlockchainInfo() (*common.BlockchainInfo, error) {
 
 // RetrieveBlocks returns an iterator that can be used for iterating over a range of blocks
 func (store *BlockStore) RetrieveBlocks(startNum uint64) (ledger.ResultsIterator, error) {
-	return store.fileMgr.retrieveBlocks(startNum)
+	itr, err := store.fileMgr.retrieveBlocks(startNum)
+	if err != nil {
+		// Returned explicitly rather than as a typed nil, so that a caller testing the iterator instead of
+		// the error does not get something that looks like an iterator and panics on first use.
+		return nil, err
+	}
+	return itr, nil
 }
 
 // RetrieveBlockByHash returns the block for given block-hash

--- a/common/ledger/blkstorage/prune.go
+++ b/common/ledger/blkstorage/prune.go
@@ -8,8 +8,11 @@ package blkstorage
 
 import (
 	"fmt"
+	"os"
+	"sync"
 	"sync/atomic"
 
+	"github.com/hyperledger/fabric-x-common/tools/fileutil"
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/util/leveldbhelper"
 
 	"github.com/pkg/errors"
@@ -29,7 +32,7 @@ var pruneMarkerKey = []byte("blkPruneMarker")
 // Its two fields answer different questions and move independently:
 //
 //   - firstReadableBlockNum is a logical bound. It is what a caller asked to prune below, so reads under
-//     it are refused whether or not the bytes happen to still be on disk.
+//     it fail with ErrPruned whether or not the bytes happen to still be on disk.
 //   - firstStoredBlockfileNum is a physical fact: the lowest block file still present. Recovery scans start
 //     there, and the orphan sweep bounds itself by it.
 //
@@ -71,24 +74,228 @@ func (m *pruneMarker) String() string {
 		m.firstReadableBlockNum, m.firstStoredBlockfileNum)
 }
 
-// pruneMgr owns the prune marker. It is deliberately independent of blockfileMgr: it needs only the
-// ledger's slice of the index database, which makes it constructible and testable on its own.
+// pruneMgr owns the prune marker and the pruning of individual block files.
 type pruneMgr struct {
-	db *leveldbhelper.DBHandle
+	rootDir string
+	db      *leveldbhelper.DBHandle
+	index   *blockIndex
 
 	// marker is the durable prune marker. It is held atomically so that read guards can consult it without
 	// locking, and is always non-nil once the manager is constructed.
 	marker atomic.Pointer[pruneMarker]
+
+	// mutex serializes pruneBefore operations.
+	mutex sync.Mutex
 }
 
-func newPruneMgr(db *leveldbhelper.DBHandle) (*pruneMgr, error) {
-	p := &pruneMgr{db: db}
+func newPruneMgr(rootDir string, db *leveldbhelper.DBHandle, index *blockIndex) (*pruneMgr, error) {
+	p := &pruneMgr{rootDir: rootDir, db: db, index: index}
 	marker, err := p.load()
 	if err != nil {
 		return nil, err
 	}
 	p.marker.Store(marker)
 	return p, nil
+}
+
+// pruneBefore removes the block files whose blocks all lie below blockNum, and fails reads below it.
+// blockNum is an upper bound: only whole files can go, because index offsets are absolute within a file.
+// It is capped at lastPersistedBlock, whose header newBlockfileMgr reads on open, and it never lowers the
+// bound already in force.
+//
+// The algorithm:
+//
+//  1. Take the prune mutex, and sweep any file left behind below the lowest one the marker records.
+//  2. Count the files that lie entirely below the capped request.
+//  3. If none qualify, persist the new bound alone, or return if the bound did not move either.
+//  4. Otherwise advance the bound, then remove each counted file in its own atomic commit.
+//
+// A call that stops partway keeps the bound it reached and the files it committed; the next call counts
+// again to find the rest, which is why step 2 cannot be skipped when the bound is unchanged.
+func (p *pruneMgr) pruneBefore(blockNum uint64, tail *blockfilesInfo) error {
+	if tail.noBlockFiles {
+		return nil
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	currentMarker := p.marker.Load()
+
+	if err := p.sweepOrphans(currentMarker.firstStoredBlockfileNum); err != nil {
+		return err
+	}
+
+	// lastPersistedBlock+1 is the ordinary way to ask for everything; above that the caller names a block
+	// the ledger does not have.
+	if blockNum > tail.lastPersistedBlock+1 {
+		logger.Warnf("Prune request [%d] names a block the ledger does not have; its last block is [%d], "+
+			"so the request is capped there", blockNum, tail.lastPersistedBlock)
+	}
+
+	// bound is how far removal may reach; firstAvailable is the lowest block a read may return. They differ
+	// when the request is below the bound already in force, which must not lower it.
+	bound := min(blockNum, tail.lastPersistedBlock)
+	firstAvailable := max(currentMarker.firstReadableBlockNum, bound)
+
+	lowestFile := currentMarker.firstStoredBlockfileNum
+	eligible, err := p.countEligibleFiles(bound, lowestFile, tail)
+	if err != nil {
+		return err
+	}
+
+	if eligible == 0 {
+		if firstAvailable == currentMarker.firstReadableBlockNum {
+			// Nothing moved, so nothing is worth a durable write.
+			return nil
+		}
+		// The request falls inside the lowest file, so only the bound moves.
+		logger.Infof("Pruned blocks below [%d]; no block file became eligible", firstAvailable)
+		return p.setMarker(&pruneMarker{
+			firstReadableBlockNum:   firstAvailable,
+			firstStoredBlockfileNum: lowestFile,
+		})
+	}
+
+	// Advance the bound before any index entry goes, or a read could pass the check and then miss the index.
+	// firstStoredBlockfileNum advances per file, as each commit lands.
+	p.marker.Store(&pruneMarker{
+		firstReadableBlockNum:   firstAvailable,
+		firstStoredBlockfileNum: lowestFile,
+	})
+
+	for f := lowestFile; f < lowestFile+eligible; f++ {
+		if err := p.pruneBlockfile(f, firstAvailable); err != nil {
+			return err
+		}
+	}
+
+	logger.Infof("Pruned blocks below [%d]; removed block files [%d] to [%d]",
+		firstAvailable, lowestFile, lowestFile+eligible-1)
+	return nil
+}
+
+// countEligibleFiles returns how many files, counting up from lowestFile, hold only blocks below bound.
+// The active file is excluded, so the last block always survives.
+func (p *pruneMgr) countEligibleFiles(bound uint64, lowestFile int, tail *blockfilesInfo) (int, error) {
+	count := 0
+	for f := lowestFile; f < tail.latestFileNumber; f++ {
+		firstAbove, err := p.firstBlockNumAfter(f, tail)
+		if err != nil {
+			return 0, err
+		}
+		if firstAbove > bound {
+			break
+		}
+		count++
+	}
+	return count, nil
+}
+
+// firstBlockNumAfter returns the first block number of the file above fileNum. Reading that file's first
+// record is O(1); finding fileNum's own last block would mean scanning it.
+func (p *pruneMgr) firstBlockNumAfter(fileNum int, tail *blockfilesInfo) (uint64, error) {
+	if fileNum+1 == tail.latestFileNumber && tail.latestFileSize == 0 {
+		return tail.lastPersistedBlock + 1, nil
+	}
+	n, err := retrieveFirstBlockNumFromFile(p.rootDir, fileNum+1)
+	if err != nil {
+		return 0, errors.WithMessagef(err, "cannot determine the first block of block file [%d]", fileNum+1)
+	}
+	return n, nil
+}
+
+// pruneBlockfile deletes the index entries of one file's blocks and records the file as gone in a single
+// atomic batch, then unlinks it.
+func (p *pruneMgr) pruneBlockfile(fileNum int, firstAvailable uint64) error {
+	batch := p.db.NewUpdateBatch()
+	blocks, err := p.addIndexDeletionsForFile(batch, fileNum)
+	if err != nil {
+		return err
+	}
+	marker := &pruneMarker{firstReadableBlockNum: firstAvailable, firstStoredBlockfileNum: fileNum + 1}
+	batch.Put(pruneMarkerKey, marker.marshal())
+
+	// The atomic commit point. A crash before it removes nothing; a crash after it leaves a block file
+	// that nothing references, which sweepOrphans collects.
+	if err := p.db.WriteBatch(batch, true); err != nil {
+		return err
+	}
+	// Only now may the marker claim the file is gone: sweepOrphans unlinks everything below
+	// firstStoredBlockfileNum, and a store that cannot reopen is the cost of claiming it early.
+	p.marker.Store(marker)
+
+	logger.Debugf("Pruning block file [%d], dropping the index entries of [%d] blocks", fileNum, blocks)
+	return p.removeBlockfile(fileNum)
+}
+
+// addIndexDeletionsForFile queues deletion of the index entries of every block in one block file, and
+// returns how many blocks it queued.
+func (p *pruneMgr) addIndexDeletionsForFile(batch *leveldbhelper.UpdateBatch, fileNum int) (int, error) {
+	stream, err := newBlockStream(p.rootDir, fileNum, 0, fileNum)
+	if err != nil {
+		return 0, err
+	}
+	defer stream.close()
+
+	blocks := 0
+	for {
+		// Nil bytes with no error is the stream's clean end of file. A partially written record at the tail
+		// comes back as ErrUnexpectedEndOfBlockfile instead, and is returned as the error it is.
+		blockBytes, _, err := stream.nextBlockBytesAndPlacementInfo()
+		if err != nil {
+			return blocks, err
+		}
+		if blockBytes == nil {
+			return blocks, nil
+		}
+		blockInfo, err := extractSerializedBlockInfo(blockBytes)
+		if err != nil {
+			return blocks, err
+		}
+		if err := addIndexEntriesToBeDeleted(batch, blockInfo, p.index); err != nil {
+			return blocks, err
+		}
+		blocks++
+	}
+}
+
+// sweepOrphans unlinks the block files below the lowest one the marker records. A call that committed and
+// then failed to unlink leaves them behind the marker, where counting would never reach them again. It
+// lists the directory rather than probing from zero, and syncs it once at the end.
+func (p *pruneMgr) sweepOrphans(below int) error {
+	if below == 0 {
+		return nil
+	}
+	nums, err := blockfileNumsIn(p.rootDir)
+	if err != nil {
+		return err
+	}
+
+	swept := 0
+	for _, n := range nums {
+		if n >= below {
+			break // ascending, so nothing lower remains
+		}
+		if err := os.Remove(deriveBlockfilePath(p.rootDir, n)); err != nil && !os.IsNotExist(err) {
+			return errors.Wrapf(err, "error removing orphaned block file [%d]", n)
+		}
+		swept++
+	}
+	if swept == 0 {
+		return nil
+	}
+	logger.Infof("Removed [%d] block files below [%d], left behind by an earlier prune", swept, below)
+	return fileutil.SyncDir(p.rootDir)
+}
+
+// removeBlockfile unlinks a block file and syncs the directory, so each removal is durable on return
+// instead of depending on the caller finishing the loop.
+func (p *pruneMgr) removeBlockfile(fileNum int) error {
+	if err := os.Remove(deriveBlockfilePath(p.rootDir, fileNum)); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "error removing block file [%d]", fileNum)
+	}
+	return fileutil.SyncDir(p.rootDir)
 }
 
 func (p *pruneMgr) firstReadableBlockNum() uint64 {
@@ -99,9 +306,8 @@ func (p *pruneMgr) firstStoredBlockfileNum() int {
 	return p.marker.Load().firstStoredBlockfileNum
 }
 
-// setMarker persists the marker and then publishes it to readers. It is the path for a call that moves the
-// readable bound without removing a file; when a file is removed, the marker is written inside the same
-// batch as the index deletions, so that each file's commit is atomic.
+// setMarker persists the marker, then publishes it. It is for a call that moves the bound without removing
+// a file; a removal writes the marker inside its own commit instead.
 func (p *pruneMgr) setMarker(marker *pruneMarker) error {
 	if err := p.save(marker); err != nil {
 		return err

--- a/common/ledger/blkstorage/prune.go
+++ b/common/ledger/blkstorage/prune.go
@@ -1,0 +1,133 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blkstorage
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/hyperledger/fabric-x-orderer/common/ledger/util/leveldbhelper"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// ErrPruned is returned when a block below the prune point is requested, whether or not its bytes are
+// still on disk.
+var ErrPruned = errors.New("block has been pruned")
+
+// pruneMarkerKey holds the durable prune marker, next to blkMgrInfoKey, inside the ledger's DBHandle.
+var pruneMarkerKey = []byte("blkPruneMarker")
+
+// pruneMarker records how far the front of the ledger has been pruned. Absent (or zero) means nothing has
+// been pruned and the ledger still starts at block 0.
+//
+// Its two fields answer different questions and move independently:
+//
+//   - firstReadableBlockNum is a logical bound. It is what a caller asked to prune below, so reads under
+//     it are refused whether or not the bytes happen to still be on disk.
+//   - firstStoredBlockfileNum is a physical fact: the lowest block file still present. Recovery scans start
+//     there, and the orphan sweep bounds itself by it.
+//
+// They may diverge because pruning removes whole files only.
+// Therefore, firstReadableBlockNum is at least the firstBlockNum in firstStoredBlockfileNum.
+type pruneMarker struct {
+	firstReadableBlockNum   uint64
+	firstStoredBlockfileNum int
+}
+
+func (m *pruneMarker) marshal() []byte {
+	var buf []byte
+	buf = protowire.AppendVarint(buf, m.firstReadableBlockNum)
+	buf = protowire.AppendVarint(buf, uint64(m.firstStoredBlockfileNum))
+	return buf
+}
+
+func (m *pruneMarker) unmarshal(b []byte) error {
+	var position int
+
+	val, n := protowire.ConsumeVarint(b[position:])
+	if n < 0 {
+		return protowire.ParseError(n)
+	}
+	position += n
+	m.firstReadableBlockNum = val
+
+	val, n = protowire.ConsumeVarint(b[position:])
+	if n < 0 {
+		return protowire.ParseError(n)
+	}
+	m.firstStoredBlockfileNum = int(val)
+
+	return nil
+}
+
+func (m *pruneMarker) String() string {
+	return fmt.Sprintf("firstReadableBlockNum=[%d], firstStoredBlockfileNum=[%d]",
+		m.firstReadableBlockNum, m.firstStoredBlockfileNum)
+}
+
+// pruneMgr owns the prune marker. It is deliberately independent of blockfileMgr: it needs only the
+// ledger's slice of the index database, which makes it constructible and testable on its own.
+type pruneMgr struct {
+	db *leveldbhelper.DBHandle
+
+	// marker is the durable prune marker. It is held atomically so that read guards can consult it without
+	// locking, and is always non-nil once the manager is constructed.
+	marker atomic.Pointer[pruneMarker]
+}
+
+func newPruneMgr(db *leveldbhelper.DBHandle) (*pruneMgr, error) {
+	p := &pruneMgr{db: db}
+	marker, err := p.load()
+	if err != nil {
+		return nil, err
+	}
+	p.marker.Store(marker)
+	return p, nil
+}
+
+func (p *pruneMgr) firstReadableBlockNum() uint64 {
+	return p.marker.Load().firstReadableBlockNum
+}
+
+func (p *pruneMgr) firstStoredBlockfileNum() int {
+	return p.marker.Load().firstStoredBlockfileNum
+}
+
+// setMarker persists the marker and then publishes it to readers. It is the path for a call that moves the
+// readable bound without removing a file; when a file is removed, the marker is written inside the same
+// batch as the index deletions, so that each file's commit is atomic.
+func (p *pruneMgr) setMarker(marker *pruneMarker) error {
+	if err := p.save(marker); err != nil {
+		return err
+	}
+	p.marker.Store(marker)
+	return nil
+}
+
+func (p *pruneMgr) save(marker *pruneMarker) error {
+	return p.db.Put(pruneMarkerKey, marker.marshal(), true)
+}
+
+// load reads the durable marker. An absent key means nothing has been pruned, and yields a zero-valued
+// marker rather than nil so that readers never have to nil-check.
+func (p *pruneMgr) load() (*pruneMarker, error) {
+	b, err := p.db.Get(pruneMarkerKey)
+	if err != nil {
+		return nil, err
+	}
+	marker := &pruneMarker{}
+	if b == nil {
+		return marker, nil
+	}
+	if err := marker.unmarshal(b); err != nil {
+		return nil, errors.WithMessage(err, "error unmarshalling prune marker")
+	}
+	logger.Debugf("loaded prune marker:%s", marker)
+	return marker, nil
+}

--- a/common/ledger/blkstorage/prune_test.go
+++ b/common/ledger/blkstorage/prune_test.go
@@ -8,12 +8,15 @@ package blkstorage
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/testutil"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,6 +71,49 @@ func pruneFilesUpTo(t *testing.T, mgr *blockfileMgr, firstStoredBlockfileNum int
 // block files. syncIndex rebuilds only in that state.
 func rewindIndexSavepoint(t *testing.T, mgr *blockfileMgr, lastIndexedBlock uint64) {
 	require.NoError(t, mgr.db.Put(indexSavePointKey, encodeBlockNum(lastIndexedBlock), true))
+}
+
+// blockfileNums returns the block file numbers present in rootDir, ascending.
+func blockfileNums(t *testing.T, rootDir string) []int {
+	nums, err := blockfileNumsIn(rootDir)
+	require.NoError(t, err)
+	return nums
+}
+
+// appendBlocks appends n blocks to the tail of the ledger and returns them.
+func appendBlocks(t *testing.T, mgr *blockfileMgr, n int) []*common.Block {
+	appended := make([]*common.Block, 0, n)
+	for i := 0; i < n; i++ {
+		info := mgr.getBlockchainInfo()
+		b := testutil.ConstructTestBlock(t, info.Height, 1, 10)
+		b.Header.PreviousHash = info.CurrentBlockHash
+		require.NoError(t, mgr.addBlock(b))
+		appended = append(appended, b)
+	}
+	return appended
+}
+
+// requirePruneInvariant asserts the readable bound sits at or above the first block of the lowest block
+// file still on disk. Reversed, the read guard would admit a block whose file has been removed.
+func requirePruneInvariant(t *testing.T, mgr *blockfileMgr) {
+	marker := mgr.pruner.marker.Load()
+	firstInLowest, err := retrieveFirstBlockNumFromFile(mgr.rootDir, marker.firstStoredBlockfileNum)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, marker.firstReadableBlockNum, firstInLowest)
+}
+
+// requireBlocksPruned asserts that every block below firstAvailable is reported as pruned and every block
+// from firstAvailable up is returned unchanged.
+func requireBlocksPruned(t *testing.T, mgr *blockfileMgr, blocks []*common.Block, firstAvailable int) {
+	for i := 0; i < firstAvailable; i++ {
+		_, err := mgr.retrieveBlockByNumber(uint64(i))
+		require.ErrorIs(t, err, ErrPruned)
+	}
+	for i := firstAvailable; i < len(blocks); i++ {
+		got, err := mgr.retrieveBlockByNumber(uint64(i))
+		require.NoError(t, err)
+		require.Equal(t, blocks[i], got)
+	}
 }
 
 // Scenario:
@@ -317,14 +363,14 @@ func TestPruneMgrLoadsThePersistedMarker(t *testing.T) {
 	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 5)
 	defer env.Cleanup()
 
-	p, err := newPruneMgr(w.blockfileMgr.db)
+	p, err := newPruneMgr(w.blockfileMgr.rootDir, w.blockfileMgr.db, w.blockfileMgr.index)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), p.firstReadableBlockNum())
 	require.Equal(t, 0, p.firstStoredBlockfileNum())
 
 	require.NoError(t, p.setMarker(&pruneMarker{firstReadableBlockNum: 3, firstStoredBlockfileNum: 1}))
 
-	reloaded, err := newPruneMgr(w.blockfileMgr.db)
+	reloaded, err := newPruneMgr(w.blockfileMgr.rootDir, w.blockfileMgr.db, w.blockfileMgr.index)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), reloaded.firstReadableBlockNum())
 	require.Equal(t, 1, reloaded.firstStoredBlockfileNum())
@@ -429,4 +475,608 @@ func TestOpenPrunedLedgerWithStaleMarker(t *testing.T) {
 	_, err := reopened.provider.Open("testLedger")
 	require.ErrorContains(t, err, "block file [1] is missing")
 	require.ErrorContains(t, err, "pruned up to block [10]")
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(20), a file boundary.
+//  3. Expect the marker to be block 20 / file 2, and block files 0 and 1 to be gone.
+//  4. Expect blocks 0..19 to fail with ErrPruned and blocks 20..49 to be returned unchanged.
+//  5. Expect Height to stay 50 and an iterator started at block 20 to return block 20.
+func TestPruneBeforeOnFileBoundary(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(20))
+
+	require.Equal(t, uint64(20), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	requireBlocksPruned(t, mgr, blocks, 20)
+	require.Equal(t, uint64(len(blocks)), mgr.getBlockchainInfo().Height)
+
+	itr, err := mgr.retrieveBlocks(20)
+	require.NoError(t, err)
+	defer itr.Close()
+	got, err := itr.Next()
+	require.NoError(t, err)
+	require.Equal(t, blocks[20], got)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(25), which falls inside block file 2.
+//  3. Expect the readable bound to be exactly 25, and block file 2 to survive whole because it also holds
+//     blocks 25..29.
+//  4. Expect block 24 to fail with ErrPruned even though its bytes are still on disk, and block 25 to be
+//     returned.
+func TestPruneBeforeMidFileHidesTheBlocksItKeeps(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(25))
+
+	require.Equal(t, uint64(25), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{2, 3, 4}, blockfileNums(t, mgr.rootDir))
+	requirePruneInvariant(t, mgr)
+
+	_, err := mgr.retrieveBlockByNumber(24)
+	require.ErrorIs(t, err, ErrPruned)
+
+	got, err := mgr.retrieveBlockByNumber(25)
+	require.NoError(t, err)
+	require.Equal(t, blocks[25], got)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(5), which falls inside block file 0.
+//  3. Expect the readable bound to be 5 with no file removed and every block file still present.
+//  4. Expect blocks 0..4 to fail with ErrPruned and blocks 5..49 to be returned.
+func TestPruneBeforeAdvancesBoundWithoutRemovingAFile(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(5))
+
+	require.Equal(t, uint64(5), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 0, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{0, 1, 2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	requireBlocksPruned(t, mgr, blocks, 5)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(5), which is below the first file boundary.
+//  3. Expect the bound to move to 5 with no file removed.
+//  4. Call pruneBefore(20) twice, then pruneBefore(10) and pruneBefore(0).
+//  5. Expect the bound to settle at block 20 and never decrease.
+func TestPruneBeforeIsIdempotentAndMonotone(t *testing.T) {
+	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(5))
+	require.Equal(t, uint64(5), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, []int{0, 1, 2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	require.NoError(t, mgr.pruneBefore(20))
+	require.Equal(t, uint64(20), mgr.pruner.firstReadableBlockNum())
+
+	for _, blockNum := range []uint64{20, 10, 0} {
+		require.NoError(t, mgr.pruneBefore(blockNum))
+		require.Equal(t, uint64(20), mgr.pruner.firstReadableBlockNum())
+		require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+		require.Equal(t, []int{2, 3, 4}, blockfileNums(t, mgr.rootDir))
+	}
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(MaxUint64), far past the end of the ledger.
+//  3. Expect the bound to be capped at 49, the last block, and block file 4 which holds it to survive.
+//  4. Expect block 48 to fail with ErrPruned, block 49 to be returned, and Height to stay 50.
+//  5. Call pruneBefore(MaxUint64) again and expect it to change nothing.
+//  6. Append one more block and expect it to be readable.
+func TestPruneBeforeKeepsFileHoldingLastBlock(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+
+	lastBlock := uint64(len(blocks) - 1)
+	require.Equal(t, lastBlock, mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 4, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{4}, blockfileNums(t, mgr.rootDir))
+	requirePruneInvariant(t, mgr)
+
+	_, err := mgr.retrieveBlockByNumber(lastBlock - 1)
+	require.ErrorIs(t, err, ErrPruned)
+
+	got, err := mgr.retrieveBlockByNumber(lastBlock)
+	require.NoError(t, err)
+	require.Equal(t, blocks[lastBlock], got)
+	require.Equal(t, uint64(len(blocks)), mgr.getBlockchainInfo().Height)
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+	require.Equal(t, lastBlock, mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, []int{4}, blockfileNums(t, mgr.rootDir))
+
+	appended := appendBlocks(t, mgr, 1)
+	got, err = mgr.retrieveBlockByNumber(uint64(len(blocks)))
+	require.NoError(t, err)
+	require.Equal(t, appended[0], got)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files, then roll over without appending, leaving block file 5 empty.
+//  2. Call pruneBefore(MaxUint64).
+//  3. Expect block file 4, which holds block 49, and the empty block file 5 to both survive, with the
+//     bound capped at 49.
+//  4. Close the store and reopen it, and expect block 49 to still be returned.
+func TestPruneBeforeWithEmptyActiveFile(t *testing.T) {
+	path := t.TempDir()
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	mgr := w.blockfileMgr
+	mgr.moveToNextFile()
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+
+	require.Equal(t, uint64(len(blocks)-1), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 4, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{4, 5}, blockfileNums(t, mgr.rootDir))
+	requirePruneInvariant(t, mgr)
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	got, err := store.RetrieveBlockByNumber(uint64(len(blocks) - 1))
+	require.NoError(t, err)
+	require.Equal(t, blocks[len(blocks)-1], got)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files and call pruneBefore(25), so the readable bound and the lowest
+//     block file no longer correspond.
+//  2. Close the store and reopen it.
+//  3. Expect both to survive independently: bound 25, lowest block file 2.
+//  4. Expect Height to stay 50, blocks 0..24 to fail with ErrPruned and blocks 25..49 to be returned.
+func TestPruneBeforeSurvivesReopen(t *testing.T) {
+	path := t.TempDir()
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	require.NoError(t, w.blockfileMgr.pruneBefore(25))
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(25), store.FirstAvailableBlockNumber())
+	require.Equal(t, 2, store.fileMgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{2, 3, 4}, blockfileNums(t, store.fileMgr.rootDir))
+	requirePruneInvariant(t, store.fileMgr)
+
+	info, err := store.GetBlockchainInfo()
+	require.NoError(t, err)
+	require.Equal(t, uint64(len(blocks)), info.Height)
+
+	requireBlocksPruned(t, store.fileMgr, blocks, 25)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files and record the index savepoint.
+//  2. Call pruneBefore(20).
+//  3. Expect the block-number index entries for blocks 0..19 to be gone and those for 20..49 to remain.
+//  4. Expect the index savepoint to be unchanged.
+func TestPruneBeforeDeletesIndexEntries(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	savepointBefore, err := mgr.index.getLastBlockIndexed()
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.pruneBefore(20))
+
+	for i := 0; i < 20; i++ {
+		_, err := mgr.index.getBlockLocByBlockNum(uint64(i))
+		require.ErrorContains(t, err, fmt.Sprintf("no such block number [%d] in index", i))
+	}
+	for i := 20; i < len(blocks); i++ {
+		_, err := mgr.index.getBlockLocByBlockNum(uint64(i))
+		require.NoError(t, err)
+	}
+
+	savepointAfter, err := mgr.index.getLastBlockIndexed()
+	require.NoError(t, err)
+	require.Equal(t, savepointBefore, savepointAfter)
+}
+
+// Scenario:
+//  1. Open a ledger and append nothing.
+//  2. Call pruneBefore(10).
+//  3. Expect no error, the marker to stay 0, and nothing to be removed.
+func TestPruneBeforeOnEmptyLedger(t *testing.T) {
+	env := newTestEnv(t, NewConf(t.TempDir(), 0))
+	defer env.Cleanup()
+	mgr := newTestBlockfileWrapper(env, "testLedger").blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(10))
+
+	require.Equal(t, uint64(0), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 0, mgr.pruner.firstStoredBlockfileNum())
+}
+
+// Scenario:
+//  1. Store 5 blocks, which all fit in block file 0.
+//  2. Call pruneBefore(MaxUint64).
+//  3. Expect no file to be removed, because the only file holds the last block, and the bound to be
+//     capped at block 4.
+//  4. Expect blocks 0..3 to fail with ErrPruned and block 4 to be returned.
+func TestPruneBeforeWithSingleBlockfile(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 5)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+
+	require.Equal(t, uint64(len(blocks)-1), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 0, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{0}, blockfileNums(t, mgr.rootDir))
+
+	requireBlocksPruned(t, mgr, blocks, len(blocks)-1)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(10), exactly the first block of block file 1.
+//  3. Expect only block file 0 to be removed and the marker to be block 10.
+//  4. Call pruneBefore(30), exactly the first block of block file 3.
+//  5. Expect block files 1 and 2 to be removed and the marker to be block 30.
+//  6. Call pruneBefore(40) and expect block file 3 to be removed, leaving only block file 4.
+//  7. Expect blocks 0..39 to fail with ErrPruned, blocks 40..49 to be returned, and Height to stay 50.
+func TestPruneBeforeAdvancesAcrossSuccessiveCalls(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(10))
+	require.Equal(t, uint64(10), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 1, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{1, 2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	require.NoError(t, mgr.pruneBefore(30))
+	require.Equal(t, uint64(30), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 3, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{3, 4}, blockfileNums(t, mgr.rootDir))
+
+	require.NoError(t, mgr.pruneBefore(40))
+	require.Equal(t, uint64(40), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 4, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{4}, blockfileNums(t, mgr.rootDir))
+
+	requireBlocksPruned(t, mgr, blocks, 40)
+	require.Equal(t, uint64(len(blocks)), mgr.getBlockchainInfo().Height)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files and call pruneBefore(MaxUint64), leaving only block file 4.
+//  2. Roll over and append 10 more blocks, so block file 5 holds blocks 50..59.
+//  3. Call pruneBefore(MaxUint64) again.
+//  4. Expect block file 4 to be removed now that it no longer holds the last block, leaving only block
+//     file 5 and a marker of block 50.
+//  5. Expect blocks 40..49 to fail with ErrPruned and blocks 50..59 to be returned.
+func TestPruneBeforeAfterAppendingMoreBlocks(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+	require.Equal(t, []int{4}, blockfileNums(t, mgr.rootDir))
+
+	mgr.moveToNextFile()
+	appended := appendBlocks(t, mgr, blocksPerFileForTest)
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+
+	lastBlock := uint64(len(blocks) + len(appended) - 1)
+	require.Equal(t, lastBlock, mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 5, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{5}, blockfileNums(t, mgr.rootDir))
+	requirePruneInvariant(t, mgr)
+
+	for i := uint64(40); i < lastBlock; i++ {
+		_, err := mgr.retrieveBlockByNumber(i)
+		require.ErrorIs(t, err, ErrPruned)
+	}
+	got, err := mgr.retrieveBlockByNumber(lastBlock)
+	require.NoError(t, err)
+	require.Equal(t, appended[len(appended)-1], got)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Call pruneBefore(30) from 8 goroutines at once.
+//  3. Expect every call to return without error.
+//  4. Expect the marker to be block 30 / file 3, exactly the files below it to be gone, and blocks 0..29
+//     to fail with ErrPruned.
+func TestPruneBeforeConcurrentCalls(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	const callers = 8
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- mgr.pruneBefore(30)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, uint64(30), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 3, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{3, 4}, blockfileNums(t, mgr.rootDir))
+	requireBlocksPruned(t, mgr, blocks, 30)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Truncate the tail of block file 2, so streaming its blocks fails partway.
+//  3. Call pruneBefore(45).
+//  4. Expect an error, and the two files removed before the failure to stay removed: block files 0
+//     and 1 gone, marker advanced to block 20 and no further.
+//  5. Expect block files 2, 3 and 4 to remain.
+func TestPruneBeforeKeepsProgressWhenAFileFails(t *testing.T) {
+	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	corrupted := deriveBlockfilePath(mgr.rootDir, 2)
+	info, err := os.Stat(corrupted)
+	require.NoError(t, err)
+	require.NoError(t, os.Truncate(corrupted, info.Size()-10))
+
+	require.Error(t, mgr.pruneBefore(45))
+
+	// The bound is durable from the first commit, so it reflects the whole request; only the physical
+	// pruning stopped short.
+	require.Equal(t, uint64(45), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{2, 3, 4}, blockfileNums(t, mgr.rootDir))
+	requirePruneInvariant(t, mgr)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Advance the marker to block 20 / file 2 and unlink block file 0 only, the state a crash partway
+//     through the unlinks leaves behind.
+//  3. Call pruneBefore(20), which has nothing new to remove.
+//  4. Expect block file 1 to be removed too, the already-missing block file 0 to be tolerated, and the
+//     marker to stay at block 20.
+func TestPruneBeforeSweepsFilesLeftBehindByACrash(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruner.setMarker(&pruneMarker{firstReadableBlockNum: 20, firstStoredBlockfileNum: 2}))
+	require.NoError(t, os.Remove(deriveBlockfilePath(mgr.rootDir, 0)))
+	require.Equal(t, []int{1, 2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	require.NoError(t, mgr.pruneBefore(20))
+
+	require.Equal(t, []int{2, 3, 4}, blockfileNums(t, mgr.rootDir))
+	require.Equal(t, uint64(20), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+	requireBlocksPruned(t, mgr, blocks, 20)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Truncate block file 1 to zero bytes, so its first block cannot be read.
+//  3. Call pruneBefore(40).
+//  4. Expect an error naming that block file, and nothing to have been removed: the probe for the first
+//     candidate file is what fails, before any commit, so the marker stays 0 and every file remains.
+func TestPruneBeforeFailsBeforeCommittingWhenAFileIsUnreadable(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, os.Truncate(deriveBlockfilePath(mgr.rootDir, 1), 0))
+
+	err := mgr.pruneBefore(40)
+	require.ErrorContains(t, err, "cannot determine the first block of block file [1]")
+
+	require.Equal(t, uint64(0), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 0, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{0, 1, 2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	got, err := mgr.retrieveBlockByNumber(0)
+	require.NoError(t, err)
+	require.Equal(t, blocks[0], got)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files and call pruneBefore(25), so the readable bound sits inside the
+//     lowest surviving file rather than on its boundary.
+//  2. Rewind the index savepoint to block 45 and close the store.
+//  3. Reopen it, and expect the open to succeed with the bound and lowest file both preserved.
+//  4. Expect blocks 0..24 to fail with ErrPruned and blocks 25..49 to be returned.
+func TestReopenAfterRealPruneWithIndexBehind(t *testing.T) {
+	path := t.TempDir()
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	require.NoError(t, w.blockfileMgr.pruneBefore(25))
+	rewindIndexSavepoint(t, w.blockfileMgr, uint64(len(blocks)-5))
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(25), store.fileMgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, store.fileMgr.pruner.firstStoredBlockfileNum())
+	requireBlocksPruned(t, store.fileMgr, blocks, 25)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files and call pruneBefore(25).
+//  2. Rewind the index savepoint below the readable bound, to block 5, and reopen the store.
+//  3. Expect the open to succeed: the rebuild starts at the lowest surviving file and re-indexes blocks
+//     20..49, including 20..24 which the bound hides.
+//  4. Expect blocks 20..24 to have index entries again, and still to fail with ErrPruned, because the read
+//     guard rejects them before the index is consulted.
+func TestReopenAfterRealPruneWithIndexBelowTheBound(t *testing.T) {
+	path := t.TempDir()
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	require.NoError(t, w.blockfileMgr.pruneBefore(25))
+	rewindIndexSavepoint(t, w.blockfileMgr, 5)
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	for i := 20; i < 25; i++ {
+		_, err := store.fileMgr.index.getBlockLocByBlockNum(uint64(i))
+		require.NoError(t, err, "block %d is on disk, so the rebuild indexes it", i)
+		_, err = store.RetrieveBlockByNumber(uint64(i))
+		require.ErrorIs(t, err, ErrPruned)
+	}
+	requireBlocksPruned(t, store.fileMgr, blocks, 25)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Make the ledger directory read-only, so unlinking fails after the commit that records the file gone.
+//  3. Call pruneBefore(20) and expect an error, with the bound and lowest file already advanced and both
+//     block files still on disk.
+//  4. Restore write permission and call pruneBefore(20) again.
+//  5. Expect the orphaned files to be swept and the marker to stay where it was.
+func TestPruneBeforeUnlinkFailureLeavesRecoverableOrphans(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, os.Chmod(mgr.rootDir, 0o500))
+	err := mgr.pruneBefore(20)
+	require.NoError(t, os.Chmod(mgr.rootDir, 0o700))
+	require.ErrorContains(t, err, "error removing block file [0]")
+
+	require.Equal(t, uint64(20), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 1, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{0, 1, 2, 3, 4}, blockfileNums(t, mgr.rootDir))
+
+	require.NoError(t, mgr.pruneBefore(20))
+
+	require.Equal(t, []int{2, 3, 4}, blockfileNums(t, mgr.rootDir))
+	require.Equal(t, uint64(20), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+	requireBlocksPruned(t, mgr, blocks, 20)
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files and call pruneBefore(20).
+//  2. Expect a block hash lookup for a pruned block to fail, but not with ErrPruned: its hash index
+//     entry went with the file, and that path has no availability guard.
+//  3. Expect a transaction lookup for a pruned block to fail the same way.
+//  4. Expect an iterator started below the bound to fail with ErrPruned, because that path is guarded.
+func TestPruneBeforeUnguardedLookupsDoNotReportErrPruned(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	txID, err := protoutil.GetOrComputeTxIDFromEnvelope(blocks[5].Data.Data[0])
+	require.NoError(t, err)
+	require.NoError(t, mgr.pruneBefore(20))
+
+	_, err = mgr.retrieveBlockByHash(protoutil.BlockHeaderHash(blocks[5].Header))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrPruned)
+
+	_, err = mgr.retrieveTransactionByID(txID)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrPruned)
+
+	_, err = mgr.retrieveBlocks(19)
+	require.ErrorIs(t, err, ErrPruned)
+}
+
+// Scenario:
+//  1. Store a single block, so the only block file holds the last block.
+//  2. Call pruneBefore(MaxUint64).
+//  3. Expect nothing to change: no file is eligible and the bound cannot pass the last block.
+func TestPruneBeforeOnSingleBlockLedger(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 1)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruneBefore(math.MaxUint64))
+
+	require.Equal(t, uint64(0), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 0, mgr.pruner.firstStoredBlockfileNum())
+	require.Equal(t, []int{0}, blockfileNums(t, mgr.rootDir))
+
+	got, err := mgr.retrieveBlockByNumber(0)
+	require.NoError(t, err)
+	require.Equal(t, blocks[0], got)
+}
+
+// Scenario:
+//  1. Store 401 blocks across 41 block files, ten blocks per file, so file 40 holds block 400 alone.
+//  2. Call pruneBefore(i*100+99) for i = 0..3.
+//  3. Expect each call to move the bound to exactly its request, and the lowest surviving file to i*10+9:
+//     the file whose last block is the bound keeps its blocks, since pruning removes whole files.
+//  4. Expect two files left at the end -- file 39, holding blocks 390..399, and file 40, holding the last
+//     block -- with blocks below 399 refused and 399 and 400 returned.
+//  5. Call pruneBefore(400) and expect file 39 to go too, leaving one file.
+func TestPruneBeforeRepeatedlyDownToTheLastFiles(t *testing.T) {
+	const blocks = 401
+	env, w, all := newPrunableTestLedger(t, t.TempDir(), blocks)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.Len(t, blockfileNums(t, mgr.rootDir), 41)
+
+	for i := uint64(0); i < 4; i++ {
+		bound := i*100 + 99
+		require.NoError(t, mgr.pruneBefore(bound))
+
+		require.Equal(t, bound, mgr.pruner.firstReadableBlockNum())
+		require.Equal(t, int(i*10+9), mgr.pruner.firstStoredBlockfileNum())
+		requirePruneInvariant(t, mgr)
+	}
+
+	require.Equal(t, []int{39, 40}, blockfileNums(t, mgr.rootDir))
+	require.Equal(t, uint64(399), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, uint64(blocks), mgr.getBlockchainInfo().Height)
+	requireBlocksPruned(t, mgr, all, 399)
+
+	// The bound could not pass block 399 while its file held it. Asking for the block after frees that
+	// file too, and only the file holding the last block remains.
+	require.NoError(t, mgr.pruneBefore(400))
+
+	require.Equal(t, []int{40}, blockfileNums(t, mgr.rootDir))
+	require.Equal(t, uint64(400), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 40, mgr.pruner.firstStoredBlockfileNum())
+	requireBlocksPruned(t, mgr, all, 400)
 }

--- a/common/ledger/blkstorage/prune_test.go
+++ b/common/ledger/blkstorage/prune_test.go
@@ -8,6 +8,7 @@ package blkstorage
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/testutil"
@@ -45,6 +46,28 @@ func newPrunableTestLedger(
 	}
 
 	return env, w, blocks
+}
+
+// pruneFilesUpTo advances the marker to the first block of firstStoredBlockfileNum and unlinks every block
+// file below it, producing the on-disk state that pruning leaves behind.
+func pruneFilesUpTo(t *testing.T, mgr *blockfileMgr, firstStoredBlockfileNum int) {
+	// Pruning never removes the file holding lastPersistedBlock, so neither may this fixture.
+	require.LessOrEqual(t, uint64(firstStoredBlockfileNum)*blocksPerFileForTest, mgr.blockfilesInfo.lastPersistedBlock,
+		"fixture would remove the file holding lastPersistedBlock")
+
+	require.NoError(t, mgr.pruner.setMarker(&pruneMarker{
+		firstReadableBlockNum:   uint64(firstStoredBlockfileNum * blocksPerFileForTest),
+		firstStoredBlockfileNum: firstStoredBlockfileNum,
+	}))
+	for f := 0; f < firstStoredBlockfileNum; f++ {
+		require.NoError(t, os.Remove(deriveBlockfilePath(mgr.rootDir, f)))
+	}
+}
+
+// rewindIndexSavepoint sets the index savepoint back to lastIndexedBlock, leaving the index behind the
+// block files. syncIndex rebuilds only in that state.
+func rewindIndexSavepoint(t *testing.T, mgr *blockfileMgr, lastIndexedBlock uint64) {
+	require.NoError(t, mgr.db.Put(indexSavePointKey, encodeBlockNum(lastIndexedBlock), true))
 }
 
 // Scenario:
@@ -305,4 +328,105 @@ func TestPruneMgrLoadsThePersistedMarker(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), reloaded.firstReadableBlockNum())
 	require.Equal(t, 1, reloaded.firstStoredBlockfileNum())
+}
+
+// Scenario:
+// 1. Store 50 blocks across 5 block files.
+// 2. Write a prune marker at block 20 / file 2 and delete block files 0 and 1.
+// 3. Rewind the index savepoint to block 45, so syncIndex has a tail to rebuild.
+// 4. Close the store and reopen it.
+// 5. Expect the open to succeed, the marker to be reported back, and Height to stay 50.
+// 6. Expect block 19 to fail with ErrPruned and blocks 20..49 to be returned.
+// 7. Append one more block and expect Height to become 51.
+func TestReopenPrunedLedgerRebuildsIndexFromSurvivingFiles(t *testing.T) {
+	path := t.TempDir()
+	const firstAvailableFile = 2
+	const firstAvailable = firstAvailableFile * blocksPerFileForTest
+
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	pruneFilesUpTo(t, w.blockfileMgr, firstAvailableFile)
+	rewindIndexSavepoint(t, w.blockfileMgr, uint64(len(blocks)-5))
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(firstAvailable), store.FirstAvailableBlockNumber())
+	require.Equal(t, firstAvailableFile, store.fileMgr.pruner.firstStoredBlockfileNum())
+
+	info, err := store.GetBlockchainInfo()
+	require.NoError(t, err)
+	require.Equal(t, uint64(len(blocks)), info.Height)
+
+	_, err = store.RetrieveBlockByNumber(firstAvailable - 1)
+	require.ErrorIs(t, err, ErrPruned)
+
+	for i := firstAvailable; i < len(blocks); i++ {
+		got, err := store.RetrieveBlockByNumber(uint64(i))
+		require.NoError(t, err)
+		require.Equal(t, blocks[i], got)
+	}
+
+	next := testutil.ConstructTestBlock(t, info.Height, 1, 10)
+	next.Header.PreviousHash = info.CurrentBlockHash
+	require.NoError(t, store.AddBlock(next))
+	require.Equal(t, uint64(len(blocks)+1), store.fileMgr.getBlockchainInfo().Height)
+}
+
+// Scenario:
+// 1. Store 50 blocks across 5 block files.
+// 2. Write a prune marker at block 20 / file 2 and delete block files 0 and 1.
+// 3. Rewind the index savepoint to block 5, below the marker.
+// 4. Close the store and reopen it.
+// 5. Expect the open to succeed and blocks 20..49 to be returned.
+// 6. Expect block 19 to fail with ErrPruned.
+func TestReopenPrunedLedgerWithIndexBehindPruneFrontier(t *testing.T) {
+	path := t.TempDir()
+	const firstAvailableFile = 2
+	const firstAvailable = firstAvailableFile * blocksPerFileForTest
+
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	pruneFilesUpTo(t, w.blockfileMgr, firstAvailableFile)
+	rewindIndexSavepoint(t, w.blockfileMgr, 5)
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	for i := firstAvailable; i < len(blocks); i++ {
+		got, err := store.RetrieveBlockByNumber(uint64(i))
+		require.NoError(t, err)
+		require.Equal(t, blocks[i], got)
+	}
+	_, err = store.RetrieveBlockByNumber(firstAvailable - 1)
+	require.ErrorIs(t, err, ErrPruned)
+}
+
+// Scenario:
+// 1. Store 50 blocks across 5 block files.
+// 2. Write a prune marker at block 20 / file 2 and delete block files 0 and 1.
+// 3. Roll the marker back to block 10 / file 1, which has already been deleted.
+// 4. Rewind the index savepoint to block 45 and close the store.
+// 5. Expect reopening to fail with an error naming the missing block file and the prune point.
+func TestOpenPrunedLedgerWithStaleMarker(t *testing.T) {
+	path := t.TempDir()
+
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	pruneFilesUpTo(t, w.blockfileMgr, 2)
+	require.NoError(t, w.blockfileMgr.pruner.setMarker(&pruneMarker{
+		firstReadableBlockNum:   blocksPerFileForTest,
+		firstStoredBlockfileNum: 1,
+	}))
+	rewindIndexSavepoint(t, w.blockfileMgr, uint64(len(blocks)-5))
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	_, err := reopened.provider.Open("testLedger")
+	require.ErrorContains(t, err, "block file [1] is missing")
+	require.ErrorContains(t, err, "pruned up to block [10]")
 }

--- a/common/ledger/blkstorage/prune_test.go
+++ b/common/ledger/blkstorage/prune_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blkstorage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-orderer/common/ledger/testutil"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+)
+
+// blocksPerFileForTest is the number of blocks written per block file by newPrunableTestLedger.
+const blocksPerFileForTest = 10
+
+// newPrunableTestLedger stores numBlocks blocks with exactly blocksPerFileForTest blocks per block file,
+// so that blockNum / blocksPerFileForTest is that block's file number and every file starts on a multiple
+// of blocksPerFileForTest. The layout is asserted, not assumed, because the tests derive a marker's file
+// number from its block number.
+func newPrunableTestLedger(
+	t *testing.T, path string, numBlocks int,
+) (*testEnv, *testBlockfileMgrWrapper, []*common.Block) {
+	blocks := testutil.ConstructTestBlocks(t, numBlocks)
+	env := newTestEnv(t, NewConf(path, 0))
+	w := newTestBlockfileWrapper(env, "testLedger")
+	for i, b := range blocks {
+		if i != 0 && i%blocksPerFileForTest == 0 {
+			w.blockfileMgr.moveToNextFile()
+		}
+		require.NoError(t, w.blockfileMgr.addBlock(b))
+	}
+
+	lastFileNum := (numBlocks - 1) / blocksPerFileForTest
+	require.Equal(t, lastFileNum, w.blockfileMgr.blockfilesInfo.latestFileNumber)
+	for f := 0; f <= lastFileNum; f++ {
+		firstInFile, err := retrieveFirstBlockNumFromFile(w.blockfileMgr.rootDir, f)
+		require.NoError(t, err)
+		require.Equal(t, uint64(f*blocksPerFileForTest), firstInFile)
+	}
+
+	return env, w, blocks
+}
+
+// Scenario:
+// 1. Marshal a prune marker.
+// 2. Unmarshal the bytes into a fresh prune marker.
+// 3. Expect it to equal the original, for zero, small and large field values.
+func TestPruneMarkerMarshalUnmarshal(t *testing.T) {
+	for _, marker := range []*pruneMarker{
+		{firstReadableBlockNum: 0, firstStoredBlockfileNum: 0},
+		{firstReadableBlockNum: 1, firstStoredBlockfileNum: 1},
+		{firstReadableBlockNum: 20, firstStoredBlockfileNum: 2},
+		{firstReadableBlockNum: 1 << 40, firstStoredBlockfileNum: 1 << 20},
+	} {
+		t.Run(marker.String(), func(t *testing.T) {
+			decoded := &pruneMarker{}
+			require.NoError(t, decoded.unmarshal(marker.marshal()))
+			require.Equal(t, marker, decoded)
+		})
+	}
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files, writing no prune marker.
+//  2. Expect the readable bound and the lowest block file to be 0, and the ledger not to be reported as
+//     bootstrapped from a snapshot.
+//  3. Expect every block, including block 0, to be retrievable by number, and MaxUint64 to return the last.
+//  4. Expect block 0 to pass the availability check.
+func TestPruneMarkerAbsentByDefault(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.Equal(t, uint64(0), mgr.firstAvailableBlockNum())
+	require.Equal(t, uint64(0), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 0, mgr.pruner.firstStoredBlockfileNum())
+	require.False(t, mgr.bootstrappedFromSnapshot())
+
+	// Every block, including block 0, is still served (also covers the MaxUint64 "newest" alias).
+	w.testGetBlockByNumber(blocks)
+	require.NoError(t, mgr.checkBlockAvailable(0))
+}
+
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Write a prune marker at block 20 / file 2, leaving every block file in place.
+//  3. Expect the accessors to report the marker, Height to stay 50, and the ledger not to be reported as
+//     bootstrapped from a snapshot.
+//  4. For blocks 0, 1 and 19, expect retrieveBlockByNumber, retrieveBlockHeaderByNumber, retrieveBlocks
+//     and retrieveTransactionByBlockNumTranNum to fail with ErrPruned.
+//  5. For blocks 20..49, expect those paths to succeed and return the original blocks, and MaxUint64 to
+//     return the last block.
+//  6. Expect an iterator started at block 20 to return block 20.
+func TestPruneMarkerReadGuards(t *testing.T) {
+	env, w, blocks := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	const firstAvailable = 20
+	require.NoError(t, mgr.pruner.setMarker(&pruneMarker{
+		firstReadableBlockNum:   firstAvailable,
+		firstStoredBlockfileNum: firstAvailable / blocksPerFileForTest,
+	}))
+
+	require.Equal(t, uint64(firstAvailable), mgr.firstAvailableBlockNum())
+	require.Equal(t, uint64(firstAvailable), mgr.pruner.firstReadableBlockNum())
+	require.Equal(t, 2, mgr.pruner.firstStoredBlockfileNum())
+
+	// Height is about the tail and must be untouched by a prune.
+	require.Equal(t, uint64(len(blocks)), mgr.getBlockchainInfo().Height)
+
+	// A pruned ledger is not a snapshot-bootstrapped one.
+	require.False(t, mgr.bootstrappedFromSnapshot())
+	require.Equal(t, uint64(0), mgr.firstBlockNumAfterSnapshotBootstrap())
+
+	t.Run("blocks below the marker are reported as pruned", func(t *testing.T) {
+		for _, blockNum := range []uint64{0, 1, firstAvailable - 1} {
+			_, err := mgr.retrieveBlockByNumber(blockNum)
+			require.ErrorIs(t, err, ErrPruned)
+			require.ErrorContains(t, err,
+				fmt.Sprintf("cannot serve block [%d]. First available block = [%d]", blockNum, firstAvailable))
+
+			_, err = mgr.retrieveBlockHeaderByNumber(blockNum)
+			require.ErrorIs(t, err, ErrPruned)
+
+			_, err = mgr.retrieveBlocks(blockNum)
+			require.ErrorIs(t, err, ErrPruned)
+
+			_, err = mgr.retrieveTransactionByBlockNumTranNum(blockNum, 0)
+			require.ErrorIs(t, err, ErrPruned)
+		}
+	})
+
+	t.Run("blocks at or above the marker are served unchanged", func(t *testing.T) {
+		// Also covers the MaxUint64 "give me the newest" alias, which must stay reachable.
+		w.testGetBlockByNumber(blocks[firstAvailable:])
+
+		header, err := mgr.retrieveBlockHeaderByNumber(firstAvailable)
+		require.NoError(t, err)
+		require.Equal(t, blocks[firstAvailable].Header, header)
+
+		_, err = mgr.retrieveTransactionByBlockNumTranNum(firstAvailable, 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("an iterator may start at the marker", func(t *testing.T) {
+		itr, err := mgr.retrieveBlocks(firstAvailable)
+		require.NoError(t, err)
+		defer itr.Close()
+
+		got, err := itr.Next()
+		require.NoError(t, err)
+		require.Equal(t, blocks[firstAvailable], got)
+	})
+}
+
+// Scenario:
+// 1. Store 50 blocks across 5 block files.
+// 2. Write a prune marker at block 30 / file 3, leaving every block file in place.
+// 3. Close the store and reopen it.
+// 4. Expect the marker to be reported back and Height to stay 50.
+// 5. Expect block 29 to fail with ErrPruned and block 30 to be returned.
+func TestPruneMarkerSurvivesCloseAndReopen(t *testing.T) {
+	path := t.TempDir()
+	const firstAvailable = 30
+
+	env, w, blocks := newPrunableTestLedger(t, path, 50)
+	require.NoError(t, w.blockfileMgr.pruner.setMarker(&pruneMarker{
+		firstReadableBlockNum:   firstAvailable,
+		firstStoredBlockfileNum: firstAvailable / blocksPerFileForTest,
+	}))
+	env.provider.Close()
+
+	reopened := newTestEnv(t, NewConf(path, 0))
+	defer reopened.Cleanup()
+	store, err := reopened.provider.Open("testLedger")
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(firstAvailable), store.FirstAvailableBlockNumber())
+	require.Equal(t, 3, store.fileMgr.pruner.firstStoredBlockfileNum())
+
+	info, err := store.GetBlockchainInfo()
+	require.NoError(t, err)
+	require.Equal(t, uint64(len(blocks)), info.Height)
+
+	_, err = store.RetrieveBlockByNumber(firstAvailable - 1)
+	require.ErrorIs(t, err, ErrPruned)
+
+	got, err := store.RetrieveBlockByNumber(firstAvailable)
+	require.NoError(t, err)
+	require.Equal(t, blocks[firstAvailable], got)
+}
+
+// The state below is synthetic: snapshot bootstrap is only reachable from tests in this repo, so the two
+// bounds never coexist in practice. The test pins checkBlockAvailable's precedence in case they ever do.
+//
+// Scenario:
+//  1. Store 50 blocks across 5 block files.
+//  2. Set a bootstrapping snapshot whose last block is 9, and a prune marker at block 30 / file 3.
+//  3. Expect the snapshot frontier to be 10, the readable bound to be 30, and the ledger to be reported
+//     as bootstrapped from a snapshot.
+//  4. Expect block 9 to be rejected as bootstrapped-from-snapshot and not as ErrPruned.
+//  5. Expect blocks 10 and 29 to be rejected with ErrPruned.
+//  6. Expect block 30 to pass the availability check.
+//  7. Lower the marker below the snapshot frontier and expect the snapshot bound to win instead.
+func TestFirstAvailableBlockNumCombinesSnapshotAndPruneMarker(t *testing.T) {
+	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 50)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	const snapshotLastBlock = 9 // the snapshot covered blocks 0-9, so the files start at 10
+	const markerBlock = 30
+
+	mgr.bootstrappingSnapshotInfo = &BootstrappingSnapshotInfo{LastBlockNum: snapshotLastBlock}
+	require.NoError(t, mgr.pruner.setMarker(&pruneMarker{
+		firstReadableBlockNum:   markerBlock,
+		firstStoredBlockfileNum: markerBlock / blocksPerFileForTest,
+	}))
+
+	require.Equal(t, uint64(snapshotLastBlock+1), mgr.firstBlockNumAfterSnapshotBootstrap())
+	require.Equal(t, uint64(markerBlock), mgr.firstAvailableBlockNum())
+	require.True(t, mgr.bootstrappedFromSnapshot())
+
+	// Below the snapshot frontier: those blocks were never in the block files, so the snapshot
+	// explanation is the precise one and ErrPruned would be misleading.
+	err := mgr.checkBlockAvailable(snapshotLastBlock)
+	require.NotErrorIs(t, err, ErrPruned)
+	require.ErrorContains(t, err, "bootstrapped from a snapshot")
+	require.ErrorContains(t, err, fmt.Sprintf("First available block = [%d]", markerBlock))
+
+	// Between the two bounds: pruning is what removed these.
+	require.ErrorIs(t, mgr.checkBlockAvailable(snapshotLastBlock+1), ErrPruned)
+	require.ErrorIs(t, mgr.checkBlockAvailable(markerBlock-1), ErrPruned)
+
+	// At or above both bounds: available.
+	require.NoError(t, mgr.checkBlockAvailable(markerBlock))
+
+	// The other branch of the max: a bound below the snapshot frontier leaves the frontier in charge.
+	require.NoError(t, mgr.pruner.setMarker(&pruneMarker{firstReadableBlockNum: 5, firstStoredBlockfileNum: 0}))
+	require.Equal(t, uint64(snapshotLastBlock+1), mgr.firstAvailableBlockNum())
+	require.ErrorContains(t, mgr.checkBlockAvailable(snapshotLastBlock), "bootstrapped from a snapshot")
+}
+
+// Scenario:
+//  1. Store 20 blocks across 2 block files.
+//  2. Write a prune marker at block 10 / file 1.
+//  3. Expect the ledger not to be reported as bootstrapped from a snapshot, and the snapshot frontier to
+//     stay 0.
+//  4. Delete the index savepoint, so syncIndex takes the full-rebuild path.
+//  5. Expect syncIndex to succeed.
+func TestPruneMarkerDoesNotAffectSnapshotDetection(t *testing.T) {
+	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 20)
+	defer env.Cleanup()
+	mgr := w.blockfileMgr
+
+	require.NoError(t, mgr.pruner.setMarker(&pruneMarker{firstReadableBlockNum: 10, firstStoredBlockfileNum: 1}))
+
+	require.False(t, mgr.bootstrappedFromSnapshot())
+	require.Equal(t, uint64(0), mgr.firstBlockNumAfterSnapshotBootstrap())
+
+	// syncIndex only consults bootstrappedFromSnapshot() when there is no index savepoint, i.e. on a
+	// full rebuild. Drop the savepoint to actually reach that branch -- with a healthy savepoint
+	// syncIndex returns early at "already in sync" and this assertion would be vacuous.
+	require.NoError(t, mgr.db.Delete(indexSavePointKey, true))
+	require.NoError(t, mgr.syncIndex())
+}
+
+// Scenario:
+// 1. Store 5 blocks.
+// 2. Overwrite the prune marker key with a truncated varint.
+// 3. Expect loading the marker to fail with an unmarshalling error.
+func TestLoadPruneMarkerOnCorruptValue(t *testing.T) {
+	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 5)
+	defer env.Cleanup()
+
+	// A varint that claims more continuation bytes than are present.
+	require.NoError(t, w.blockfileMgr.db.Put(pruneMarkerKey, []byte{0xff}, true))
+
+	_, err := w.blockfileMgr.pruner.load()
+	require.ErrorContains(t, err, "error unmarshalling prune marker")
+}
+
+// Scenario:
+//  1. Construct a pruneMgr over a ledger's index database handle and expect a zero marker.
+//  2. Set a marker through it.
+//  3. Construct a second pruneMgr over the same handle and expect it to load that marker.
+func TestPruneMgrLoadsThePersistedMarker(t *testing.T) {
+	env, w, _ := newPrunableTestLedger(t, t.TempDir(), 5)
+	defer env.Cleanup()
+
+	p, err := newPruneMgr(w.blockfileMgr.db)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), p.firstReadableBlockNum())
+	require.Equal(t, 0, p.firstStoredBlockfileNum())
+
+	require.NoError(t, p.setMarker(&pruneMarker{firstReadableBlockNum: 3, firstStoredBlockfileNum: 1}))
+
+	reloaded, err := newPruneMgr(w.blockfileMgr.db)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), reloaded.firstReadableBlockNum())
+	require.Equal(t, 1, reloaded.firstStoredBlockfileNum())
+}

--- a/common/ledger/blkstorage/rollback.go
+++ b/common/ledger/blkstorage/rollback.go
@@ -175,7 +175,9 @@ func (r *rollbackMgr) rollbackBlockFiles() error {
 		return err
 	}
 	// must not use index for block location search since the index can be behind the target block
-	targetFileNum, err := binarySearchFileNumForBlock(r.ledgerDir, r.targetBlockNum)
+	// TODO rollback is not pruning-aware: on a pruned ledger the files do not start at 0, and a target
+	// below the prune point cannot be satisfied at all. Both need handling before the two can coexist.
+	targetFileNum, err := binarySearchFileNumForBlock(r.ledgerDir, 0, r.targetBlockNum)
 	if err != nil {
 		return err
 	}

--- a/common/ledger/blockledger/fileledger/impl.go
+++ b/common/ledger/blockledger/fileledger/impl.go
@@ -8,11 +8,13 @@ package fileledger
 
 import (
 	"github.com/hyperledger/fabric-x-orderer/common/ledger"
+	"github.com/hyperledger/fabric-x-orderer/common/ledger/blkstorage"
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/blockledger"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/pkg/errors"
 )
 
 var logger = flogging.MustGetLogger("common.ledger.blockledger.file")
@@ -52,6 +54,11 @@ func (i *fileLedgerIterator) Next() (*cb.Block, cb.Status) {
 	result, err := i.commonIterator.Next()
 	if err != nil {
 		logger.Error(err)
+		if errors.Is(err, blkstorage.ErrPruned) {
+			// The block will never arrive, so the consumer has to be re-seeded rather than retry this
+			// position. This is the same answer a freshly created iterator gets for the same block.
+			return nil, cb.Status_BAD_REQUEST
+		}
 		return nil, cb.Status_SERVICE_UNAVAILABLE
 	}
 	// Cover the case where another thread calls Close on the iterator.

--- a/common/ledger/blockledger/fileledger/impl.go
+++ b/common/ledger/blockledger/fileledger/impl.go
@@ -31,6 +31,7 @@ type FileLedgerBlockStore interface {
 	RetrieveBlocks(startBlockNumber uint64) (ledger.ResultsIterator, error)
 	Shutdown()
 	RetrieveBlockByNumber(blockNum uint64) (*cb.Block, error)
+	PruneBefore(blockNum uint64) error
 }
 
 // NewFileLedger creates a new FileLedger for interaction with the ledger
@@ -123,4 +124,9 @@ func (fl *FileLedger) Append(block *cb.Block) error {
 
 func (fl *FileLedger) RetrieveBlockByNumber(blockNumber uint64) (*cb.Block, error) {
 	return fl.blockStore.RetrieveBlockByNumber(blockNumber)
+}
+
+// PruneBefore prunes the blocks below seq, see blockledger.Writer.
+func (fl *FileLedger) PruneBefore(seq uint64) error {
+	return fl.blockStore.PruneBefore(seq)
 }

--- a/common/ledger/blockledger/fileledger/impl.go
+++ b/common/ledger/blockledger/fileledger/impl.go
@@ -32,6 +32,7 @@ type FileLedgerBlockStore interface {
 	Shutdown()
 	RetrieveBlockByNumber(blockNum uint64) (*cb.Block, error)
 	PruneBefore(blockNum uint64) error
+	FirstAvailableBlockNumber() uint64
 }
 
 // NewFileLedger creates a new FileLedger for interaction with the ledger
@@ -71,7 +72,9 @@ func (fl *FileLedger) Iterator(startPosition *ab.SeekPosition) (blockledger.Iter
 	var startingBlockNumber uint64
 	switch start := startPosition.Type.(type) {
 	case *ab.SeekPosition_Oldest:
-		startingBlockNumber = 0
+		// Oldest means the oldest block this ledger can still serve, which is not block 0 once the front has
+		// been pruned or the ledger was bootstrapped from a snapshot.
+		startingBlockNumber = fl.blockStore.FirstAvailableBlockNumber()
 	case *ab.SeekPosition_Newest:
 		info, err := fl.blockStore.GetBlockchainInfo()
 		if err != nil {
@@ -87,6 +90,11 @@ func (fl *FileLedger) Iterator(startPosition *ab.SeekPosition) (blockledger.Iter
 		height := fl.Height()
 		if startingBlockNumber > height {
 			return &blockledger.NotFoundErrorIterator{}, 0
+		}
+		if first := fl.blockStore.FirstAvailableBlockNumber(); startingBlockNumber < first {
+			logger.Warnw("Requested block is not available on this ledger and never will be",
+				"blockNum", startingBlockNumber, "firstAvailableBlockNum", first)
+			return &blockledger.UnavailableErrorIterator{}, 0
 		}
 	case *ab.SeekPosition_NextCommit:
 		startingBlockNumber = fl.Height()

--- a/common/ledger/blockledger/fileledger/impl_test.go
+++ b/common/ledger/blockledger/fileledger/impl_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package fileledger
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -23,6 +22,7 @@ import (
 	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -519,4 +519,31 @@ func TestIteratorOldestWithoutPruning(t *testing.T) {
 	block, status := it.Next()
 	require.Equal(t, cb.Status_SUCCESS, status)
 	require.Zero(t, block.Header.Number)
+}
+
+// Scenario:
+//  1. Build a ledger whose iterator fails with ErrPruned, as it does when a prune overtakes a live
+//     reader mid-stream.
+//  2. Read from that iterator.
+//  3. Expect BAD_REQUEST rather than SERVICE_UNAVAILABLE: the block is gone for good, so retrying this
+//     position can never succeed and the consumer has to be re-seeded.
+func TestIteratorNextOnAPrunedBlockIsTerminal(t *testing.T) {
+	resultsIterator := &mockBlockStoreIterator{}
+	resultsIterator.On("Next").Return(nil, errors.WithMessage(blkstorage.ErrPruned, "cannot serve block [7]"))
+	resultsIterator.On("Close").Return()
+
+	fl := &FileLedger{
+		blockStore: &mockBlockStore{
+			blockchainInfo:  &cb.BlockchainInfo{Height: uint64(1)},
+			resultsIterator: resultsIterator,
+		},
+		signal: make(chan struct{}),
+	}
+
+	it, _ := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Oldest{}})
+	defer it.Close()
+
+	block, status := it.Next()
+	require.Nil(t, block)
+	require.Equal(t, cb.Status_BAD_REQUEST, status)
 }

--- a/common/ledger/blockledger/fileledger/impl_test.go
+++ b/common/ledger/blockledger/fileledger/impl_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	cl "github.com/hyperledger/fabric-x-orderer/common/ledger"
+	"github.com/hyperledger/fabric-x-orderer/common/ledger/blkstorage"
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/blkstorage/blkstoragetest"
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/blockledger"
 	"github.com/hyperledger/fabric-x-orderer/common/ledger/testutil"
@@ -67,6 +68,7 @@ type mockBlockStore struct {
 	defaultError               error
 	getBlockchainInfoError     error
 	retrieveBlockByNumberError error
+	prunedBefore               uint64
 }
 
 func (mbs *mockBlockStore) AddBlock(block *cb.Block) error {
@@ -103,6 +105,11 @@ func (mbs *mockBlockStore) RetrieveBlockByTxID(txID string) (*cb.Block, error) {
 
 func (mbs *mockBlockStore) RetrieveTxValidationCodeByTxID(txID string) (peer.TxValidationCode, error) {
 	return mbs.txValidationCode, mbs.defaultError
+}
+
+func (mbs *mockBlockStore) PruneBefore(blockNum uint64) error {
+	mbs.prunedBefore = blockNum
+	return mbs.defaultError
 }
 
 func (*mockBlockStore) Shutdown() {
@@ -384,4 +391,40 @@ func getSampleEnvelopeWithSignatureHeader() *cb.Envelope {
 	payload := &cb.Payload{Header: header}
 	payloadBytes := protoutil.MarshalOrPanic(payload)
 	return &cb.Envelope{Payload: payloadBytes}
+}
+
+// Scenario:
+//  1. Append a block to a ledger holding a genesis block, so it holds two.
+//  2. Call PruneBefore(1).
+//  3. Expect block 0 to be refused with ErrPruned and block 1 to be returned.
+//  4. Expect Height to stay 2.
+func TestPruneBefore(t *testing.T) {
+	tev, fl := initialize(t)
+	defer tev.tearDown()
+
+	require.NoError(t, fl.Append(blockledger.CreateNextBlock(fl, []*cb.Envelope{getSampleEnvelopeWithSignatureHeader()})))
+	require.Equal(t, uint64(2), fl.Height())
+
+	require.NoError(t, fl.PruneBefore(1))
+
+	_, err := fl.RetrieveBlockByNumber(0)
+	require.ErrorIs(t, err, blkstorage.ErrPruned)
+
+	block, err := fl.RetrieveBlockByNumber(1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), block.Header.Number)
+
+	require.Equal(t, uint64(2), fl.Height())
+}
+
+// Scenario:
+//  1. Call PruneBefore on a ledger whose block store returns an error.
+//  2. Expect the error to be returned rather than swallowed, and the requested block number to have reached
+//     the store.
+func TestPruneBeforeError(t *testing.T) {
+	store := &mockBlockStore{defaultError: fmt.Errorf("no pruning today")}
+	fl := &FileLedger{blockStore: store, signal: make(chan struct{})}
+
+	require.ErrorContains(t, fl.PruneBefore(7), "no pruning today")
+	require.Equal(t, uint64(7), store.prunedBefore)
 }

--- a/common/ledger/blockledger/fileledger/impl_test.go
+++ b/common/ledger/blockledger/fileledger/impl_test.go
@@ -69,6 +69,7 @@ type mockBlockStore struct {
 	getBlockchainInfoError     error
 	retrieveBlockByNumberError error
 	prunedBefore               uint64
+	firstAvailableBlockNumber  uint64
 }
 
 func (mbs *mockBlockStore) AddBlock(block *cb.Block) error {
@@ -105,6 +106,10 @@ func (mbs *mockBlockStore) RetrieveBlockByTxID(txID string) (*cb.Block, error) {
 
 func (mbs *mockBlockStore) RetrieveTxValidationCodeByTxID(txID string) (peer.TxValidationCode, error) {
 	return mbs.txValidationCode, mbs.defaultError
+}
+
+func (mbs *mockBlockStore) FirstAvailableBlockNumber() uint64 {
+	return mbs.firstAvailableBlockNumber
 }
 
 func (mbs *mockBlockStore) PruneBefore(blockNum uint64) error {
@@ -290,13 +295,16 @@ func TestBlockRetrievalWithSnapshot(t *testing.T) {
 	defer it3.Close()
 	require.Equal(t, uint64(numBlocks), startingNum3)
 
+	// A block covered by the snapshot is never coming to this ledger, so the request is terminal rather than
+	// not-yet-found -- the same answer a pruned block gets.
 	it4, _ := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: uint64(numBlocks - 1)}}})
 	defer it4.Close()
-	require.Equal(t, &blockledger.NotFoundErrorIterator{}, it4)
+	require.Equal(t, &blockledger.UnavailableErrorIterator{}, it4)
 
+	// Past the end of the ledger stays not-found: that block may yet be written.
 	it5, _ := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: uint64(numBlocks + 1)}}})
 	defer it5.Close()
-	require.Equal(t, &blockledger.NotFoundErrorIterator{}, it4)
+	require.Equal(t, &blockledger.NotFoundErrorIterator{}, it5)
 
 	// add a block and verify iterator.Next
 	nextBlk := blocks[numBlocks]
@@ -427,4 +435,88 @@ func TestPruneBeforeError(t *testing.T) {
 
 	require.ErrorContains(t, fl.PruneBefore(7), "no pruning today")
 	require.Equal(t, uint64(7), store.prunedBefore)
+}
+
+// Scenario:
+//  1. Append a block to a ledger holding a genesis block, then prune below block 1.
+//  2. Expect an Oldest iterator to start at block 1 rather than 0, and to return it.
+//  3. Expect Newest to still return block 1, since Height is unaffected and the last block always survives.
+func TestIteratorOldestOnPrunedLedger(t *testing.T) {
+	tev, fl := initialize(t)
+	defer tev.tearDown()
+
+	require.NoError(t, fl.Append(blockledger.CreateNextBlock(fl, []*cb.Envelope{getSampleEnvelopeWithSignatureHeader()})))
+	require.NoError(t, fl.PruneBefore(1))
+
+	it, num := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Oldest{}})
+	defer it.Close()
+	require.Equal(t, uint64(1), num, "Oldest must be the first block still available, not block 0")
+
+	block, status := it.Next()
+	require.Equal(t, cb.Status_SUCCESS, status)
+	require.Equal(t, uint64(1), block.Header.Number)
+
+	newest, num := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Newest{}})
+	defer newest.Close()
+	require.Equal(t, uint64(1), num)
+	block, status = newest.Next()
+	require.Equal(t, cb.Status_SUCCESS, status)
+	require.Equal(t, uint64(1), block.Header.Number)
+}
+
+// Scenario:
+//  1. Append a block and prune below block 1.
+//  2. Expect a Specified iterator for block 0 to report BAD_REQUEST, not NOT_FOUND: the block will never
+//     come back, so a consumer must re-seed rather than retry.
+//  3. Expect a Specified iterator past the end of the ledger to still report NOT_FOUND, since that block may
+//     simply not exist yet.
+//  4. Expect a Specified iterator at the first available block to succeed.
+func TestIteratorSpecifiedBelowPrunePoint(t *testing.T) {
+	tev, fl := initialize(t)
+	defer tev.tearDown()
+
+	require.NoError(t, fl.Append(blockledger.CreateNextBlock(fl, []*cb.Envelope{getSampleEnvelopeWithSignatureHeader()})))
+	require.NoError(t, fl.PruneBefore(1))
+
+	pruned, num := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Specified{
+		Specified: &ab.SeekSpecified{Number: 0},
+	}})
+	defer pruned.Close()
+	require.Zero(t, num)
+	_, status := pruned.Next()
+	require.Equal(t, cb.Status_BAD_REQUEST, status)
+
+	notYet, _ := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Specified{
+		Specified: &ab.SeekSpecified{Number: fl.Height() + 1},
+	}})
+	defer notYet.Close()
+	_, status = notYet.Next()
+	require.Equal(t, cb.Status_NOT_FOUND, status)
+
+	available, num := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Specified{
+		Specified: &ab.SeekSpecified{Number: 1},
+	}})
+	defer available.Close()
+	require.Equal(t, uint64(1), num)
+	block, status := available.Next()
+	require.Equal(t, cb.Status_SUCCESS, status)
+	require.Equal(t, uint64(1), block.Header.Number)
+}
+
+// Scenario:
+//  1. Append a block to a ledger that has never been pruned.
+//  2. Expect Oldest to start at block 0, unchanged.
+func TestIteratorOldestWithoutPruning(t *testing.T) {
+	tev, fl := initialize(t)
+	defer tev.tearDown()
+
+	require.NoError(t, fl.Append(blockledger.CreateNextBlock(fl, []*cb.Envelope{getSampleEnvelopeWithSignatureHeader()})))
+
+	it, num := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Oldest{}})
+	defer it.Close()
+	require.Zero(t, num)
+
+	block, status := it.Next()
+	require.Equal(t, cb.Status_SUCCESS, status)
+	require.Zero(t, block.Header.Number)
 }

--- a/common/ledger/blockledger/fileledger/mock/file_ledger_block_store.go
+++ b/common/ledger/blockledger/fileledger/mock/file_ledger_block_store.go
@@ -32,6 +32,17 @@ type FileLedgerBlockStore struct {
 		result1 *common.BlockchainInfo
 		result2 error
 	}
+	PruneBeforeStub        func(uint64) error
+	pruneBeforeMutex       sync.RWMutex
+	pruneBeforeArgsForCall []struct {
+		arg1 uint64
+	}
+	pruneBeforeReturns struct {
+		result1 error
+	}
+	pruneBeforeReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RetrieveBlockByNumberStub        func(uint64) (*common.Block, error)
 	retrieveBlockByNumberMutex       sync.RWMutex
 	retrieveBlockByNumberArgsForCall []struct {
@@ -181,6 +192,67 @@ func (fake *FileLedgerBlockStore) GetBlockchainInfoReturnsOnCall(i int, result1 
 		result1 *common.BlockchainInfo
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FileLedgerBlockStore) PruneBefore(arg1 uint64) error {
+	fake.pruneBeforeMutex.Lock()
+	ret, specificReturn := fake.pruneBeforeReturnsOnCall[len(fake.pruneBeforeArgsForCall)]
+	fake.pruneBeforeArgsForCall = append(fake.pruneBeforeArgsForCall, struct {
+		arg1 uint64
+	}{arg1})
+	stub := fake.PruneBeforeStub
+	fakeReturns := fake.pruneBeforeReturns
+	fake.recordInvocation("PruneBefore", []interface{}{arg1})
+	fake.pruneBeforeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FileLedgerBlockStore) PruneBeforeCallCount() int {
+	fake.pruneBeforeMutex.RLock()
+	defer fake.pruneBeforeMutex.RUnlock()
+	return len(fake.pruneBeforeArgsForCall)
+}
+
+func (fake *FileLedgerBlockStore) PruneBeforeCalls(stub func(uint64) error) {
+	fake.pruneBeforeMutex.Lock()
+	defer fake.pruneBeforeMutex.Unlock()
+	fake.PruneBeforeStub = stub
+}
+
+func (fake *FileLedgerBlockStore) PruneBeforeArgsForCall(i int) uint64 {
+	fake.pruneBeforeMutex.RLock()
+	defer fake.pruneBeforeMutex.RUnlock()
+	argsForCall := fake.pruneBeforeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FileLedgerBlockStore) PruneBeforeReturns(result1 error) {
+	fake.pruneBeforeMutex.Lock()
+	defer fake.pruneBeforeMutex.Unlock()
+	fake.PruneBeforeStub = nil
+	fake.pruneBeforeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) PruneBeforeReturnsOnCall(i int, result1 error) {
+	fake.pruneBeforeMutex.Lock()
+	defer fake.pruneBeforeMutex.Unlock()
+	fake.PruneBeforeStub = nil
+	if fake.pruneBeforeReturnsOnCall == nil {
+		fake.pruneBeforeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pruneBeforeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FileLedgerBlockStore) RetrieveBlockByNumber(arg1 uint64) (*common.Block, error) {

--- a/common/ledger/blockledger/fileledger/mock/file_ledger_block_store.go
+++ b/common/ledger/blockledger/fileledger/mock/file_ledger_block_store.go
@@ -20,6 +20,16 @@ type FileLedgerBlockStore struct {
 	addBlockReturnsOnCall map[int]struct {
 		result1 error
 	}
+	FirstAvailableBlockNumberStub        func() uint64
+	firstAvailableBlockNumberMutex       sync.RWMutex
+	firstAvailableBlockNumberArgsForCall []struct {
+	}
+	firstAvailableBlockNumberReturns struct {
+		result1 uint64
+	}
+	firstAvailableBlockNumberReturnsOnCall map[int]struct {
+		result1 uint64
+	}
 	GetBlockchainInfoStub        func() (*common.BlockchainInfo, error)
 	getBlockchainInfoMutex       sync.RWMutex
 	getBlockchainInfoArgsForCall []struct {
@@ -135,6 +145,59 @@ func (fake *FileLedgerBlockStore) AddBlockReturnsOnCall(i int, result1 error) {
 	}
 	fake.addBlockReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) FirstAvailableBlockNumber() uint64 {
+	fake.firstAvailableBlockNumberMutex.Lock()
+	ret, specificReturn := fake.firstAvailableBlockNumberReturnsOnCall[len(fake.firstAvailableBlockNumberArgsForCall)]
+	fake.firstAvailableBlockNumberArgsForCall = append(fake.firstAvailableBlockNumberArgsForCall, struct {
+	}{})
+	stub := fake.FirstAvailableBlockNumberStub
+	fakeReturns := fake.firstAvailableBlockNumberReturns
+	fake.recordInvocation("FirstAvailableBlockNumber", []interface{}{})
+	fake.firstAvailableBlockNumberMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FileLedgerBlockStore) FirstAvailableBlockNumberCallCount() int {
+	fake.firstAvailableBlockNumberMutex.RLock()
+	defer fake.firstAvailableBlockNumberMutex.RUnlock()
+	return len(fake.firstAvailableBlockNumberArgsForCall)
+}
+
+func (fake *FileLedgerBlockStore) FirstAvailableBlockNumberCalls(stub func() uint64) {
+	fake.firstAvailableBlockNumberMutex.Lock()
+	defer fake.firstAvailableBlockNumberMutex.Unlock()
+	fake.FirstAvailableBlockNumberStub = stub
+}
+
+func (fake *FileLedgerBlockStore) FirstAvailableBlockNumberReturns(result1 uint64) {
+	fake.firstAvailableBlockNumberMutex.Lock()
+	defer fake.firstAvailableBlockNumberMutex.Unlock()
+	fake.FirstAvailableBlockNumberStub = nil
+	fake.firstAvailableBlockNumberReturns = struct {
+		result1 uint64
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) FirstAvailableBlockNumberReturnsOnCall(i int, result1 uint64) {
+	fake.firstAvailableBlockNumberMutex.Lock()
+	defer fake.firstAvailableBlockNumberMutex.Unlock()
+	fake.FirstAvailableBlockNumberStub = nil
+	if fake.firstAvailableBlockNumberReturnsOnCall == nil {
+		fake.firstAvailableBlockNumberReturnsOnCall = make(map[int]struct {
+			result1 uint64
+		})
+	}
+	fake.firstAvailableBlockNumberReturnsOnCall[i] = struct {
+		result1 uint64
 	}{result1}
 }
 

--- a/common/ledger/blockledger/ledger.go
+++ b/common/ledger/blockledger/ledger.go
@@ -57,6 +57,11 @@ type Reader interface {
 type Writer interface {
 	// Append a new block to the ledger
 	Append(block *cb.Block) error
+	// PruneBefore prunes the blocks below seq. It is an upper bound rather than an exact point: storage
+	// removes whole files only, so it may keep more than asked, but never less. Reads below seq
+	// fail afterwards whether or not their bytes were removed. Height is unaffected, and the call is
+	// idempotent and monotone: a seq at or below the current bound changes nothing.
+	PruneBefore(seq uint64) error
 }
 
 // ReadWriter encapsulates the read/write functions of the ledger

--- a/common/ledger/blockledger/util.go
+++ b/common/ledger/blockledger/util.go
@@ -40,6 +40,28 @@ func (nfei *NotFoundErrorIterator) ReadyChan() <-chan struct{} {
 // Close does nothing
 func (nfei *NotFoundErrorIterator) Close() {}
 
+// UnavailableErrorIterator always returns an error of cb.Status_BAD_REQUEST, for a request for blocks below
+// the first one a ledger can serve, whether they were pruned or covered by a snapshot
+// bootstrap.
+// It is deliberately distinct from NotFoundErrorIterator: a block that is not found may simply not exist
+// yet and is worth retrying, while these never arrive, so a consumer that has fallen behind has to be
+// re-seeded from elsewhere instead. Note the status is BAD_REQUEST rather than SERVICE_UNAVAILABLE, which
+// would suggest a transient condition.
+type UnavailableErrorIterator struct{}
+
+// Next returns nil, cb.Status_BAD_REQUEST
+func (*UnavailableErrorIterator) Next() (*cb.Block, cb.Status) {
+	return nil, cb.Status_BAD_REQUEST
+}
+
+// ReadyChan returns a closed channel
+func (*UnavailableErrorIterator) ReadyChan() <-chan struct{} {
+	return closedChan
+}
+
+// Close does nothing
+func (*UnavailableErrorIterator) Close() {}
+
 // CreateNextBlock provides a utility way to construct the next block from
 // contents and metadata for a given ledger
 // XXX This will need to be modified to accept marshaled envelopes

--- a/node/batcher/batcher_cert_pinning_test.go
+++ b/node/batcher/batcher_cert_pinning_test.go
@@ -91,7 +91,13 @@ func (s *pinningTestSetup) dial(t *testing.T, clientKP *tlsgen.CertKeyPair) prot
 func (s *pinningTestSetup) RequestsReceived() int {
 	var total int
 	for seq := range s.batcher.Ledger.Height(pinnedPartyID) {
-		total += len(s.batcher.Ledger.RetrieveBatchByNumber(pinnedPartyID, seq).Requests())
+		batch, err := s.batcher.Ledger.RetrieveBatchByNumber(pinnedPartyID, seq)
+		if err != nil {
+			// This helper is called from a require.Eventually closure, so it cannot fail the test
+			// itself without calling FailNow off the test goroutine.
+			panic(err)
+		}
+		total += len(batch.Requests())
 	}
 	return total
 }

--- a/node/batcher/batcher_role.go
+++ b/node/batcher/batcher_role.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	"github.com/hyperledger/fabric-x-orderer/common/ledger/blkstorage"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/consensus/state"
 	"github.com/pkg/errors"
@@ -89,7 +90,7 @@ type BatchLedgerWriter interface {
 
 type BatchLedgeReader interface {
 	Height(partyID types.PartyID) uint64
-	RetrieveBatchByNumber(partyID types.PartyID, seq uint64) types.Batch
+	RetrieveBatchByNumber(partyID types.PartyID, seq uint64) (types.Batch, error)
 }
 
 //go:generate counterfeiter -o mocks/batch_ledger.go . BatchLedger
@@ -258,6 +259,8 @@ func (b *BatcherRole) getTermAndNotifyChange() {
 // to prevent a case where such a tx falls through the cracks, after a term change
 // all batchers resubmit to their pools txs in batches with their BAFs still in pending state
 // this will also be used after config update for resubmitting expired BAFs while ignoring the prev primary parameter
+// Batches already pruned are skipped, so this does not re-inject the requests of every
+// pending BAF signed by this node.
 func (b *BatcherRole) ResubmitPendingBAFs(state *state.State, prevPrimary types.PartyID, ignorePrevPrimary bool) {
 	for _, baf := range state.Pending {
 		if baf.Shard() == b.Shard && baf.Signer() == b.ID {
@@ -265,9 +268,17 @@ func (b *BatcherRole) ResubmitPendingBAFs(state *state.State, prevPrimary types.
 				continue
 			}
 			b.Logger.Debugf("found pending BAF signed by me (id: %d) from primary: %d ; %s", b.ID, baf.Primary(), baf.String())
-			batch := b.Ledger.RetrieveBatchByNumber(baf.Primary(), uint64(baf.Seq()))
-			if batch == nil {
-				b.Logger.Panicf("Error: No such batch; pending BAF signed by me (id: %d) from primary: %d ; %s", b.ID, baf.Primary(), baf.String())
+			batch, err := b.Ledger.RetrieveBatchByNumber(baf.Primary(), uint64(baf.Seq()))
+			if errors.Is(err, blkstorage.ErrPruned) {
+				// The batch was pruned, so its TXs are old enough that the censorship machinery has already
+				// had them re-batched and committed by another primary. Nothing to resubmit.
+				b.Logger.Warnf("Skipping pruned batch for pending BAF signed by me (id: %d) from primary: %d ; %s",
+					b.ID, baf.Primary(), baf.String())
+				continue
+			}
+			if err != nil {
+				b.Logger.Panicf("Error: No such batch; pending BAF signed by me (id: %d) from primary: %d ; %s: %s",
+					b.ID, baf.Primary(), baf.String(), err)
 			}
 			for _, req := range batch.Requests() {
 				if err := b.MemPool.Submit(req); err != nil {

--- a/node/batcher/batcher_role_old_test.go
+++ b/node/batcher/batcher_role_old_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -42,8 +43,8 @@ func (*noopLedger) Height(partyID arma_types.PartyID) uint64 {
 	return 0
 }
 
-func (*noopLedger) RetrieveBatchByNumber(partyID arma_types.PartyID, seq uint64) arma_types.Batch {
-	return nil
+func (*noopLedger) RetrieveBatchByNumber(partyID arma_types.PartyID, seq uint64) (arma_types.Batch, error) {
+	return nil, errors.New("noopLedger holds no batches")
 }
 
 type naiveReplication struct {
@@ -77,9 +78,9 @@ func (r *naiveReplication) Height(partyID arma_types.PartyID) uint64 {
 	return 0
 }
 
-func (r *naiveReplication) RetrieveBatchByNumber(partyID arma_types.PartyID, seq uint64) arma_types.Batch {
+func (r *naiveReplication) RetrieveBatchByNumber(partyID arma_types.PartyID, seq uint64) (arma_types.Batch, error) {
 	// TODO use in test
-	return nil
+	return nil, errors.New("naiveReplication holds no batches")
 }
 
 type acker struct {

--- a/node/batcher/batcher_role_test.go
+++ b/node/batcher/batcher_role_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	"github.com/hyperledger/fabric-x-orderer/common/ledger/blkstorage"
 	"github.com/hyperledger/fabric-x-orderer/common/operations"
 	arma_types "github.com/hyperledger/fabric-x-orderer/common/types"
 	"github.com/hyperledger/fabric-x-orderer/node/batcher"
@@ -677,7 +678,7 @@ func TestResubmitPending(t *testing.T) {
 
 	require.Zero(t, pool.SubmitCallCount())
 
-	ledger.RetrieveBatchByNumberReturns(batch)
+	ledger.RetrieveBatchByNumberReturns(batch, nil)
 
 	myBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID), 0, 0, nil)
 	notMyBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), arma_types.PartyID(batcherID+1), 0, 0, nil)
@@ -720,6 +721,60 @@ func TestResubmitPending(t *testing.T) {
 
 	require.Equal(t, arma_types.PartyID(1), ledger.HeightArgsForCall(0))
 	require.Equal(t, arma_types.PartyID(2), ledger.HeightArgsForCall(1))
+}
+
+// Scenario:
+//  1. Build a batcher and hand it a pending BAF it signed itself.
+//  2. Make the ledger report the batch as pruned.
+//  3. Expect resubmission to skip it without panicking and without touching the pool.
+func TestResubmitPendingSkipsPrunedBatch(t *testing.T) {
+	batchers := []arma_types.PartyID{1, 2, 3, 4}
+	batcherID := arma_types.PartyID(2)
+	shardID := arma_types.ShardID(0)
+
+	b := createBatcher(t, batcherID, shardID, batchers, uint16(len(batchers)), testutil.CreateLogger(t, int(batcherID)))
+
+	pool := &mocks.FakeMemPool{}
+	b.MemPool = pool
+
+	ledger := &mocks.FakeBatchLedger{}
+	ledger.RetrieveBatchByNumberReturns(nil, errors.Join(blkstorage.ErrPruned, errors.New("wrapped by the ledger")))
+	b.Ledger = ledger
+
+	myBAF := arma_types.NewSimpleBatchAttestationFragment(shardID, 1, 0, []byte("digest"), batcherID, 0, 0, nil)
+
+	require.NotPanics(t, func() {
+		b.ResubmitPendingBAFs(&state.State{
+			Pending: []arma_types.BatchAttestationFragment{myBAF},
+		}, 1, false)
+	})
+
+	require.Equal(t, 1, ledger.RetrieveBatchByNumberCallCount())
+	require.Zero(t, pool.SubmitCallCount())
+}
+
+// Scenario:
+//  1. Build a batcher and hand it a pending BAF it signed itself.
+//  2. Make the ledger fail for a reason other than pruning.
+//  3. Expect resubmission to panic, since a batch that should be there is missing.
+func TestResubmitPendingPanicsOnOtherLedgerError(t *testing.T) {
+	batchers := []arma_types.PartyID{1, 2, 3, 4}
+	batcherID := arma_types.PartyID(2)
+	shardID := arma_types.ShardID(0)
+
+	b := createBatcher(t, batcherID, shardID, batchers, uint16(len(batchers)), testutil.CreateLogger(t, int(batcherID)))
+
+	ledger := &mocks.FakeBatchLedger{}
+	ledger.RetrieveBatchByNumberReturns(nil, errors.New("index is corrupt"))
+	b.Ledger = ledger
+
+	myBAF := arma_types.NewSimpleBatchAttestationFragment(shardID, 1, 0, []byte("digest"), batcherID, 0, 0, nil)
+
+	require.Panics(t, func() {
+		b.ResubmitPendingBAFs(&state.State{
+			Pending: []arma_types.BatchAttestationFragment{myBAF},
+		}, 1, false)
+	})
 }
 
 func TestVerifyBatch(t *testing.T) {

--- a/node/batcher/batcher_test.go
+++ b/node/batcher/batcher_test.go
@@ -304,10 +304,12 @@ func TestBatcherComplainAndReqFwd(t *testing.T) {
 	}, 30*time.Second, 10*time.Millisecond)
 
 	// make sure req2 did not disappear
-	require.Equal(t, 1, len(batchers[1].Ledger.RetrieveBatchByNumber(2, 0).Requests()))
+	storedBatch, err := batchers[1].Ledger.RetrieveBatchByNumber(2, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(storedBatch.Requests()))
 	rawReq, err := proto.Marshal(req2)
 	require.NoError(t, err)
-	require.Equal(t, rawReq, batchers[1].Ledger.RetrieveBatchByNumber(2, 0).Requests()[0])
+	require.Equal(t, rawReq, storedBatch.Requests()[0])
 
 	// now recover old primary
 	batchers[0] = recoverBatcher(t, ca, loggers[0], configs[0], routerKeyPairs, batcherNodes[0], stubConsenters[0])
@@ -495,7 +497,9 @@ func TestBatchedRequestsHasEnvelopeBytes(t *testing.T) {
 		return batchers[0].Ledger.Height(1) == uint64(1)
 	}, 30*time.Second, 10*time.Millisecond)
 
-	rawReq := batchers[0].Ledger.RetrieveBatchByNumber(1, 0).Requests()[0]
+	storedBatch, err := batchers[0].Ledger.RetrieveBatchByNumber(1, 0)
+	require.NoError(t, err)
+	rawReq := storedBatch.Requests()[0]
 
 	// Unmarshal as Envelope, and check that there are no unknown fields
 	env := &common.Envelope{}

--- a/node/batcher/mocks/batch_ledger.go
+++ b/node/batcher/mocks/batch_ledger.go
@@ -30,7 +30,7 @@ type FakeBatchLedger struct {
 	heightReturnsOnCall map[int]struct {
 		result1 uint64
 	}
-	RetrieveBatchByNumberStub        func(types.PartyID, uint64) types.Batch
+	RetrieveBatchByNumberStub        func(types.PartyID, uint64) (types.Batch, error)
 	retrieveBatchByNumberMutex       sync.RWMutex
 	retrieveBatchByNumberArgsForCall []struct {
 		arg1 types.PartyID
@@ -38,9 +38,11 @@ type FakeBatchLedger struct {
 	}
 	retrieveBatchByNumberReturns struct {
 		result1 types.Batch
+		result2 error
 	}
 	retrieveBatchByNumberReturnsOnCall map[int]struct {
 		result1 types.Batch
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -154,7 +156,7 @@ func (fake *FakeBatchLedger) HeightReturnsOnCall(i int, result1 uint64) {
 	}{result1}
 }
 
-func (fake *FakeBatchLedger) RetrieveBatchByNumber(arg1 types.PartyID, arg2 uint64) types.Batch {
+func (fake *FakeBatchLedger) RetrieveBatchByNumber(arg1 types.PartyID, arg2 uint64) (types.Batch, error) {
 	fake.retrieveBatchByNumberMutex.Lock()
 	ret, specificReturn := fake.retrieveBatchByNumberReturnsOnCall[len(fake.retrieveBatchByNumberArgsForCall)]
 	fake.retrieveBatchByNumberArgsForCall = append(fake.retrieveBatchByNumberArgsForCall, struct {
@@ -169,9 +171,9 @@ func (fake *FakeBatchLedger) RetrieveBatchByNumber(arg1 types.PartyID, arg2 uint
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeBatchLedger) RetrieveBatchByNumberCallCount() int {
@@ -180,7 +182,7 @@ func (fake *FakeBatchLedger) RetrieveBatchByNumberCallCount() int {
 	return len(fake.retrieveBatchByNumberArgsForCall)
 }
 
-func (fake *FakeBatchLedger) RetrieveBatchByNumberCalls(stub func(types.PartyID, uint64) types.Batch) {
+func (fake *FakeBatchLedger) RetrieveBatchByNumberCalls(stub func(types.PartyID, uint64) (types.Batch, error)) {
 	fake.retrieveBatchByNumberMutex.Lock()
 	defer fake.retrieveBatchByNumberMutex.Unlock()
 	fake.RetrieveBatchByNumberStub = stub
@@ -193,27 +195,30 @@ func (fake *FakeBatchLedger) RetrieveBatchByNumberArgsForCall(i int) (types.Part
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeBatchLedger) RetrieveBatchByNumberReturns(result1 types.Batch) {
+func (fake *FakeBatchLedger) RetrieveBatchByNumberReturns(result1 types.Batch, result2 error) {
 	fake.retrieveBatchByNumberMutex.Lock()
 	defer fake.retrieveBatchByNumberMutex.Unlock()
 	fake.RetrieveBatchByNumberStub = nil
 	fake.retrieveBatchByNumberReturns = struct {
 		result1 types.Batch
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeBatchLedger) RetrieveBatchByNumberReturnsOnCall(i int, result1 types.Batch) {
+func (fake *FakeBatchLedger) RetrieveBatchByNumberReturnsOnCall(i int, result1 types.Batch, result2 error) {
 	fake.retrieveBatchByNumberMutex.Lock()
 	defer fake.retrieveBatchByNumberMutex.Unlock()
 	fake.RetrieveBatchByNumberStub = nil
 	if fake.retrieveBatchByNumberReturnsOnCall == nil {
 		fake.retrieveBatchByNumberReturnsOnCall = make(map[int]struct {
 			result1 types.Batch
+			result2 error
 		})
 	}
 	fake.retrieveBatchByNumberReturnsOnCall[i] = struct {
 		result1 types.Batch
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeBatchLedger) Invocations() map[string][][]interface{} {

--- a/node/ledger/batch_ledger_array.go
+++ b/node/ledger/batch_ledger_array.go
@@ -38,8 +38,6 @@ func NewBatchLedgerArray(shardID types.ShardID, partyID types.PartyID, parties [
 	// TODO We are using the Fabric block storage for now even though it is not ideal.
 	// (1) We don't need the hash chain, and
 	// (2) we don't need to index TXs.
-	// In addition, in the future we may want to (3) prune batches that had already been received by a quorum of
-	// assemblers; this however requires additional protocols between assemblers and consensus.
 	provider, err := blkstorage.NewProvider(
 		blkstorage.NewConf(batchLedgerDir, -1),
 		&blkstorage.IndexConfig{
@@ -122,6 +120,15 @@ func (bla *BatchLedgerArray) RetrieveBatchByNumber(partyID types.PartyID, seq ui
 		bla.logger.Panicf("partyID does not exist: %d", partyID)
 	}
 	return part.RetrieveBatchByNumber(seq)
+}
+
+// PruneBefore prunes the batches below seq from the ledger part of the given primary party.
+func (bla *BatchLedgerArray) PruneBefore(primaryPartyID types.PartyID, seq uint64) error {
+	part, ok := bla.ledgerParts[primaryPartyID]
+	if !ok {
+		return errors.Errorf("partyID does not exist: %d", primaryPartyID)
+	}
+	return part.PruneBefore(seq)
 }
 
 func (bla *BatchLedgerArray) Part(partyID types.PartyID) *BatchLedgerPart {

--- a/node/ledger/batch_ledger_array.go
+++ b/node/ledger/batch_ledger_array.go
@@ -114,7 +114,9 @@ func (bla *BatchLedgerArray) Append(partyID types.PartyID, batchSeq types.BatchS
 	part.Append(batchSeq, configSeq, batchedRequests, digest, primarySignature)
 }
 
-func (bla *BatchLedgerArray) RetrieveBatchByNumber(partyID types.PartyID, seq uint64) types.Batch {
+// RetrieveBatchByNumber retrieves the batch with a specific sequence from the ledger part of the given party,
+// and an error if the batch cannot be retrieved.
+func (bla *BatchLedgerArray) RetrieveBatchByNumber(partyID types.PartyID, seq uint64) (types.Batch, error) {
 	part, ok := bla.ledgerParts[partyID]
 	if !ok {
 		bla.logger.Panicf("partyID does not exist: %d", partyID)

--- a/node/ledger/batch_ledger_array_test.go
+++ b/node/ledger/batch_ledger_array_test.go
@@ -51,7 +51,7 @@ func TestBatchLedgerArray(t *testing.T) {
 			}
 			a.Append(pID, types.BatchSequence(seq), 0, batchedRequests, batchedRequests.Digest(), nil)
 			require.Equal(t, seq+1, a.Height(pID))
-			batch := a.RetrieveBatchByNumber(pID, seq)
+			batch := mustGetBatchOf(t, a, pID, seq)
 			require.NotNil(t, batch)
 			require.Equal(t, batchedRequests, batch.Requests())
 			require.Equal(t, pID, batch.Primary())
@@ -67,7 +67,7 @@ func TestBatchLedgerArray(t *testing.T) {
 
 	for _, pID := range parties {
 		require.Equal(t, numBatches, a.Height(pID))
-		batch := a.RetrieveBatchByNumber(pID, numBatches-1)
+		batch := mustGetBatchOf(t, a, pID, numBatches-1)
 		require.NotNil(t, batch)
 		require.Equal(t, batchedRequests, batch.Requests())
 		require.Equal(t, pID, batch.Primary())
@@ -81,7 +81,7 @@ func TestBatchLedgerArray(t *testing.T) {
 			}
 			a.Append(pID, types.BatchSequence(seq), 0, batchedRequests, batchedRequests.Digest(), nil)
 			require.Equal(t, seq+1, a.Height(pID))
-			batch := a.RetrieveBatchByNumber(pID, seq)
+			batch := mustGetBatchOf(t, a, pID, seq)
 			require.NotNil(t, batch)
 			require.Equal(t, batchedRequests, batch.Requests())
 			require.Equal(t, pID, batch.Primary())
@@ -104,7 +104,7 @@ func TestBatchLedgerArray(t *testing.T) {
 
 	for _, pID := range oldParties {
 		require.Equal(t, 2*numBatches, a.Height(pID))
-		batch := a.RetrieveBatchByNumber(pID, 2*numBatches-1)
+		batch := mustGetBatchOf(t, a, pID, 2*numBatches-1)
 		require.NotNil(t, batch)
 		require.Equal(t, batchedRequests, batch.Requests())
 		require.Equal(t, pID, batch.Primary())
@@ -118,7 +118,7 @@ func TestBatchLedgerArray(t *testing.T) {
 		}
 		a.Append(5, types.BatchSequence(seq), 0, batchedRequests, batchedRequests.Digest(), nil)
 		require.Equal(t, seq+1, a.Height(newParty))
-		batch := a.RetrieveBatchByNumber(newParty, seq)
+		batch := mustGetBatchOf(t, a, newParty, seq)
 		require.NotNil(t, batch)
 		require.Equal(t, batchedRequests, batch.Requests())
 		require.Equal(t, newParty, batch.Primary())
@@ -145,7 +145,7 @@ func TestBatchLedgerArrayPart(t *testing.T) {
 		for seq := uint64(0); seq < 10; seq++ {
 			part.Append(types.BatchSequence(seq), 0, batchedRequests, batchedRequests.Digest(), nil)
 			require.Equal(t, seq+1, part.Height())
-			batch := part.RetrieveBatchByNumber(seq)
+			batch := mustGetBatch(t, part, seq)
 			require.NotNil(t, batch)
 			require.Equal(t, batchedRequests, batch.Requests())
 			require.Equal(t, pID, batch.Primary())
@@ -176,7 +176,7 @@ func TestBatchLedgerArrayMissingPartyID(t *testing.T) {
 		a.Append(missing, types.BatchSequence(0), 0, types.BatchedRequests{[]byte("x")}, []byte("digest"), nil)
 	})
 
-	require.Panics(t, func() { _ = a.RetrieveBatchByNumber(missing, 0) })
+	require.Panics(t, func() { _, _ = a.RetrieveBatchByNumber(missing, 0) })
 
 	// PruneBefore returns an error .
 	require.ErrorContains(t, a.PruneBefore(missing, 0), "partyID does not exist: 99")
@@ -204,7 +204,7 @@ func TestBatchLedgerArrayWithPrimarySignature(t *testing.T) {
 	require.Equal(t, uint64(1), a.Height(partyID))
 
 	// Retrieve the batch and verify the primary signature
-	batch := a.RetrieveBatchByNumber(partyID, seq)
+	batch := mustGetBatchOf(t, a, partyID, seq)
 	require.NotNil(t, batch)
 	require.Equal(t, batchedRequests, batch.Requests())
 	require.Equal(t, partyID, batch.Primary())
@@ -224,13 +224,13 @@ func TestBatchLedgerArrayWithPrimarySignature(t *testing.T) {
 	require.Equal(t, uint64(2), a.Height(partyID))
 
 	// Retrieve the second batch and verify its signature
-	batch2 := a.RetrieveBatchByNumber(partyID, seq2)
+	batch2 := mustGetBatchOf(t, a, partyID, seq2)
 	require.NotNil(t, batch2)
 	require.Equal(t, batchedRequests2, batch2.Requests())
 	require.Equal(t, primarySignature2, batch2.PrimarySignature())
 
 	// Verify the first batch signature is still intact
-	batch1Again := a.RetrieveBatchByNumber(partyID, seq)
+	batch1Again := mustGetBatchOf(t, a, partyID, seq)
 	require.NotNil(t, batch1Again)
 	require.Equal(t, primarySignature, batch1Again.PrimarySignature())
 
@@ -241,11 +241,11 @@ func TestBatchLedgerArrayWithPrimarySignature(t *testing.T) {
 	require.NotNil(t, a)
 
 	// Verify signatures are persisted correctly
-	batchAfterReopen := a.RetrieveBatchByNumber(partyID, seq)
+	batchAfterReopen := mustGetBatchOf(t, a, partyID, seq)
 	require.NotNil(t, batchAfterReopen)
 	require.Equal(t, primarySignature, batchAfterReopen.PrimarySignature())
 
-	batch2AfterReopen := a.RetrieveBatchByNumber(partyID, seq2)
+	batch2AfterReopen := mustGetBatchOf(t, a, partyID, seq2)
 	require.NotNil(t, batch2AfterReopen)
 	require.Equal(t, primarySignature2, batch2AfterReopen.PrimarySignature())
 
@@ -277,15 +277,15 @@ func TestBatchLedgerArrayPruneBefore(t *testing.T) {
 	const pruned = types.PartyID(2)
 	require.NoError(t, a.PruneBefore(pruned, 20))
 
-	require.Nil(t, a.RetrieveBatchByNumber(pruned, 0))
-	require.NotNil(t, a.RetrieveBatchByNumber(pruned, 20))
+	requireNoBatchOf(t, a, pruned, 0)
+	_ = mustGetBatchOf(t, a, pruned, 20)
 	require.Equal(t, uint64(numBatches), a.Height(pruned))
 
 	for _, pID := range parties {
 		if pID == pruned {
 			continue
 		}
-		require.NotNil(t, a.RetrieveBatchByNumber(pID, 0), "party %d should be untouched", pID)
+		_ = mustGetBatchOf(t, a, pID, 0)
 		require.Equal(t, uint64(numBatches), a.Height(pID))
 	}
 }

--- a/node/ledger/batch_ledger_array_test.go
+++ b/node/ledger/batch_ledger_array_test.go
@@ -178,6 +178,9 @@ func TestBatchLedgerArrayMissingPartyID(t *testing.T) {
 
 	require.Panics(t, func() { _ = a.RetrieveBatchByNumber(missing, 0) })
 
+	// PruneBefore returns an error .
+	require.ErrorContains(t, a.PruneBefore(missing, 0), "partyID does not exist: 99")
+
 	a.Close()
 }
 
@@ -247,4 +250,42 @@ func TestBatchLedgerArrayWithPrimarySignature(t *testing.T) {
 	require.Equal(t, primarySignature2, batch2AfterReopen.PrimarySignature())
 
 	a.Close()
+}
+
+// Scenario:
+//  1. Open a four-party array and append 30 batches to each party's ledger.
+//  2. Call PruneBefore(party 2, 20).
+//  3. Expect batches below the prune point to be gone from party 2 and its Height to stay 30.
+//  4. Expect the other parties' ledgers to be untouched, so routing went to the right part.
+func TestBatchLedgerArrayPruneBefore(t *testing.T) {
+	dir := t.TempDir()
+	logger := flogging.MustGetLogger("test")
+
+	parties := []types.PartyID{1, 2, 3, 4}
+	a, err := NewBatchLedgerArray(1, 1, parties, "test-channel", dir, logger)
+	require.NoError(t, err)
+	defer a.Close()
+
+	const numBatches = 30
+	for _, pID := range parties {
+		for seq := uint64(0); seq < numBatches; seq++ {
+			reqs := types.BatchedRequests{[]byte(fmt.Sprintf("tx-%d-%d", pID, seq))}
+			a.Append(pID, types.BatchSequence(seq), 0, reqs, reqs.Digest(), nil)
+		}
+	}
+
+	const pruned = types.PartyID(2)
+	require.NoError(t, a.PruneBefore(pruned, 20))
+
+	require.Nil(t, a.RetrieveBatchByNumber(pruned, 0))
+	require.NotNil(t, a.RetrieveBatchByNumber(pruned, 20))
+	require.Equal(t, uint64(numBatches), a.Height(pruned))
+
+	for _, pID := range parties {
+		if pID == pruned {
+			continue
+		}
+		require.NotNil(t, a.RetrieveBatchByNumber(pID, 0), "party %d should be untouched", pID)
+		require.Equal(t, uint64(numBatches), a.Height(pID))
+	}
 }

--- a/node/ledger/batch_ledger_part.go
+++ b/node/ledger/batch_ledger_part.go
@@ -98,6 +98,14 @@ func (b *BatchLedgerPart) RetrieveBatchByNumber(seq uint64) types.Batch {
 	return (*FabricBatch)(block)
 }
 
+// PruneBefore prunes the batches below seq. Retrieving a batch below seq fails afterwards
+// whether or not its bytes were removed, and Height() is unaffected.
+func (b *BatchLedgerPart) PruneBefore(seq uint64) error {
+	b.logger.Debugf("Party %d, Shard: %d, is pruning batches below sequence %d from Primary: %d",
+		b.partyID, b.shardID, seq, b.primaryPartyID)
+	return b.ledger.PruneBefore(seq)
+}
+
 // Ledger returns the underlying ledger, which supports an iterator as well.
 func (b *BatchLedgerPart) Ledger() blockledger.ReadWriter {
 	return b.ledger

--- a/node/ledger/batch_ledger_part.go
+++ b/node/ledger/batch_ledger_part.go
@@ -87,15 +87,15 @@ func (b *BatchLedgerPart) Height() uint64 {
 	return b.ledger.Height()
 }
 
-// RetrieveBatchByNumber retrieves the batch with a specific sequence, or returns nil if not found.
-func (b *BatchLedgerPart) RetrieveBatchByNumber(seq uint64) types.Batch {
+// RetrieveBatchByNumber retrieves the batch with a specific sequence, and an error if the batch cannot be retrieved.
+func (b *BatchLedgerPart) RetrieveBatchByNumber(seq uint64) (types.Batch, error) {
 	block, err := b.ledger.RetrieveBlockByNumber(seq)
 	if err != nil {
-		b.logger.Errorf("Batch not found: %d, err: %s", seq, err)
-		return nil
+		return nil, errors.WithMessagef(err, "failed retrieving batch %d of primary %d in shard %d",
+			seq, b.primaryPartyID, b.shardID)
 	}
 
-	return (*FabricBatch)(block)
+	return (*FabricBatch)(block), nil
 }
 
 // PruneBefore prunes the batches below seq. Retrieving a batch below seq fails afterwards

--- a/node/ledger/batch_ledger_part_test.go
+++ b/node/ledger/batch_ledger_part_test.go
@@ -133,3 +133,37 @@ func TestBatchLedgerPart_Iterator(t *testing.T) {
 	block, _ = it.Next()
 	require.Equal(t, uint64(6), block.GetHeader().GetNumber())
 }
+
+// Scenario:
+//  1. Append 30 batches to a part.
+//  2. Call PruneBefore(20).
+//  3. Expect batches below 20 to be unavailable, 20 and above to be returned, and Height to stay 30.
+//  4. Call PruneBefore(20) again and PruneBefore(5), and expect neither to change anything.
+func TestBatchLedgerPart_PruneBefore(t *testing.T) {
+	dir := t.TempDir()
+	logger := flogging.MustGetLogger("test")
+
+	array, err := NewBatchLedgerArray(1, 1, []types.PartyID{1}, "test-channel", dir, logger)
+	require.NoError(t, err)
+	defer array.Close()
+	part := array.Part(1)
+
+	const numBatches = 30
+	for seq := uint64(0); seq < numBatches; seq++ {
+		reqs := types.BatchedRequests{[]byte(fmt.Sprintf("tx-%d", seq))}
+		part.Append(types.BatchSequence(seq), 0, reqs, reqs.Digest(), nil)
+	}
+
+	require.NoError(t, part.PruneBefore(20))
+
+	require.Nil(t, part.RetrieveBatchByNumber(0))
+	require.Nil(t, part.RetrieveBatchByNumber(19))
+	require.NotNil(t, part.RetrieveBatchByNumber(20))
+	require.NotNil(t, part.RetrieveBatchByNumber(numBatches-1))
+	require.Equal(t, uint64(numBatches), part.Height())
+
+	require.NoError(t, part.PruneBefore(20))
+	require.NoError(t, part.PruneBefore(5))
+	require.Nil(t, part.RetrieveBatchByNumber(19))
+	require.NotNil(t, part.RetrieveBatchByNumber(20))
+}

--- a/node/ledger/batch_ledger_part_test.go
+++ b/node/ledger/batch_ledger_part_test.go
@@ -37,13 +37,13 @@ func TestBatchLedgerPart(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, part)
 	require.Equal(t, uint64(0), part.Height())
-	require.Nil(t, part.RetrieveBatchByNumber(0))
+	requireNoBatch(t, part, 0)
 
 	part, err = newBatchLedgerPart(provider, 5, 1, 2, "test-channel", logger) // no problem reopening the same part
 	require.NoError(t, err)
 	require.NotNil(t, part)
 	require.Equal(t, uint64(0), part.Height())
-	require.Nil(t, part.RetrieveBatchByNumber(0))
+	requireNoBatch(t, part, 0)
 
 	batches := uint64(10)
 	for seq := uint64(0); seq < batches; seq++ {
@@ -51,7 +51,7 @@ func TestBatchLedgerPart(t *testing.T) {
 		primarySig := []byte(fmt.Sprintf("sig-%d", seq))
 		part.Append(types.BatchSequence(seq), types.ConfigSequence(seq*10), batchedRequests, batchedRequests.Digest(), primarySig)
 		require.Equal(t, seq+1, part.Height())
-		batch := part.RetrieveBatchByNumber(seq)
+		batch := mustGetBatch(t, part, seq)
 		require.NotNil(t, batch)
 		require.Equal(t, batchedRequests, batch.Requests())
 		require.Equal(t, types.PartyID(2), batch.Primary())
@@ -61,13 +61,13 @@ func TestBatchLedgerPart(t *testing.T) {
 		require.Equal(t, primarySig, batch.PrimarySignature())
 		require.Equal(t, batchedRequests.Digest(), batch.Digest())
 	}
-	require.Nil(t, part.RetrieveBatchByNumber(100))
+	requireNoBatch(t, part, 100)
 
 	part, err = newBatchLedgerPart(provider, 5, 1, 2, "test-channel", logger) // no problem reopening the same part without loosing its content
 	require.NoError(t, err)
 	require.NotNil(t, part)
 	require.Equal(t, batches, part.Height())
-	require.NotNil(t, part.RetrieveBatchByNumber(0))
+	_ = mustGetBatch(t, part, 0)
 }
 
 // TestBatchLedgerPart_AppendWithDigest verifies that Append persists the digest it was given rather than
@@ -91,7 +91,7 @@ func TestBatchLedgerPart_AppendWithDigest(t *testing.T) {
 	reqs := types.BatchedRequests{[]byte("tx1"), []byte("tx2")}
 	part.Append(0, 0, reqs, fakeDigest, nil)
 
-	stored := part.RetrieveBatchByNumber(0)
+	stored := mustGetBatch(t, part, 0)
 	require.NotNil(t, stored)
 	require.Equal(t, fakeDigest, stored.Digest())
 	require.NotEqual(t, reqs.Digest(), stored.Digest())
@@ -156,14 +156,79 @@ func TestBatchLedgerPart_PruneBefore(t *testing.T) {
 
 	require.NoError(t, part.PruneBefore(20))
 
-	require.Nil(t, part.RetrieveBatchByNumber(0))
-	require.Nil(t, part.RetrieveBatchByNumber(19))
-	require.NotNil(t, part.RetrieveBatchByNumber(20))
-	require.NotNil(t, part.RetrieveBatchByNumber(numBatches-1))
+	requireNoBatch(t, part, 0)
+	requireNoBatch(t, part, 19)
+	_ = mustGetBatch(t, part, 20)
+	_ = mustGetBatch(t, part, numBatches-1)
 	require.Equal(t, uint64(numBatches), part.Height())
 
 	require.NoError(t, part.PruneBefore(20))
 	require.NoError(t, part.PruneBefore(5))
-	require.Nil(t, part.RetrieveBatchByNumber(19))
-	require.NotNil(t, part.RetrieveBatchByNumber(20))
+	requireNoBatch(t, part, 19)
+	_ = mustGetBatch(t, part, 20)
+}
+
+// Scenario:
+//  1. Append 30 batches to a part and prune below 20.
+//  2. Expect retrieving batch 0 to fail with an error matching blkstorage.ErrPruned under errors.Is, so a
+//     caller can tell it will never come back.
+//  3. Expect retrieving a batch that was never written to fail with an error that does not match ErrPruned.
+//  4. Expect the error to name the sequence, the primary and the shard.
+func TestBatchLedgerPart_RetrieveBatchByNumberDistinguishesPruned(t *testing.T) {
+	dir := t.TempDir()
+	logger := flogging.MustGetLogger("test")
+
+	array, err := NewBatchLedgerArray(7, 1, []types.PartyID{1, 3}, "test-channel", dir, logger)
+	require.NoError(t, err)
+	defer array.Close()
+	part := array.Part(3)
+
+	const numBatches = 30
+	for seq := uint64(0); seq < numBatches; seq++ {
+		reqs := types.BatchedRequests{[]byte(fmt.Sprintf("tx-%d", seq))}
+		part.Append(types.BatchSequence(seq), 0, reqs, reqs.Digest(), nil)
+	}
+	require.NoError(t, part.PruneBefore(20))
+
+	_, err = part.RetrieveBatchByNumber(0)
+	require.ErrorIs(t, err, blkstorage.ErrPruned)
+	require.ErrorContains(t, err, "failed retrieving batch 0 of primary 3 in shard 7")
+
+	_, err = part.RetrieveBatchByNumber(numBatches + 5)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, blkstorage.ErrPruned)
+}
+
+// mustGetBatch retrieves a batch from a part, failing the test if it cannot be retrieved.
+func mustGetBatch(t *testing.T, part *BatchLedgerPart, seq uint64) types.Batch {
+	t.Helper()
+	batch, err := part.RetrieveBatchByNumber(seq)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	return batch
+}
+
+// requireNoBatch asserts that a part cannot serve the batch at seq, whatever the reason.
+func requireNoBatch(t *testing.T, part *BatchLedgerPart, seq uint64) {
+	t.Helper()
+	batch, err := part.RetrieveBatchByNumber(seq)
+	require.Error(t, err)
+	require.Nil(t, batch)
+}
+
+// mustGetBatchOf retrieves a batch of a given primary from an array, failing the test on error.
+func mustGetBatchOf(t *testing.T, array *BatchLedgerArray, primary types.PartyID, seq uint64) types.Batch {
+	t.Helper()
+	batch, err := array.RetrieveBatchByNumber(primary, seq)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	return batch
+}
+
+// requireNoBatchOf asserts that an array cannot serve the batch of a given primary at seq.
+func requireNoBatchOf(t *testing.T, array *BatchLedgerArray, primary types.PartyID, seq uint64) {
+	t.Helper()
+	batch, err := array.RetrieveBatchByNumber(primary, seq)
+	require.Error(t, err)
+	require.Nil(t, batch)
 }


### PR DESCRIPTION
blkstorage: return ErrPruned when a read loses the race with pruning
fileledger: map ErrPruned to BAD_REQUEST in the iterator
blkstorage: document the block stream constructors