### PR TITLE
batcher: skip re-verifying requests already in the mem pool

### DIFF
--- a/node/batcher/batcher_builder.go
+++ b/node/batcher/batcher_builder.go
@@ -92,7 +92,11 @@ func (b *Batcher) configureBatcher(senderCreator ConsenterControlEventSenderCrea
 
 	dr := b.consensusDecisionReplicatorCreator.CreateDecisionConsensusReplicator(b.config, b.logger, lastKnownDecisionNum)
 
-	requestsIDAndVerifier := NewRequestsInspectorVerifier(b.logger, b.config, nil, DefaultRequestID)
+	if memPool == nil {
+		memPool = createMemPool(b, b.config, DefaultRequestID)
+	}
+
+	requestsIDAndVerifier := NewRequestsInspectorVerifier(b.logger, b.config, nil, DefaultRequestID, memPool)
 
 	batchers := batchersFromConfig(b.config)
 	if len(batchers) == 0 {
@@ -169,14 +173,9 @@ func (b *Batcher) configureBatcher(senderCreator ConsenterControlEventSenderCrea
 		Complainer:              b,
 		BatchedRequestsVerifier: b.requestsInspectorVerifier,
 		SigVerifier:             b.sigVerifier,
+		MemPool:                 memPool,
 		BatchSequenceGap:        b.config.BatchSequenceGap,
 		Metrics:                 b.metrics,
-	}
-
-	if memPool == nil {
-		b.batcher.MemPool = createMemPool(b, b.config, DefaultRequestID)
-	} else {
-		b.batcher.MemPool = memPool
 	}
 }
 

--- a/node/batcher/batcher_reconfig_test.go
+++ b/node/batcher/batcher_reconfig_test.go
@@ -258,7 +258,6 @@ func TestBatcherReconfigMempoolPruneDropsInvalidRequests(t *testing.T) {
 	require.NotNil(t, batcherConfig)
 
 	logger := testutil.CreateLogger(t, int(parties[0]))
-	riv := batcher.NewRequestsInspectorVerifier(logger, batcherConfig, nil, batcher.DefaultRequestID)
 
 	// build a request pool wired with the same options the batcher's memory pool uses
 	opts := request.PoolOptions{
@@ -274,6 +273,8 @@ func TestBatcherReconfigMempoolPruneDropsInvalidRequests(t *testing.T) {
 	pool := request.NewPool(logger, batcher.DefaultRequestID, opts, noopStriker{})
 	pool.Restart(true)
 	defer pool.Close()
+
+	riv := batcher.NewRequestsInspectorVerifier(logger, batcherConfig, nil, batcher.DefaultRequestID, pool)
 
 	// requests are stored in the pool as marshaled envelopes, exactly as the batcher stores them when submitting
 	makeReq := func(payload []byte, signature []byte) []byte {

--- a/node/batcher/batcher_role.go
+++ b/node/batcher/batcher_role.go
@@ -37,6 +37,7 @@ type MemPool interface {
 	RequestCount() int64
 	Close()
 	Prune(predicate func([]byte) error)
+	Contains(reqID string) bool
 }
 
 //go:generate counterfeiter -o mocks/state_provider.go . StateProvider

--- a/node/batcher/batcher_role.go
+++ b/node/batcher/batcher_role.go
@@ -60,6 +60,9 @@ type Complainer interface {
 // BatchedRequestsVerifier verifies batched requests
 type BatchedRequestsVerifier interface {
 	VerifyBatchedRequests(types.BatchedRequests) error
+	// VerifyRequest verifies a single request unconditionally (it does not consult
+	// the mem pool), unlike VerifyBatchedRequests which skips already-pooled requests.
+	VerifyRequest(req []byte) error
 }
 
 //go:generate counterfeiter -o mocks/batch_acker.go . BatchAcker
@@ -270,7 +273,25 @@ func (b *BatcherRole) ResubmitPendingBAFs(state *state.State, prevPrimary types.
 			if batch == nil {
 				b.Logger.Panicf("Error: No such batch; pending BAF signed by me (id: %d) from primary: %d ; %s", b.ID, baf.Primary(), baf.String())
 			}
+			// These requests are read from an old ledger batch. If the BAF was created
+			// under an older config, the channel policies may have changed since, so the
+			// requests are not guaranteed to still satisfy the current policy. They must
+			// be re-verified before being resubmitted to the pool: the secondary pull
+			// path treats pool membership as "already verified under the current config"
+			// and skips re-verifying pooled requests, so an unverified request must never
+			// enter the pool. When the BAF is from the current config (e.g. a plain term
+			// change) the requests were already verified under it, so re-verification is
+			// unnecessary.
+			reverify := baf.ConfigSequence() < b.ConfigSequenceGetter.ConfigSequence()
 			for _, req := range batch.Requests() {
+				if reverify {
+					// Verify one request at a time so a single offending request is dropped
+					// without discarding the rest of the batch.
+					if err := b.BatchedRequestsVerifier.VerifyRequest(req); err != nil {
+						b.Logger.Errorf("Dropping request that failed verification under the current config before resubmitting to pool; err: %v", err)
+						continue
+					}
+				}
 				if err := b.MemPool.Submit(req); err != nil {
 					if strings.Contains(err.Error(), "already inserted") {
 						b.Logger.Debugf("Failed submitting request to pool; err: %v", err)

--- a/node/batcher/batcher_role_test.go
+++ b/node/batcher/batcher_role_test.go
@@ -815,6 +815,63 @@ func TestVerifyBatch(t *testing.T) {
 	require.Equal(t, 2, ledger.AppendCallCount())
 }
 
+// TestResubmitPendingBAFsReverifiesOnConfigChange covers the reconfiguration case:
+// requests taken from a BAF created under an older config are re-verified under the
+// current policy before being resubmitted to the pool, and any request that fails
+// the current policy is dropped rather than reinserted (so it never becomes eligible
+// for the secondary pull-path verification shortcut).
+func TestResubmitPendingBAFsReverifiesOnConfigChange(t *testing.T) {
+	N := uint16(4)
+	batchers := []arma_types.PartyID{1, 2, 3, 4}
+	batcherID := arma_types.PartyID(2)
+	shardID := arma_types.ShardID(0)
+	logger := testutil.CreateLogger(t, int(batcherID))
+
+	b := createBatcher(t, batcherID, shardID, batchers, N, logger)
+
+	validReq := []byte("valid-request")
+	invalidReq := []byte("invalid-request")
+	reqs := arma_types.BatchedRequests{validReq, invalidReq}
+
+	// The pending BAF and its ledger batch were created under config seq 0.
+	batch := arma_types.NewSimpleBatch(shardID, 1, 0, reqs, 0, nil)
+	ledger := &mocks.FakeBatchLedger{}
+	ledger.RetrieveBatchByNumberReturns(batch)
+	b.Ledger = ledger
+
+	// The batcher's current config seq is newer than the BAF's, so its requests must
+	// be re-verified under the current policy.
+	configSeqGet := &mocks.FakeConfigSequenceGetter{}
+	configSeqGet.ConfigSequenceReturns(1)
+	b.ConfigSequenceGetter = configSeqGet
+
+	// Under the current policy invalidReq no longer verifies.
+	verifier := &mocks.FakeBatchedRequestsVerifier{}
+	verifier.VerifyRequestStub = func(req []byte) error {
+		if string(req) == string(invalidReq) {
+			return errors.New("fails current policy")
+		}
+		return nil
+	}
+	b.BatchedRequestsVerifier = verifier
+
+	pool := &mocks.FakeMemPool{}
+	b.MemPool = pool
+
+	myBAF := arma_types.NewSimpleBatchAttestationFragment(batch.Shard(), batch.Primary(), batch.Seq(), batch.Digest(), batcherID, 0, 0, nil)
+	st := &state.State{
+		Shards:  []state.ShardTerm{{Shard: shardID, Term: 1}},
+		Pending: []arma_types.BatchAttestationFragment{myBAF},
+	}
+
+	b.ResubmitPendingBAFs(st, 0, true)
+
+	// Both requests were re-verified, but only the valid one was resubmitted to the pool.
+	require.Equal(t, 2, verifier.VerifyRequestCallCount())
+	require.Equal(t, 1, pool.SubmitCallCount())
+	require.Equal(t, validReq, pool.SubmitArgsForCall(0))
+}
+
 func createBatcher(t *testing.T, batcherID arma_types.PartyID, shardID arma_types.ShardID, batchers []arma_types.PartyID, N uint16, logger *flogging.FabricLogger) *batcher.BatcherRole {
 	bafCreator := &mocks.FakeBAFCreator{}
 	bafCreator.CreateBAFCalls(func(seq arma_types.BatchSequence, primary arma_types.PartyID, si arma_types.ShardID, digest []byte, txCount uint64, primarySignature []byte) arma_types.BatchAttestationFragment {

--- a/node/batcher/mocks/batched_requests_verifier.go
+++ b/node/batcher/mocks/batched_requests_verifier.go
@@ -20,6 +20,17 @@ type FakeBatchedRequestsVerifier struct {
 	verifyBatchedRequestsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	VerifyRequestStub        func([]byte) error
+	verifyRequestMutex       sync.RWMutex
+	verifyRequestArgsForCall []struct {
+		arg1 []byte
+	}
+	verifyRequestReturns struct {
+		result1 error
+	}
+	verifyRequestReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -85,11 +96,79 @@ func (fake *FakeBatchedRequestsVerifier) VerifyBatchedRequestsReturnsOnCall(i in
 	}{result1}
 }
 
+func (fake *FakeBatchedRequestsVerifier) VerifyRequest(arg1 []byte) error {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.verifyRequestMutex.Lock()
+	ret, specificReturn := fake.verifyRequestReturnsOnCall[len(fake.verifyRequestArgsForCall)]
+	fake.verifyRequestArgsForCall = append(fake.verifyRequestArgsForCall, struct {
+		arg1 []byte
+	}{arg1Copy})
+	stub := fake.VerifyRequestStub
+	fakeReturns := fake.verifyRequestReturns
+	fake.recordInvocation("VerifyRequest", []interface{}{arg1Copy})
+	fake.verifyRequestMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBatchedRequestsVerifier) VerifyRequestCallCount() int {
+	fake.verifyRequestMutex.RLock()
+	defer fake.verifyRequestMutex.RUnlock()
+	return len(fake.verifyRequestArgsForCall)
+}
+
+func (fake *FakeBatchedRequestsVerifier) VerifyRequestCalls(stub func([]byte) error) {
+	fake.verifyRequestMutex.Lock()
+	defer fake.verifyRequestMutex.Unlock()
+	fake.VerifyRequestStub = stub
+}
+
+func (fake *FakeBatchedRequestsVerifier) VerifyRequestArgsForCall(i int) []byte {
+	fake.verifyRequestMutex.RLock()
+	defer fake.verifyRequestMutex.RUnlock()
+	argsForCall := fake.verifyRequestArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBatchedRequestsVerifier) VerifyRequestReturns(result1 error) {
+	fake.verifyRequestMutex.Lock()
+	defer fake.verifyRequestMutex.Unlock()
+	fake.VerifyRequestStub = nil
+	fake.verifyRequestReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBatchedRequestsVerifier) VerifyRequestReturnsOnCall(i int, result1 error) {
+	fake.verifyRequestMutex.Lock()
+	defer fake.verifyRequestMutex.Unlock()
+	fake.VerifyRequestStub = nil
+	if fake.verifyRequestReturnsOnCall == nil {
+		fake.verifyRequestReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.verifyRequestReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeBatchedRequestsVerifier) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.verifyBatchedRequestsMutex.RLock()
 	defer fake.verifyBatchedRequestsMutex.RUnlock()
+	fake.verifyRequestMutex.RLock()
+	defer fake.verifyRequestMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/node/batcher/mocks/mem_pool.go
+++ b/node/batcher/mocks/mem_pool.go
@@ -13,6 +13,17 @@ type FakeMemPool struct {
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
 	}
+	ContainsStub        func(string) bool
+	containsMutex       sync.RWMutex
+	containsArgsForCall []struct {
+		arg1 string
+	}
+	containsReturns struct {
+		result1 bool
+	}
+	containsReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	HaltStub        func()
 	haltMutex       sync.RWMutex
 	haltArgsForCall []struct {
@@ -90,6 +101,67 @@ func (fake *FakeMemPool) CloseCalls(stub func()) {
 	fake.closeMutex.Lock()
 	defer fake.closeMutex.Unlock()
 	fake.CloseStub = stub
+}
+
+func (fake *FakeMemPool) Contains(arg1 string) bool {
+	fake.containsMutex.Lock()
+	ret, specificReturn := fake.containsReturnsOnCall[len(fake.containsArgsForCall)]
+	fake.containsArgsForCall = append(fake.containsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ContainsStub
+	fakeReturns := fake.containsReturns
+	fake.recordInvocation("Contains", []interface{}{arg1})
+	fake.containsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeMemPool) ContainsCallCount() int {
+	fake.containsMutex.RLock()
+	defer fake.containsMutex.RUnlock()
+	return len(fake.containsArgsForCall)
+}
+
+func (fake *FakeMemPool) ContainsCalls(stub func(string) bool) {
+	fake.containsMutex.Lock()
+	defer fake.containsMutex.Unlock()
+	fake.ContainsStub = stub
+}
+
+func (fake *FakeMemPool) ContainsArgsForCall(i int) string {
+	fake.containsMutex.RLock()
+	defer fake.containsMutex.RUnlock()
+	argsForCall := fake.containsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeMemPool) ContainsReturns(result1 bool) {
+	fake.containsMutex.Lock()
+	defer fake.containsMutex.Unlock()
+	fake.ContainsStub = nil
+	fake.containsReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeMemPool) ContainsReturnsOnCall(i int, result1 bool) {
+	fake.containsMutex.Lock()
+	defer fake.containsMutex.Unlock()
+	fake.ContainsStub = nil
+	if fake.containsReturnsOnCall == nil {
+		fake.containsReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.containsReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeMemPool) Halt() {
@@ -397,6 +469,8 @@ func (fake *FakeMemPool) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
+	fake.containsMutex.RLock()
+	defer fake.containsMutex.RUnlock()
 	fake.haltMutex.RLock()
 	defer fake.haltMutex.RUnlock()
 	fake.nextRequestsMutex.RLock()

--- a/node/batcher/requests_inspector_verifier.go
+++ b/node/batcher/requests_inspector_verifier.go
@@ -31,6 +31,13 @@ type RequestVerifier interface {
 	VerifyStructureAndClassify(request *comm.Request) (common.HeaderType, error)
 }
 
+// PooledRequests reports whether a request is currently held in the mem pool.
+// A request in the pool was already verified when it entered it, so it need not
+// be re-verified when it later arrives inside a pulled batch.
+type PooledRequests interface {
+	Contains(reqID string) bool
+}
+
 type RequestsInspectorVerifier struct {
 	requestMaxBytes uint64
 	batchMaxBytes   uint32
@@ -42,9 +49,10 @@ type RequestsInspectorVerifier struct {
 	requestVerifier RequestVerifier
 	requestIDFunc   func(req []byte) string
 	configSeq       uint32
+	pool            PooledRequests
 }
 
-func NewRequestsInspectorVerifier(logger *flogging.FabricLogger, config *config.BatcherNodeConfig, requestVerifier RequestVerifier, requestIDFunc func(req []byte) string) *RequestsInspectorVerifier {
+func NewRequestsInspectorVerifier(logger *flogging.FabricLogger, config *config.BatcherNodeConfig, requestVerifier RequestVerifier, requestIDFunc func(req []byte) string, pool PooledRequests) *RequestsInspectorVerifier {
 	riv := &RequestsInspectorVerifier{
 		logger:          logger,
 		shardID:         config.ShardId,
@@ -54,6 +62,7 @@ func NewRequestsInspectorVerifier(logger *flogging.FabricLogger, config *config.
 		requestMaxBytes: config.RequestMaxBytes,
 		requestIDFunc:   requestIDFunc,
 		configSeq:       uint32(config.Bundle.ConfigtxValidator().Sequence()),
+		pool:            pool,
 	}
 	if requestVerifier != nil {
 		riv.requestVerifier = requestVerifier
@@ -103,6 +112,14 @@ func (r *RequestsInspectorVerifier) VerifyBatchedRequests(reqs types.BatchedRequ
 				default:
 				}
 				if workerID != j%numWorkers {
+					continue
+				}
+				// A request already present in the mem pool was verified when it entered
+				// the pool (by this party's router, or via VerifyRequest on the batcher
+				// forward path) and remains valid under the current config (the pool is
+				// pruned and re-verified on reconfiguration). Skip re-verifying it.
+				// TODO: maybe add a metric counting skipped verifications to measure the hit rate.
+				if r.pool.Contains(r.RequestID(reqs[j])) {
 					continue
 				}
 				if err := r.VerifyRequest(reqs[j]); err != nil {

--- a/node/batcher/requests_inspector_verifier_test.go
+++ b/node/batcher/requests_inspector_verifier_test.go
@@ -40,7 +40,7 @@ func TestRequestsInspectAndVerify(t *testing.T) {
 		RequestMaxBytes: 60,
 		Bundle:          bundle,
 	}
-	verifier := batcher.NewRequestsInspectorVerifier(logger, config, nil, batcher.DefaultRequestID)
+	verifier := batcher.NewRequestsInspectorVerifier(logger, config, nil, batcher.DefaultRequestID, &fakeRequestPool{})
 
 	req1, err := proto.Marshal(tx.CreateStructuredRequest([]byte{1})) // should map to shard 1
 	require.NoError(t, err)
@@ -136,6 +136,71 @@ func TestRequestsInspectAndVerify(t *testing.T) {
 	})
 }
 
+// fakeRequestPool is a test double for batcher.RequestPool. A request is reported
+// as present iff its id was added to present; the zero value is an empty pool.
+type fakeRequestPool struct {
+	present map[string]bool
+}
+
+func (f *fakeRequestPool) Contains(reqID string) bool {
+	return f.present[reqID]
+}
+
+func TestVerifyBatchedRequestsSkipsPooledRequests(t *testing.T) {
+	logger := testutil.CreateLogger(t, 1)
+
+	bundle := &configMocks.FakeConfigResources{}
+	configtxValidator := &policyMocks.FakeConfigtxValidator{}
+	configtxValidator.ChannelIDReturns("arma")
+	configtxValidator.SequenceReturns(0)
+	bundle.ConfigtxValidatorReturns(configtxValidator)
+
+	config := &config.BatcherNodeConfig{
+		ShardId:         1,
+		Shards:          []config.ShardInfo{{ShardId: 1}}, // single shard: skip shard mapping
+		BatchMaxSize:    500,
+		BatchMaxBytes:   10000,
+		RequestMaxBytes: 1000,
+		Bundle:          bundle,
+	}
+
+	reqs := make([][]byte, 10)
+	for i := 0; i < 10; i++ {
+		r, err := proto.Marshal(tx.CreateStructuredRequest([]byte{byte(i)}))
+		require.NoError(t, err)
+		reqs[i] = r
+	}
+
+	t.Run("only requests absent from the pool are verified", func(t *testing.T) {
+		reqVerifier := &mocks.FakeRequestVerifier{}
+		reqVerifier.VerifyReturns(nil)
+		reqVerifier.VerifyStructureAndClassifyReturns(0, nil)
+
+		pool := &fakeRequestPool{present: map[string]bool{}}
+		for i := 0; i < 10; i += 2 { // even-indexed requests are already in the pool
+			pool.present[batcher.DefaultRequestID(reqs[i])] = true
+		}
+		verifier := batcher.NewRequestsInspectorVerifier(logger, config, reqVerifier, batcher.DefaultRequestID, pool)
+
+		require.NoError(t, verifier.VerifyBatchedRequests(reqs))
+		require.Equal(t, 5, reqVerifier.VerifyCallCount())
+	})
+
+	t.Run("requests already in the pool are not re-verified even if verification would fail", func(t *testing.T) {
+		reqVerifier := &mocks.FakeRequestVerifier{}
+		reqVerifier.VerifyReturns(errors.New("must not be called for pooled requests"))
+
+		allPooled := &fakeRequestPool{present: map[string]bool{}}
+		for _, r := range reqs {
+			allPooled.present[batcher.DefaultRequestID(r)] = true
+		}
+		verifier := batcher.NewRequestsInspectorVerifier(logger, config, reqVerifier, batcher.DefaultRequestID, allPooled)
+
+		require.NoError(t, verifier.VerifyBatchedRequests(reqs))
+		require.Zero(t, reqVerifier.VerifyCallCount())
+	})
+}
+
 func TestRequestVerificationStopEarly(t *testing.T) {
 	req1, err := proto.Marshal(tx.CreateStructuredRequest([]byte{1})) // should map to shard 1
 	require.NoError(t, err)
@@ -158,7 +223,7 @@ func TestRequestVerificationStopEarly(t *testing.T) {
 	}
 	reqVerifier := &mocks.FakeRequestVerifier{}
 
-	verifier := batcher.NewRequestsInspectorVerifier(logger, config, reqVerifier, batcher.DefaultRequestID)
+	verifier := batcher.NewRequestsInspectorVerifier(logger, config, reqVerifier, batcher.DefaultRequestID, &fakeRequestPool{})
 
 	reqs := make([][]byte, 100)
 	for i := 0; i < 100; i++ {

--- a/request/pending.go
+++ b/request/pending.go
@@ -314,6 +314,21 @@ func (ps *PendingStore) removeRequest(reqID string, now time.Time) {
 	ps.OnDelete(reqID)
 }
 
+// Contains reports whether a request with the given id is currently held in the store.
+// A tombstoned (already-removed) request is reported as absent.
+func (ps *PendingStore) Contains(reqID string) bool {
+	v, ok := ps.reqID2Bucket.Load(reqID)
+	if !ok {
+		return false
+	}
+	b := v.(*bucket)
+	if b.isDummyBucket() {
+		return false
+	}
+	_, exists := b.requests.Load(reqID)
+	return exists
+}
+
 func (ps *PendingStore) Prune(predicate func([]byte) error) {
 	ps.reqID2Bucket.Range(func(key, value any) bool {
 		reqID := key.(string)

--- a/request/pending_test.go
+++ b/request/pending_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -108,6 +109,59 @@ func TestPending(t *testing.T) {
 	}
 
 	assert.Equal(t, uint32(workerNum*workPerWorker), atomic.LoadUint32(&submittedCount))
+}
+
+func TestPendingStoreContains(t *testing.T) {
+	sugaredLogger := testutil.CreateLogger(t, 0)
+	requestInspector := &reqInspector{}
+
+	start := time.Now()
+	ticker := time.NewTicker(time.Millisecond * 100)
+	defer ticker.Stop()
+
+	ps := &request.PendingStore{
+		ReqIDLifetime:         time.Second * 10,
+		ReqIDGCInterval:       time.Second,
+		Logger:                sugaredLogger,
+		SecondStrikeCallback:  func() {},
+		StartTime:             start,
+		Time:                  ticker.C,
+		FirstStrikeCallback:   func([]byte) {},
+		Epoch:                 time.Millisecond * 200,
+		FirstStrikeThreshold:  time.Second * 10,
+		Inspector:             requestInspector,
+		OnDelete:              func(key string) {},
+		SecondStrikeThreshold: time.Second,
+	}
+
+	ps.Init()
+	ps.Start()
+	defer ps.Close()
+
+	req := make([]byte, 8)
+	binary.BigEndian.PutUint64(req, uint64(1))
+	reqID := requestInspector.RequestID(req)
+
+	// A request that was never submitted is absent.
+	assert.False(t, ps.Contains(reqID))
+	assert.False(t, ps.Contains(requestInspector.RequestID([]byte("never-submitted"))))
+
+	// After submission the request is present.
+	require.NoError(t, ps.Submit(req))
+	assert.True(t, ps.Contains(reqID))
+
+	// After removal the request is absent (tombstoned).
+	ps.RemoveRequests(reqID)
+	assert.False(t, ps.Contains(reqID))
+
+	// A request dropped by Prune is absent.
+	req2 := make([]byte, 8)
+	binary.BigEndian.PutUint64(req2, uint64(2))
+	reqID2 := requestInspector.RequestID(req2)
+	require.NoError(t, ps.Submit(req2))
+	assert.True(t, ps.Contains(reqID2))
+	ps.Prune(func([]byte) error { return errors.New("drop everything") })
+	assert.False(t, ps.Contains(reqID2))
 }
 
 func TestGetAll(t *testing.T) {

--- a/request/pool.go
+++ b/request/pool.go
@@ -241,6 +241,25 @@ func (rp *Pool) RemoveRequests(requestsIDs ...string) {
 	}
 }
 
+// Contains reports whether a request with the given id is currently in the pool.
+// It is only supported while batching is disabled (i.e. a secondary batcher); when
+// batching is enabled it conservatively returns false so callers fall back to full
+// verification.
+func (rp *Pool) Contains(reqID string) bool {
+	rp.lock.RLock()
+	defer rp.lock.RUnlock()
+
+	if rp.isClosed() || rp.isStopped() {
+		return false
+	}
+
+	if rp.isBatchingEnabled() {
+		return false
+	}
+
+	return rp.pending.Contains(reqID)
+}
+
 // RequestCount returns the current number of requests in the pool.
 func (rp *Pool) RequestCount() int64 {
 	return atomic.LoadInt64(&rp.size)

--- a/request/pool_test.go
+++ b/request/pool_test.go
@@ -195,6 +195,49 @@ func TestRestartPool(t *testing.T) {
 	assert.Equal(t, 10, len(batch5))
 }
 
+func TestPoolContains(t *testing.T) {
+	sugaredLogger := testutil.CreateLogger(t, 0)
+	requestInspector := &reqInspector{}
+
+	pool := NewPool(sugaredLogger, requestInspector.RequestID, PoolOptions{
+		FirstStrikeThreshold:  time.Second * 5,
+		SecondStrikeThreshold: time.Minute / 2,
+		BatchMaxSize:          1000,
+		BatchMaxSizeBytes:     1000 * 32,
+		MaxSize:               1000,
+		RequestMaxBytes:       100 * 1024,
+		AutoRemoveTimeout:     time.Second * 10,
+		SubmitTimeout:         time.Second * 10,
+	}, &striker{})
+	defer pool.Close()
+
+	// A secondary batcher runs the pool in pending mode (batching disabled).
+	pool.Restart(false)
+
+	req := make([]byte, 8)
+	binary.BigEndian.PutUint64(req, uint64(1))
+	reqID := requestInspector.RequestID(req)
+
+	// A request that was never submitted is not present.
+	assert.False(t, pool.Contains(reqID))
+
+	// After submission the request is present.
+	require.NoError(t, pool.Submit(req))
+	assert.True(t, pool.Contains(reqID))
+
+	// After removal the request is no longer present.
+	pool.RemoveRequests(reqID)
+	assert.False(t, pool.Contains(reqID))
+
+	// In batching mode (primary) Contains is not supported and returns false,
+	// so callers conservatively fall back to full verification.
+	pool.Restart(true)
+	req2 := make([]byte, 8)
+	binary.BigEndian.PutUint64(req2, uint64(2))
+	require.NoError(t, pool.Submit(req2))
+	assert.False(t, pool.Contains(requestInspector.RequestID(req2)))
+}
+
 func TestBasicBatching(t *testing.T) {
 	sugaredLogger := testutil.CreateLogger(t, 0)
 


### PR DESCRIPTION
https://github.com/hyperledger/fabric-x-orderer/issues/1177