### PR TITLE
node/comm: fix TestBlockPullerFailures flaky 15m timeout

### DIFF
--- a/node/comm/deliver_test.go
+++ b/node/comm/deliver_test.go
@@ -217,8 +217,15 @@ func (ds *deliverServer) Deliver(stream orderer.AtomicBroadcast_DeliverServer) e
 }
 
 func (ds *deliverServer) deliverBlocks(stream orderer.AtomicBroadcast_DeliverServer) error {
+	// Capture the block channel once, when the stream starts. A test may close
+	// the current channel and swap in a fresh, pre-filled one (via setBlocks) to
+	// recover after an induced failure. Closing the channel is meant to terminate
+	// this stream (see the nil-response handling below); re-reading ds.blocks()
+	// on every iteration would instead let this lingering goroutine hop onto the
+	// new channel and drain blocks that were tabled for a subsequent probe/pull,
+	// which deadlocks that probe (its seek response never arrives).
+	blockChan := ds.blocks()
 	for {
-		blockChan := ds.blocks()
 		var response *orderer.DeliverResponse
 		select {
 		case response = <-blockChan:


### PR DESCRIPTION
## Problem

The same fake-ordering-server race flakes **two** `node/comm` block-puller tests in CI's `Unit Tests Other`:

- `TestBlockPullerFailures/failure_at_verifying_pulled_block` intermittently hangs until the 15m test timeout. The goroutine dump shows the block puller stuck in an endless re-probe loop (`connectToSomeEndpoint → probeEndpoints → fetchLastBlockSeq`), each attempt logging `didn't receive a response within 10s` and retrying forever until the suite is killed.
- `TestBlockPullerBadBlocks` (observed on the `nil_metadata` subtest) fails differently only because that test guards each `PullBlock` with its own 30s deadline. After the induced bad block is detected and recovery blocks are enqueued, the re-probe reads an empty channel and blocks 10s; the puller then retries with another `newest` seek that consumes a queued **pull** assertion, tripping `require.NotNil` on the specified seek position (`deliver_test.go:312`, `Expected value not to be nil`), and the subtest's guard fires with `PullBlock did not complete within time` (`deliver_test.go:1191`).

## Root cause

The bug is in the test's fake ordering server (`deliver_test.go`), not in production code.

Both tests recover from an induced failure with the same pattern: `close(oldChan)`, then `setBlocks(newChan)` pre-filled with the blocks the subsequent re-probe (`newest` seek) and re-pull need.

`deliverServer.deliverBlocks` re-read `ds.blocks()` on **every loop iteration**. The server-side stream goroutine serving the just-failed pull was still running; on its next iteration it picked up the **new** channel and drained the recovery blocks into its now-cancelled stream. The subsequent re-probe then read from an **empty** channel — and the server's `newest`-seek branch has no timeout, so it blocked. In `TestBlockPullerFailures` the puller re-probes every 10s until the 15m suite timeout; in `TestBlockPullerBadBlocks` the misaligned seek assertion plus the per-`PullBlock` 30s guard surface it sooner.

The existing comment in `deliverBlocks` already documented the intent — closing the channel should *terminate* the lingering stream "to avoid consuming by accident a block that is tabled to be pulled later." The per-iteration re-fetch silently defeated that intent.

## Fix

Capture the block channel **once** when the stream starts. A closed channel now makes the lingering goroutine drain-and-return as intended, instead of hopping onto the freshly installed recovery channel and stealing its blocks. This fixes both `TestBlockPullerFailures` and `TestBlockPullerBadBlocks`, which share the identical close/`setBlocks` recovery pattern.

Test-only change; `deliver.go` is untouched.

## Verification

- **Causation proven**: temporarily widening the race window (a 30ms sleep in the buggy loop) reproduced the hang deterministically; the same instrumentation with the fix passed.
- **No regression**: `TestBlockPullerFailures` + `TestBlockPullerBadBlocks` run 50× under `-race` (plus ~120 further runs), and the full `node/comm` suite under `-race`, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
