### PR TITLE
consensus: document MessageToSign re-marshal check, resolve fabric TODOs

### DIFF
--- a/node/consensus/consensus.go
+++ b/node/consensus/consensus.go
@@ -662,7 +662,14 @@ func verifyProposalMessageToSign(proposalMsg *protoutil.MessageToSign, proposalM
 	}
 
 	computedProposalMsgBytes := computedProposalMsg.ASN1MarshalOrPanic()
-	if !bytes.Equal(proposalMsgBytes, computedProposalMsgBytes) { // TODO validate msgs like fabric?
+	// We recompute MessageToSign from independently-tracked state (block header,
+	// last-config index, and the proposal's orderer metadata) and require an exact
+	// byte match before verifying the signature. This is intentionally stricter than
+	// Fabric's protoutil.BlockSigVerifier, which verifies the signature over the
+	// received header||metadata and trusts the metadata value as-is. The re-marshal +
+	// bytes.Equal pins each signature to exactly one (blockHeader, ordererMetadata,
+	// lastConfig) tuple, closing the proto.Marshal malleability / signature-substitution class.
+	if !bytes.Equal(proposalMsgBytes, computedProposalMsgBytes) {
 		return errors.New("proposal message content is not as expected")
 	}
 
@@ -689,7 +696,10 @@ func verifyBlockMessageToSign(msg *protoutil.MessageToSign, msgBytes []byte, sig
 		}),
 	}
 	computedMsgBytes := computedMsg.ASN1MarshalOrPanic()
-	if !bytes.Equal(msgBytes, computedMsgBytes) { // TODO validate msgs like fabric?
+	// As in verifyProposalMessageToSign, the re-marshal + bytes.Equal is intentionally
+	// stricter than Fabric's protoutil.BlockSigVerifier: it pins each signature to exactly
+	// one (blockHeader, ordererMetadata, lastConfig) tuple before the signature is verified.
+	if !bytes.Equal(msgBytes, computedMsgBytes) {
 		return errors.New("message content is not as expected")
 	}
 	return nil


### PR DESCRIPTION
## What

Resolves the two `// TODO validate msgs like fabric?` comments in `node/consensus/consensus.go` (`verifyProposalMessageToSign` and `verifyBlockMessageToSign`).

Both functions recompute the signed `MessageToSign` from independently-tracked state (block header, last-config index, and the block's orderer metadata), ASN.1-marshal it, and require an exact `bytes.Equal` match against the received signed bytes **before** verifying the signature. This is intentionally *stricter* than Fabric's `protoutil.BlockSigVerifier`, which verifies the signature over the received `header||metadata` and trusts the metadata value as-is. The re-marshal + `bytes.Equal` pins each signature to exactly one `(blockHeader, ordererMetadata, lastConfig)` tuple, closing the `proto.Marshal` malleability / signature-substitution class.

## Why

This is the second suggested next step of #175. A parity pass against Fabric's `BlockSigVerifier.Verify` confirmed there is nothing Fabric validates at these sites that we do not:

- signer identity is resolved and required to be in the consenter set (`ECDSAVerifier.VerifySignature` rejects unknown `{shard,party}`; `idHeader.GetIdentifier() == signatureID` binds the signed IdentifierHeader to the signer),
- the signature is verified over the ASN.1 `MessageToSign`,
- quorum is enforced by SmartBFT (which drives `VerifyConsenterSig` per signature).

We do all of that **plus** the tuple-pinning re-marshal check. So the correct resolution is to document why we are deliberately stricter rather than relax to Fabric's approach. No behavioral change; documentation only.

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)