### PR TITLE
types,consensus: domain-separate BAF and Complaint signatures

### DIFF
--- a/common/types/signature_domain.go
+++ b/common/types/signature_domain.go
@@ -1,0 +1,33 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package types
+
+// SignatureDomain is a context tag that binds a signature to a specific
+// message type. Folding a distinct domain into the signed bytes provides
+// domain separation: a signature produced over one message type cannot be
+// replayed as a valid signature over another, even when the same key signs
+// both families.
+type SignatureDomain string
+
+const (
+	// DomainBAF tags bytes signed as a Batch Attestation Fragment.
+	DomainBAF SignatureDomain = "arma.baf"
+	// DomainComplaint tags bytes signed as a Complaint.
+	DomainComplaint SignatureDomain = "arma.complaint"
+)
+
+// PrefixWithDomain binds msg to a signature domain by prepending a
+// length-prefixed domain tag. The 2-byte big-endian length makes the
+// tag/message boundary unambiguous, so outputs under distinct domains occupy
+// disjoint byte spaces and can never collide.
+func PrefixWithDomain(domain SignatureDomain, msg []byte) []byte {
+	tag := []byte(domain)
+	out := make([]byte, 0, 2+len(tag)+len(msg))
+	out = append(out, byte(len(tag)>>8), byte(len(tag)))
+	out = append(out, tag...)
+	return append(out, msg...)
+}

--- a/common/types/signature_domain.go
+++ b/common/types/signature_domain.go
@@ -24,8 +24,16 @@ const (
 // length-prefixed domain tag. The 2-byte big-endian length makes the
 // tag/message boundary unambiguous, so outputs under distinct domains occupy
 // disjoint byte spaces and can never collide.
+//
+// The tag must fit in the 2-byte length field; a longer tag would wrap and
+// break the disjointness guarantee. Domains are compile-time constants, so an
+// oversized tag is a programming error and panics rather than silently
+// producing colliding frames.
 func PrefixWithDomain(domain SignatureDomain, msg []byte) []byte {
 	tag := []byte(domain)
+	if len(tag) > 0xFFFF {
+		panic("signature domain tag exceeds 65535 bytes")
+	}
 	out := make([]byte, 0, 2+len(tag)+len(msg))
 	out = append(out, byte(len(tag)>>8), byte(len(tag)))
 	out = append(out, tag...)

--- a/common/types/signature_domain_test.go
+++ b/common/types/signature_domain_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package types_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-orderer/common/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixWithDomain(t *testing.T) {
+	msg := []byte{1, 2, 3}
+	tag := []byte(types.DomainBAF)
+
+	out := types.PrefixWithDomain(types.DomainBAF, msg)
+
+	// Framing is a 2-byte big-endian tag length, then the tag, then the message.
+	require.Equal(t, byte(len(tag)>>8), out[0])
+	require.Equal(t, byte(len(tag)), out[1])
+	require.Equal(t, tag, out[2:2+len(tag)])
+	require.Equal(t, msg, out[2+len(tag):])
+}
+
+func TestPrefixWithDomainSeparatesDomains(t *testing.T) {
+	// The same payload signed under two different domains must never collide.
+	msg := []byte{1, 2, 3}
+	require.NotEqual(t,
+		types.PrefixWithDomain(types.DomainBAF, msg),
+		types.PrefixWithDomain(types.DomainComplaint, msg),
+	)
+}
+
+// TestDomainFramesAreDisjoint is the core security property: because each
+// domain contributes a distinct, length-prefixed tag at a fixed offset, no
+// output produced under one domain can ever equal an output produced under
+// another domain, for ANY payloads. This is what blocks replaying a signature
+// over one message type (e.g. a BAF) as a signature over another (a Complaint).
+func TestDomainFramesAreDisjoint(t *testing.T) {
+	bafFrame := types.PrefixWithDomain(types.DomainBAF, nil)
+	complaintFrame := types.PrefixWithDomain(types.DomainComplaint, nil)
+
+	require.False(t, bytes.HasPrefix(bafFrame, complaintFrame))
+	require.False(t, bytes.HasPrefix(complaintFrame, bafFrame))
+}

--- a/common/types/signature_domain_test.go
+++ b/common/types/signature_domain_test.go
@@ -48,3 +48,20 @@ func TestDomainFramesAreDisjoint(t *testing.T) {
 	require.False(t, bytes.HasPrefix(bafFrame, complaintFrame))
 	require.False(t, bytes.HasPrefix(complaintFrame, bafFrame))
 }
+
+// TestPrefixWithDomainPanicsOnOversizedTag guards the disjointness invariant:
+// a tag that does not fit in the 2-byte length field would wrap and could
+// collide with a shorter tag's frame, so the helper must reject it rather than
+// silently produce a colliding frame.
+func TestPrefixWithDomainPanicsOnOversizedTag(t *testing.T) {
+	oversized := types.SignatureDomain(make([]byte, 0x10000))
+	require.Panics(t, func() {
+		types.PrefixWithDomain(oversized, []byte{1, 2, 3})
+	})
+
+	// The largest representable tag must still be accepted.
+	maxTag := types.SignatureDomain(make([]byte, 0xFFFF))
+	require.NotPanics(t, func() {
+		types.PrefixWithDomain(maxTag, []byte{1, 2, 3})
+	})
+}

--- a/common/types/simpla_baf_test.go
+++ b/common/types/simpla_baf_test.go
@@ -60,6 +60,16 @@ func TestSimpleBAF(t *testing.T) {
 		require.False(t, bytes.Equal(bafBytes, toBeSigned), "ASN.1 and protobuf encodings are different")
 	})
 
+	t.Run("ToBeSigned is bound to the BAF domain", func(t *testing.T) {
+		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, 18, 0, nil)
+		tbs := baf.ToBeSigned()
+
+		// The signed bytes carry the BAF domain tag, and cannot be mistaken for
+		// another message type's signed bytes (e.g. a Complaint).
+		require.True(t, bytes.HasPrefix(tbs, types.PrefixWithDomain(types.DomainBAF, nil)))
+		require.False(t, bytes.HasPrefix(tbs, types.PrefixWithDomain(types.DomainComplaint, nil)))
+	})
+
 	t.Run("serialize and deserialize", func(t *testing.T) {
 		baf := types.NewSimpleBatchAttestationFragment(1, 2, 3, []byte{4, 5, 6, 7}, 8, 18, 12, nil)
 		baf.SetSignature([]byte{9, 10, 11, 12})

--- a/common/types/simple_baf.go
+++ b/common/types/simple_baf.go
@@ -182,7 +182,7 @@ func (s *SimpleBatchAttestationFragment) ToBeSigned() []byte {
 	if err != nil {
 		panic(err)
 	}
-	return result
+	return PrefixWithDomain(DomainBAF, result)
 }
 
 // Deserialize unmarshals every field including the signatures using protobuf.

--- a/node/consensus/state/complaint.go
+++ b/node/consensus/state/complaint.go
@@ -106,7 +106,7 @@ func (c *Complaint) ToBeSigned() []byte {
 		Reason:    c.Reason,
 		ConfigSeq: c.ConfigSeq,
 	}
-	return toBeSignedComplaint.Bytes()
+	return types.PrefixWithDomain(types.DomainComplaint, toBeSignedComplaint.Bytes())
 }
 
 func (c *Complaint) String() string {

--- a/node/consensus/state/complaint_test.go
+++ b/node/consensus/state/complaint_test.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package state_test
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
+	"github.com/hyperledger/fabric-x-orderer/common/types"
 	consensus_state "github.com/hyperledger/fabric-x-orderer/node/consensus/state"
 	"github.com/stretchr/testify/assert"
 )
@@ -76,11 +78,11 @@ func TestComplaintToBeSigned(t *testing.T) {
 		ConfigSeq: 20,
 	}
 
-	// ToBeSigned must exclude the signature: it equals the encoding of the same
-	// complaint with a nil signature.
+	// ToBeSigned must exclude the signature: it equals the domain-tagged
+	// encoding of the same complaint with a nil signature.
 	unsigned := c
 	unsigned.Signature = nil
-	assert.Equal(t, unsigned.Bytes(), c.ToBeSigned())
+	assert.Equal(t, types.PrefixWithDomain(types.DomainComplaint, unsigned.Bytes()), c.ToBeSigned())
 
 	// The result must be independent of the signature so all signers over the
 	// same complaint sign identical bytes.
@@ -92,6 +94,11 @@ func TestComplaintToBeSigned(t *testing.T) {
 	c3 := c
 	c3.Term = 3
 	assert.NotEqual(t, c.ToBeSigned(), c3.ToBeSigned())
+
+	// The signed bytes are bound to the Complaint domain and cannot be mistaken
+	// for another message type's signed bytes (e.g. a BAF).
+	assert.True(t, bytes.HasPrefix(c.ToBeSigned(), types.PrefixWithDomain(types.DomainComplaint, nil)))
+	assert.False(t, bytes.HasPrefix(c.ToBeSigned(), types.PrefixWithDomain(types.DomainBAF, nil)))
 }
 
 func TestComplaintString(t *testing.T) {


### PR DESCRIPTION
Every ECDSA signature over a BAF, Complaint, or block MessageToSign flows through the same SHA256+VerifyASN1 sink with the same key, and nothing in the signed bytes says which message type they belong to. Cross-type replay is blocked today only by the ASN.1/binary layouts happening not to overlap -- "probably safe", not "provably safe".

Fold a distinct, length-prefixed domain tag into the signed bytes at the ToBeSigned() chokepoint for the two orderer-internal signature families. Because sign and verify both go through ToBeSigned(), both sides change symmetrically with no interface or call-site edits. Block signatures are left untouched: they are Fabric-compatible and externally verifiable, so their format must not change.

This is a clean break -- tagged bytes only, no interop with the old untagged format. BAFs/Complaints are only ever verified live against the current config sequence, so no persisted signatures are re-verified under the new scheme.

Refs #175