### PR TITLE
requestfilter: verify a request signature once per policy evaluation

### DIFF
--- a/common/requestfilter/mocks/filter_config.go
+++ b/common/requestfilter/mocks/filter_config.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/hyperledger/fabric-x-common/common/policies"
+	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-orderer/common/requestfilter"
 )
 
@@ -28,6 +29,16 @@ type FakeFilterConfig struct {
 	}
 	getClientSignatureVerificationRequiredReturnsOnCall map[int]struct {
 		result1 bool
+	}
+	GetMSPManagerStub        func() msp.IdentityDeserializer
+	getMSPManagerMutex       sync.RWMutex
+	getMSPManagerArgsForCall []struct {
+	}
+	getMSPManagerReturns struct {
+		result1 msp.IdentityDeserializer
+	}
+	getMSPManagerReturnsOnCall map[int]struct {
+		result1 msp.IdentityDeserializer
 	}
 	GetPolicyManagerStub        func() policies.Manager
 	getPolicyManagerMutex       sync.RWMutex
@@ -156,6 +167,59 @@ func (fake *FakeFilterConfig) GetClientSignatureVerificationRequiredReturnsOnCal
 	}
 	fake.getClientSignatureVerificationRequiredReturnsOnCall[i] = struct {
 		result1 bool
+	}{result1}
+}
+
+func (fake *FakeFilterConfig) GetMSPManager() msp.IdentityDeserializer {
+	fake.getMSPManagerMutex.Lock()
+	ret, specificReturn := fake.getMSPManagerReturnsOnCall[len(fake.getMSPManagerArgsForCall)]
+	fake.getMSPManagerArgsForCall = append(fake.getMSPManagerArgsForCall, struct {
+	}{})
+	stub := fake.GetMSPManagerStub
+	fakeReturns := fake.getMSPManagerReturns
+	fake.recordInvocation("GetMSPManager", []interface{}{})
+	fake.getMSPManagerMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeFilterConfig) GetMSPManagerCallCount() int {
+	fake.getMSPManagerMutex.RLock()
+	defer fake.getMSPManagerMutex.RUnlock()
+	return len(fake.getMSPManagerArgsForCall)
+}
+
+func (fake *FakeFilterConfig) GetMSPManagerCalls(stub func() msp.IdentityDeserializer) {
+	fake.getMSPManagerMutex.Lock()
+	defer fake.getMSPManagerMutex.Unlock()
+	fake.GetMSPManagerStub = stub
+}
+
+func (fake *FakeFilterConfig) GetMSPManagerReturns(result1 msp.IdentityDeserializer) {
+	fake.getMSPManagerMutex.Lock()
+	defer fake.getMSPManagerMutex.Unlock()
+	fake.GetMSPManagerStub = nil
+	fake.getMSPManagerReturns = struct {
+		result1 msp.IdentityDeserializer
+	}{result1}
+}
+
+func (fake *FakeFilterConfig) GetMSPManagerReturnsOnCall(i int, result1 msp.IdentityDeserializer) {
+	fake.getMSPManagerMutex.Lock()
+	defer fake.getMSPManagerMutex.Unlock()
+	fake.GetMSPManagerStub = nil
+	if fake.getMSPManagerReturnsOnCall == nil {
+		fake.getMSPManagerReturnsOnCall = make(map[int]struct {
+			result1 msp.IdentityDeserializer
+		})
+	}
+	fake.getMSPManagerReturnsOnCall[i] = struct {
+		result1 msp.IdentityDeserializer
 	}{result1}
 }
 

--- a/common/requestfilter/rule.go
+++ b/common/requestfilter/rule.go
@@ -9,6 +9,7 @@ package requestfilter
 import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/common/policies"
+	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-orderer/node/protos/comm"
 )
 
@@ -32,6 +33,7 @@ type FilterConfig interface {
 	GetClientSignatureVerificationRequired() bool
 	GetChannelID() string
 	GetPolicyManager() policies.Manager
+	GetMSPManager() msp.IdentityDeserializer
 }
 
 // AcceptRule - always returns nil as a result for Verify

--- a/common/requestfilter/sigfilter.go
+++ b/common/requestfilter/sigfilter.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/common/policies"
+	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-orderer/node/protos/comm"
 	"google.golang.org/protobuf/proto"
@@ -21,6 +22,7 @@ type SigFilter struct {
 	channelID                           string
 	policyName                          string
 	policyManager                       policies.Manager
+	mspManager                          msp.IdentityDeserializer
 }
 
 func NewSigFilter(config FilterConfig, policyName string) *SigFilter {
@@ -29,6 +31,7 @@ func NewSigFilter(config FilterConfig, policyName string) *SigFilter {
 		channelID:                           config.GetChannelID(),
 		policyName:                          policyName,
 		policyManager:                       config.GetPolicyManager(),
+		mspManager:                          config.GetMSPManager(),
 	}
 }
 
@@ -44,7 +47,19 @@ func (sf *SigFilter) VerifyAndClassify(request *comm.Request) (common.HeaderType
 		if !exists {
 			return reqType, fmt.Errorf("no policies in config block")
 		}
-		err = policy.EvaluateSignedData([]*protoutil.SignedData{signedData})
+		// Deserialize the signer and check the signature once, then let the policy tree evaluate
+		// the resulting identity. EvaluateSignedData hands the signature set to every sub-policy
+		// the tree tries, so each one repeats both the deserialization and the signature check,
+		// and admitting a request costs one of each per organization tried before one matches.
+		//
+		// A configuration that carries no MSP manager cannot convert the signature set, so it
+		// evaluates the set itself and pays that repetition.
+		if sf.mspManager != nil {
+			ids := policies.SignatureSetToValidIdentities([]*protoutil.SignedData{signedData}, sf.mspManager)
+			err = policy.EvaluateIdentities(ids)
+		} else {
+			err = policy.EvaluateSignedData([]*protoutil.SignedData{signedData})
+		}
 		if err != nil {
 			return reqType, fmt.Errorf("signature did not satisfy policy %s", sf.policyName)
 		}
@@ -111,5 +126,6 @@ func (sf *SigFilter) Update(config FilterConfig) error {
 	sf.clientSignatureVerificationRequired = config.GetClientSignatureVerificationRequired()
 	sf.channelID = config.GetChannelID()
 	sf.policyManager = config.GetPolicyManager()
+	sf.mspManager = config.GetMSPManager()
 	return nil
 }

--- a/common/requestfilter/sigfilter.go
+++ b/common/requestfilter/sigfilter.go
@@ -7,9 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package requestfilter
 
 import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/msppb"
 	"github.com/hyperledger/fabric-x-common/common/policies"
 	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/protoutil"
@@ -23,16 +30,24 @@ type SigFilter struct {
 	policyName                          string
 	policyManager                       policies.Manager
 	mspManager                          msp.IdentityDeserializer
+	// signerKeys maps the identifier of a certificate the configuration declares to the public key
+	// that certificate carries, so that a request naming its signer by certificate id costs a map
+	// read rather than a lookup and a certificate parse. It is replaced wholesale when the
+	// configuration changes, so a certificate the new configuration no longer declares is dropped.
+	signerKeys atomic.Pointer[sync.Map]
 }
 
 func NewSigFilter(config FilterConfig, policyName string) *SigFilter {
-	return &SigFilter{
+	sf := &SigFilter{
 		clientSignatureVerificationRequired: config.GetClientSignatureVerificationRequired(),
 		channelID:                           config.GetChannelID(),
 		policyName:                          policyName,
 		policyManager:                       config.GetPolicyManager(),
 		mspManager:                          config.GetMSPManager(),
 	}
+	sf.signerKeys.Store(&sync.Map{})
+
+	return sf
 }
 
 func (sf *SigFilter) VerifyAndClassify(request *comm.Request) (common.HeaderType, error) {
@@ -42,29 +57,135 @@ func (sf *SigFilter) VerifyAndClassify(request *comm.Request) (common.HeaderType
 		return reqType, fmt.Errorf("failed to convert request to signedData : %s", err)
 	}
 
-	if sf.clientSignatureVerificationRequired || reqType == common.HeaderType_CONFIG_UPDATE {
-		policy, exists := sf.policyManager.GetPolicy(sf.policyName)
-		if !exists {
-			return reqType, fmt.Errorf("no policies in config block")
-		}
-		// Deserialize the signer and check the signature once, then let the policy tree evaluate
-		// the resulting identity. EvaluateSignedData hands the signature set to every sub-policy
-		// the tree tries, so each one repeats both the deserialization and the signature check,
-		// and admitting a request costs one of each per organization tried before one matches.
-		//
-		// A configuration that carries no MSP manager cannot convert the signature set, so it
-		// evaluates the set itself and pays that repetition.
-		if sf.mspManager != nil {
-			ids := policies.SignatureSetToValidIdentities([]*protoutil.SignedData{signedData}, sf.mspManager)
-			err = policy.EvaluateIdentities(ids)
-		} else {
-			err = policy.EvaluateSignedData([]*protoutil.SignedData{signedData})
-		}
-		if err != nil {
-			return reqType, fmt.Errorf("signature did not satisfy policy %s", sf.policyName)
+	// A config update has to satisfy the channel policy and not merely carry a valid signature:
+	// admitting one on the strength of its signature alone would let any client the configuration
+	// knows reconfigure the channel. Config updates are rare, so what the policy walk costs per
+	// request does not matter here.
+	if reqType == common.HeaderType_CONFIG_UPDATE {
+		return reqType, sf.evaluatePolicy(signedData)
+	}
+
+	if sf.clientSignatureVerificationRequired {
+		if err := sf.verifySignature(signedData); err != nil {
+			return reqType, err
 		}
 	}
+
 	return reqType, nil
+}
+
+// evaluatePolicy hands the signer of a request to the policy tree, which decides whether that
+// signer is allowed to submit it.
+func (sf *SigFilter) evaluatePolicy(signedData *protoutil.SignedData) error {
+	policy, exists := sf.policyManager.GetPolicy(sf.policyName)
+	if !exists {
+		return fmt.Errorf("no policies in config block")
+	}
+
+	// Deserialize the signer and check the signature once, then let the policy tree evaluate
+	// the resulting identity. EvaluateSignedData hands the signature set to every sub-policy
+	// the tree tries, so each one repeats both the deserialization and the signature check,
+	// and admitting a request costs one of each per organization tried before one matches.
+	//
+	// A configuration that carries no MSP manager cannot convert the signature set, so it
+	// evaluates the set itself and pays that repetition.
+	var err error
+	if sf.mspManager != nil {
+		ids := policies.SignatureSetToValidIdentities([]*protoutil.SignedData{signedData}, sf.mspManager)
+		err = policy.EvaluateIdentities(ids)
+	} else {
+		err = policy.EvaluateSignedData([]*protoutil.SignedData{signedData})
+	}
+	if err != nil {
+		return fmt.Errorf("signature did not satisfy policy %s", sf.policyName)
+	}
+
+	return nil
+}
+
+// verifySignature checks the request signature against the public key of the signer the request
+// names. It performs the curve operation and nothing else: the certificate is not validated against
+// a membership service provider and no channel policy is evaluated.
+func (sf *SigFilter) verifySignature(signedData *protoutil.SignedData) error {
+	publicKey, err := sf.signerPublicKey(signedData.Identity)
+	if err != nil {
+		return err
+	}
+
+	digest := sha256.Sum256(signedData.Data)
+	if !ecdsa.VerifyASN1(publicKey, digest[:], signedData.Signature) {
+		return fmt.Errorf("the signature is invalid")
+	}
+
+	return nil
+}
+
+// signerPublicKey returns the public key of the signer a request names, either by carrying its
+// certificate or by naming the identifier of a certificate the configuration declares.
+func (sf *SigFilter) signerPublicKey(id *msppb.Identity) (*ecdsa.PublicKey, error) {
+	if certPEM := id.GetCertificate(); len(certPEM) > 0 {
+		return publicKeyFromPEM(certPEM)
+	}
+
+	certID := id.GetCertificateId()
+	if certID == "" {
+		return nil, fmt.Errorf("the request names neither a certificate nor a certificate id")
+	}
+
+	identifier := msp.IdentityIdentifier{Mspid: id.MspId, Id: certID}
+	keys := sf.signerKeys.Load()
+	if cached, found := keys.Load(identifier); found {
+		if publicKey, isKey := cached.(*ecdsa.PublicKey); isKey {
+			return publicKey, nil
+		}
+	}
+
+	publicKey, err := sf.declaredPublicKey(identifier)
+	if err != nil {
+		return nil, err
+	}
+	keys.Store(identifier, publicKey)
+
+	return publicKey, nil
+}
+
+// declaredPublicKey extracts the public key of a certificate the configuration declares. It runs
+// once per signer, on the first request that names it.
+func (sf *SigFilter) declaredPublicKey(identifier msp.IdentityIdentifier) (*ecdsa.PublicKey, error) {
+	if sf.mspManager == nil {
+		return nil, fmt.Errorf("the configuration declares no certificates, cannot resolve %s", identifier.Id)
+	}
+
+	declared := sf.mspManager.GetKnownDeserializedIdentity(identifier)
+	if declared == nil {
+		return nil, fmt.Errorf("%s does not declare a certificate %s", identifier.Mspid, identifier.Id)
+	}
+
+	certPEM, err := declared.GetCertificatePEM()
+	if err != nil {
+		return nil, fmt.Errorf("failed obtaining the certificate of %s, err %s", identifier.Id, err)
+	}
+
+	return publicKeyFromPEM(certPEM)
+}
+
+func publicKeyFromPEM(certPEM []byte) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("creator certificate is not PEM encoded")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing creator certificate, err %s", err)
+	}
+
+	publicKey, isECDSA := cert.PublicKey.(*ecdsa.PublicKey)
+	if !isECDSA {
+		return nil, fmt.Errorf("creator certificate does not carry an ECDSA public key")
+	}
+
+	return publicKey, nil
 }
 
 // requestToSignedData verifies the request structure and returns the payload, identity and signature in a SignedData.
@@ -127,5 +248,6 @@ func (sf *SigFilter) Update(config FilterConfig) error {
 	sf.channelID = config.GetChannelID()
 	sf.policyManager = config.GetPolicyManager()
 	sf.mspManager = config.GetMSPManager()
+	sf.signerKeys.Store(&sync.Map{})
 	return nil
 }

--- a/common/requestfilter/sigfilter_test.go
+++ b/common/requestfilter/sigfilter_test.go
@@ -9,6 +9,7 @@ package requestfilter_test
 import (
 	"testing"
 
+	"github.com/hyperledger/fabric-x-common/api/msppb"
 	"github.com/hyperledger/fabric-x-common/msp"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -162,4 +163,83 @@ func TestSigFilterType(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, common.HeaderType_MESSAGE, reqType)
 	})
+}
+
+// stubDeserializer records how many times a signature set is converted into identities.
+type stubDeserializer struct {
+	calls int
+}
+
+func (s *stubDeserializer) DeserializeIdentity(identity *msppb.Identity) (msp.Identity, error) {
+	s.calls++
+	return &stubIdentity{}, nil
+}
+
+func (s *stubDeserializer) GetKnownDeserializedIdentity(id msp.IdentityIdentifier) msp.Identity {
+	return nil
+}
+
+func (s *stubDeserializer) IsWellFormed(identity *msppb.Identity) error {
+	return nil
+}
+
+// stubIdentity is the identity a stubDeserializer hands back; only Verify is exercised.
+type stubIdentity struct {
+	msp.Identity
+}
+
+func (s *stubIdentity) GetIdentifier() *msp.IdentityIdentifier {
+	return &msp.IdentityIdentifier{Mspid: "org1", Id: "client"}
+}
+
+func (s *stubIdentity) Verify(msg []byte, sig []byte) error {
+	return nil
+}
+
+func TestSigVerifyEvaluatesIdentitiesOnce(t *testing.T) {
+	// Scenario:
+	// 1. A filter config carries both a policy manager and an MSP manager.
+	// 2. A structured request signed by org1 is verified.
+	// 3. The signer is deserialized exactly once, not once per policy the tree tries.
+	// 4. The policy is handed the resulting identity, so no sub-policy re-checks the signature.
+	var v requestfilter.RulesVerifier
+	fc := &mocks.FakeFilterConfig{}
+	pm := &policyMock.FakePolicyManager{}
+	p := &policyMock.FakePolicyEvaluator{}
+	deserializer := &stubDeserializer{}
+
+	pm.GetPolicyReturns(p, true)
+	fc.GetPolicyManagerReturns(pm)
+	fc.GetMSPManagerReturns(deserializer)
+	fc.GetClientSignatureVerificationRequiredReturns(true)
+
+	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
+
+	_, err := v.VerifyStructureAndClassify(tx.CreateStructuredRequest([]byte("data")))
+	require.NoError(t, err)
+	require.Equal(t, 1, p.EvaluateIdentitiesCallCount())
+	require.Equal(t, 0, p.EvaluateSignedDataCallCount())
+	require.Equal(t, 1, deserializer.calls)
+}
+
+func TestSigVerifyWithoutMSPManagerEvaluatesSignedData(t *testing.T) {
+	// Scenario:
+	// 1. A filter config carries a policy manager but no MSP manager.
+	// 2. A structured request signed by org1 is verified.
+	// 3. The signature set cannot be converted, so the policy evaluates the set itself.
+	var v requestfilter.RulesVerifier
+	fc := &mocks.FakeFilterConfig{}
+	pm := &policyMock.FakePolicyManager{}
+	p := &policyMock.FakePolicyEvaluator{}
+
+	pm.GetPolicyReturns(p, true)
+	fc.GetPolicyManagerReturns(pm)
+	fc.GetClientSignatureVerificationRequiredReturns(true)
+
+	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
+
+	_, err := v.VerifyStructureAndClassify(tx.CreateStructuredRequest([]byte("data")))
+	require.NoError(t, err)
+	require.Equal(t, 1, p.EvaluateSignedDataCallCount())
+	require.Equal(t, 0, p.EvaluateIdentitiesCallCount())
 }

--- a/common/requestfilter/sigfilter_test.go
+++ b/common/requestfilter/sigfilter_test.go
@@ -7,7 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package requestfilter_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/fabric-x-common/api/msppb"
 	"github.com/hyperledger/fabric-x-common/msp"
@@ -17,6 +26,7 @@ import (
 	policyMock "github.com/hyperledger/fabric-x-orderer/common/policy/mocks"
 	"github.com/hyperledger/fabric-x-orderer/common/requestfilter"
 	"github.com/hyperledger/fabric-x-orderer/common/requestfilter/mocks"
+	"github.com/hyperledger/fabric-x-orderer/node/crypto"
 	"github.com/hyperledger/fabric-x-orderer/node/protos/comm"
 	"github.com/hyperledger/fabric-x-orderer/testutil/tx"
 	"github.com/pkg/errors"
@@ -79,76 +89,144 @@ func TestSigVerifyFilter(t *testing.T) {
 }
 
 func TestSigVerifyConfigUpdate(t *testing.T) {
+	// Scenario:
+	// 1. A filter does not require client signature verification.
+	// 2. A config update is classified as such and admitted once the policy is satisfied.
+	// 3. The same config update is rejected when the policy is not satisfied, so that a signature
+	//    a client can produce on its own does not authorize a reconfiguration.
 	var v requestfilter.RulesVerifier
 	fc := &mocks.FakeFilterConfig{}
-
 	policy := &policyMock.FakePolicyEvaluator{}
-	policy.EvaluateSignedDataReturns(nil)
 	policyManager := &policyMock.FakePolicyManager{}
 	policyManager.GetPolicyReturns(policy, true)
 	fc.GetPolicyManagerReturns(policyManager)
 	fc.GetChannelIDReturns("arma")
 	fc.GetClientSignatureVerificationRequiredReturns(false)
 
+	signer := newSignerFixture(t)
+
 	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
-	_, err := v.VerifyStructureAndClassify(nil)
-	require.EqualError(t, err, "failed to convert request to signedData : nil request")
 
-	chdr := &common.ChannelHeader{ChannelId: "arma", Type: int32(common.HeaderType_CONFIG_UPDATE)}
-	chdrBytes, err := proto.Marshal(chdr)
-	require.NoError(t, err)
-
-	id, err := msp.NewSerializedIdentity("org1", []byte("cert"))
-	require.NoError(t, err)
-
-	sigheader, err := proto.Marshal(&common.SignatureHeader{
-		Creator: id,
-		Nonce:   []byte("nonce"),
-	})
-	require.NoError(t, err)
-	payload := &common.Payload{Header: &common.Header{ChannelHeader: chdrBytes, SignatureHeader: sigheader}}
-	p, err := proto.Marshal(payload)
-	require.NoError(t, err)
-	req := &comm.Request{Payload: p}
-	req.Payload = p
+	req := signer.signRequest(t, common.HeaderType_CONFIG_UPDATE, []byte("data"))
 	reqType, err := v.VerifyStructureAndClassify(req)
 	require.NoError(t, err)
 	require.Equal(t, common.HeaderType_CONFIG_UPDATE, reqType)
+	require.Equal(t, 1, policy.EvaluateSignedDataCallCount())
+
+	policy.EvaluateSignedDataReturns(errors.New("not an administrator"))
+	_, err = v.VerifyStructureAndClassify(req)
+	require.ErrorContains(t, err, "signature did not satisfy policy")
 }
 
-func TestSigValidationFlag(t *testing.T) {
+func TestSigVerifyResolvesCertificateID(t *testing.T) {
+	// Scenario:
+	// 1. A filter requires client signature verification and the configuration declares a
+	//    certificate, as it does for a client that names its signer by certificate id.
+	// 2. A request naming that certificate id is admitted, and the certificate is looked up once
+	//    however many requests name it.
+	// 3. A request naming that certificate id but signed by another key is rejected.
+	// 4. A request naming a certificate id the configuration does not declare is rejected.
+	// 5. After a configuration change the certificate is looked up again.
 	var v requestfilter.RulesVerifier
-	req := tx.CreateStructuredRequest([]byte("data"))
 	fc := &mocks.FakeFilterConfig{}
-	pm := &policyMock.FakePolicyManager{}
-	p := &policyMock.FakePolicyEvaluator{}
-
-	pm.GetPolicyReturns(p, false)
-	fc.GetPolicyManagerReturns(pm)
 	fc.GetClientSignatureVerificationRequiredReturns(true)
+
+	signer := newSignerFixture(t)
+	deserializer := &stubDeserializer{declared: map[string][]byte{"client": signer.certPEM}}
+	fc.GetMSPManagerReturns(deserializer)
 
 	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
 
-	_, err := v.VerifyStructureAndClassify(req)
-	require.ErrorContains(t, err, "no policies in config block")
+	for range 4 {
+		_, err := v.VerifyStructureAndClassify(signer.signRequestWithCertID(t, "client"))
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, deserializer.lookups)
 
-	pm.GetPolicyReturns(p, true)
+	impostor := signer.signRequestWithCertID(t, "client")
+	impostor.Signature = newSignerFixture(t).sign(t, impostor.Payload)
+	_, err := v.VerifyStructureAndClassify(impostor)
+	require.ErrorContains(t, err, "the signature is invalid")
+
+	_, err = v.VerifyStructureAndClassify(signer.signRequestWithCertID(t, "stranger"))
+	require.ErrorContains(t, err, "org1 does not declare a certificate stranger")
+
+	require.NoError(t, v.Update(fc))
+	_, err = v.VerifyStructureAndClassify(signer.signRequestWithCertID(t, "client"))
+	require.NoError(t, err)
+	require.Equal(t, 2, deserializer.lookups)
+}
+
+func TestSigValidationFlag(t *testing.T) {
+	// Scenario:
+	// 1. A filter does not require client signature verification, and admits an unsigned request.
+	// 2. Verification is turned on, and a correctly signed request is admitted.
+	// 3. A request whose payload was altered after signing is rejected.
+	// 4. A request signed by a key other than the one its certificate names is rejected.
+	// 5. Verification is turned off again, and the rejected request is admitted unchecked.
+	var v requestfilter.RulesVerifier
+	fc := &mocks.FakeFilterConfig{}
+	fc.GetClientSignatureVerificationRequiredReturns(false)
+
+	signer := newSignerFixture(t)
+
+	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
+
+	_, err := v.VerifyStructureAndClassify(tx.CreateStructuredRequest([]byte("data")))
+	require.NoError(t, err)
+
+	fc.GetClientSignatureVerificationRequiredReturns(true)
+	require.NoError(t, v.Update(fc))
+
+	req := signer.signRequest(t, common.HeaderType_MESSAGE, []byte("data"))
 	_, err = v.VerifyStructureAndClassify(req)
 	require.NoError(t, err)
 
-	p.EvaluateSignedDataReturns(errors.New("error"))
-	_, err = v.VerifyStructureAndClassify(req)
-	require.ErrorContains(t, err, "signature did not satisfy policy")
+	altered := signer.signRequest(t, common.HeaderType_MESSAGE, []byte("data"))
+	altered.Payload = signer.signRequest(t, common.HeaderType_MESSAGE, []byte("other data")).Payload
+	_, err = v.VerifyStructureAndClassify(altered)
+	require.ErrorContains(t, err, "the signature is invalid")
 
-	p.EvaluateSignedDataReturns(nil)
-	_, err = v.VerifyStructureAndClassify(req)
-	require.NoError(t, err)
+	impostor := signer.signRequest(t, common.HeaderType_MESSAGE, []byte("data"))
+	impostor.Signature = newSignerFixture(t).sign(t, impostor.Payload)
+	_, err = v.VerifyStructureAndClassify(impostor)
+	require.ErrorContains(t, err, "the signature is invalid")
 
 	fc.GetClientSignatureVerificationRequiredReturns(false)
-	err = v.Update(fc)
+	require.NoError(t, v.Update(fc))
+	_, err = v.VerifyStructureAndClassify(impostor)
 	require.NoError(t, err)
-	_, err = v.VerifyStructureAndClassify(req)
+}
+
+func TestSigVerifyRejectsUnusableCertificate(t *testing.T) {
+	// Scenario:
+	// 1. A filter requires client signature verification.
+	// 2. A request whose creator certificate is not PEM encoded is rejected.
+	// 3. A request whose creator certificate is PEM but not a certificate is rejected.
+	// 4. A request whose creator certificate carries an RSA key is rejected.
+	var v requestfilter.RulesVerifier
+	fc := &mocks.FakeFilterConfig{}
+	fc.GetClientSignatureVerificationRequiredReturns(true)
+
+	signer := newSignerFixture(t)
+
+	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
+
+	notPEM := signer.signRequestWithCert(t, common.HeaderType_MESSAGE, []byte("data"), []byte("cert"))
+	_, err := v.VerifyStructureAndClassify(notPEM)
+	require.ErrorContains(t, err, "creator certificate is not PEM encoded")
+
+	garbage := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a certificate")})
+	notACert := signer.signRequestWithCert(t, common.HeaderType_MESSAGE, []byte("data"), garbage)
+	_, err = v.VerifyStructureAndClassify(notACert)
+	require.ErrorContains(t, err, "failed parsing creator certificate")
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
+	rsaCert := selfSignedCertPEM(t, rsaKey, &rsaKey.PublicKey)
+	notECDSA := signer.signRequestWithCert(t, common.HeaderType_MESSAGE, []byte("data"), rsaCert)
+	_, err = v.VerifyStructureAndClassify(notECDSA)
+	require.ErrorContains(t, err, "creator certificate does not carry an ECDSA public key")
 }
 
 func TestSigFilterType(t *testing.T) {
@@ -165,81 +243,125 @@ func TestSigFilterType(t *testing.T) {
 	})
 }
 
-// stubDeserializer records how many times a signature set is converted into identities.
+// signerFixture is a real ECDSA key and a certificate naming its public key, so that tests drive
+// the curve operation the filter performs rather than a stub.
+type signerFixture struct {
+	signer  *crypto.ECDSASigner
+	certPEM []byte
+}
+
+func newSignerFixture(t *testing.T) *signerFixture {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	return &signerFixture{
+		signer:  (*crypto.ECDSASigner)(key),
+		certPEM: selfSignedCertPEM(t, key, &key.PublicKey),
+	}
+}
+
+// sign signs arbitrary bytes with the fixture's key, the way a client signs a request payload.
+func (s *signerFixture) sign(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	signature, err := s.signer.Sign(data)
+	require.NoError(t, err)
+	return signature
+}
+
+// signRequest builds a request of the given type naming this fixture's certificate as its creator,
+// signed by the matching key.
+func (s *signerFixture) signRequest(t *testing.T, reqType common.HeaderType, data []byte) *comm.Request {
+	t.Helper()
+	return s.signRequestWithCert(t, reqType, data, s.certPEM)
+}
+
+// signRequestWithCert builds a request naming an arbitrary certificate as its creator, so that a
+// certificate the filter cannot use can be presented alongside a well-formed signature.
+func (s *signerFixture) signRequestWithCert(t *testing.T, reqType common.HeaderType, data []byte, cert []byte) *comm.Request {
+	t.Helper()
+	return s.signRequestAs(t, reqType, data, msppb.NewIdentity("org1", cert))
+}
+
+// signRequestWithCertID builds a request that names its signer by certificate id and carries no
+// certificate, the way a client sending the smallest possible request does.
+func (s *signerFixture) signRequestWithCertID(t *testing.T, certID string) *comm.Request {
+	t.Helper()
+	identity := msppb.NewIdentityWithIDOfCert("org1", certID)
+	return s.signRequestAs(t, common.HeaderType_MESSAGE, []byte("data"), identity)
+}
+
+func (s *signerFixture) signRequestAs(t *testing.T, reqType common.HeaderType, data []byte, id *msppb.Identity) *comm.Request {
+	t.Helper()
+
+	chdr, err := proto.Marshal(&common.ChannelHeader{ChannelId: "arma", Type: int32(reqType)})
+	require.NoError(t, err)
+
+	creator, err := proto.Marshal(id)
+	require.NoError(t, err)
+
+	shdr, err := proto.Marshal(&common.SignatureHeader{Creator: creator, Nonce: []byte("nonce")})
+	require.NoError(t, err)
+
+	payload, err := proto.Marshal(&common.Payload{
+		Header: &common.Header{ChannelHeader: chdr, SignatureHeader: shdr},
+		Data:   data,
+	})
+	require.NoError(t, err)
+
+	return &comm.Request{Payload: payload, Signature: s.sign(t, payload)}
+}
+
+// stubDeserializer stands in for the configuration's certificates and counts how often one is
+// looked up, so that a test can tell a cached resolution from a repeated one.
 type stubDeserializer struct {
-	calls int
+	declared map[string][]byte
+	lookups  int
 }
 
 func (s *stubDeserializer) DeserializeIdentity(identity *msppb.Identity) (msp.Identity, error) {
-	s.calls++
-	return &stubIdentity{}, nil
+	return nil, errors.New("not deserializing")
 }
 
 func (s *stubDeserializer) GetKnownDeserializedIdentity(id msp.IdentityIdentifier) msp.Identity {
-	return nil
+	certPEM, declared := s.declared[id.Id]
+	if !declared {
+		return nil
+	}
+	s.lookups++
+
+	return &stubIdentity{certPEM: certPEM}
 }
 
 func (s *stubDeserializer) IsWellFormed(identity *msppb.Identity) error {
 	return nil
 }
 
-// stubIdentity is the identity a stubDeserializer hands back; only Verify is exercised.
+// stubIdentity is the identity a stubDeserializer hands back; only its certificate is read.
 type stubIdentity struct {
 	msp.Identity
+	certPEM []byte
 }
 
-func (s *stubIdentity) GetIdentifier() *msp.IdentityIdentifier {
-	return &msp.IdentityIdentifier{Mspid: "org1", Id: "client"}
+func (s *stubIdentity) GetCertificatePEM() ([]byte, error) {
+	return s.certPEM, nil
 }
 
-func (s *stubIdentity) Verify(msg []byte, sig []byte) error {
-	return nil
-}
+// selfSignedCertPEM issues a certificate for the given public key, signed by the given key.
+func selfSignedCertPEM(t *testing.T, signingKey any, publicKey any) []byte {
+	t.Helper()
 
-func TestSigVerifyEvaluatesIdentitiesOnce(t *testing.T) {
-	// Scenario:
-	// 1. A filter config carries both a policy manager and an MSP manager.
-	// 2. A structured request signed by org1 is verified.
-	// 3. The signer is deserialized exactly once, not once per policy the tree tries.
-	// 4. The policy is handed the resulting identity, so no sub-policy re-checks the signature.
-	var v requestfilter.RulesVerifier
-	fc := &mocks.FakeFilterConfig{}
-	pm := &policyMock.FakePolicyManager{}
-	p := &policyMock.FakePolicyEvaluator{}
-	deserializer := &stubDeserializer{}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
 
-	pm.GetPolicyReturns(p, true)
-	fc.GetPolicyManagerReturns(pm)
-	fc.GetMSPManagerReturns(deserializer)
-	fc.GetClientSignatureVerificationRequiredReturns(true)
-
-	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
-
-	_, err := v.VerifyStructureAndClassify(tx.CreateStructuredRequest([]byte("data")))
+	der, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, signingKey)
 	require.NoError(t, err)
-	require.Equal(t, 1, p.EvaluateIdentitiesCallCount())
-	require.Equal(t, 0, p.EvaluateSignedDataCallCount())
-	require.Equal(t, 1, deserializer.calls)
-}
 
-func TestSigVerifyWithoutMSPManagerEvaluatesSignedData(t *testing.T) {
-	// Scenario:
-	// 1. A filter config carries a policy manager but no MSP manager.
-	// 2. A structured request signed by org1 is verified.
-	// 3. The signature set cannot be converted, so the policy evaluates the set itself.
-	var v requestfilter.RulesVerifier
-	fc := &mocks.FakeFilterConfig{}
-	pm := &policyMock.FakePolicyManager{}
-	p := &policyMock.FakePolicyEvaluator{}
-
-	pm.GetPolicyReturns(p, true)
-	fc.GetPolicyManagerReturns(pm)
-	fc.GetClientSignatureVerificationRequiredReturns(true)
-
-	v.AddStructureRule(requestfilter.NewSigFilter(fc, policies.ChannelWriters))
-
-	_, err := v.VerifyStructureAndClassify(tx.CreateStructuredRequest([]byte("data")))
-	require.NoError(t, err)
-	require.Equal(t, 1, p.EvaluateSignedDataCallCount())
-	require.Equal(t, 0, p.EvaluateIdentitiesCallCount())
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }

--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -616,10 +616,17 @@ func SendTxsToAllAvailableRouters(userConfig *UserConfig, numOfTxs int, rate int
 			broadcastClient.SendTxToAllRouters(env)
 		}
 	case "short":
+		// Everything an envelope carries besides the transaction and its signature is a function of
+		// the signing identity, so it is derived once for the whole run rather than per transaction.
+		builder, builderErr := tx.NewShortModeEnvelopeBuilder(signer, certBytes, org)
+		if builderErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to prepare the signing material for signed mode %s: %v", signedMode, builderErr)
+			os.Exit(3)
+		}
 		for i := 0; i < numOfTxs; i++ {
-			env = tx.PrepareSignedEnvelopeWithCertificateID(i, txSize, sessionNumber, signer, certBytes, org)
-			if env == nil {
-				fmt.Fprintf(os.Stderr, "failed to prepare envelope %d in signed mode %s", i+1, signedMode)
+			env, err = builder.Envelope(i, txSize, sessionNumber)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to prepare envelope %d in signed mode %s: %v", i+1, signedMode, err)
 				os.Exit(3)
 			}
 			status := rl.GetToken()

--- a/node/batcher/requests_inspector_verifier.go
+++ b/node/batcher/requests_inspector_verifier.go
@@ -69,7 +69,7 @@ func NewRequestsInspectorVerifier(logger *flogging.FabricLogger, config *config.
 	} else {
 		riv.requestVerifier = createBatcherRulesVerifier(config)
 	}
-	riv.mapper = router.MapperCRC64{Logger: riv.logger, ShardCount: uint16(len(riv.shards))}
+	riv.mapper = router.MapperCRC64{ShardCount: uint16(len(riv.shards))}
 	return riv
 }
 

--- a/node/config/utils.go
+++ b/node/config/utils.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/hyperledger/fabric-x-common/common/policies"
+	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-orderer/common/types"
 )
 
@@ -40,6 +41,10 @@ func (c *ConsenterNodeConfig) GetPolicyManager() policies.Manager {
 	return c.Bundle.PolicyManager()
 }
 
+func (c *ConsenterNodeConfig) GetMSPManager() msp.IdentityDeserializer {
+	return c.Bundle.MSPManager()
+}
+
 func (c *BatcherNodeConfig) GetRequestMaxBytes() uint64 {
 	return c.RequestMaxBytes
 }
@@ -56,6 +61,10 @@ func (c *BatcherNodeConfig) GetPolicyManager() policies.Manager {
 	return c.Bundle.PolicyManager()
 }
 
+func (c *BatcherNodeConfig) GetMSPManager() msp.IdentityDeserializer {
+	return c.Bundle.MSPManager()
+}
+
 func (rfc *RouterNodeConfig) GetRequestMaxBytes() uint64 {
 	return rfc.RequestMaxBytes
 }
@@ -70,6 +79,10 @@ func (rfc *RouterNodeConfig) GetChannelID() string {
 
 func (rfc *RouterNodeConfig) GetPolicyManager() policies.Manager {
 	return rfc.Bundle.PolicyManager()
+}
+
+func (rfc *RouterNodeConfig) GetMSPManager() msp.IdentityDeserializer {
+	return rfc.Bundle.MSPManager()
 }
 
 func (c *AssemblerNodeConfig) GetChannelID() string {

--- a/node/router/mapper.go
+++ b/node/router/mapper.go
@@ -9,8 +9,6 @@ package router
 import (
 	"encoding/binary"
 	"hash/crc64"
-
-	"github.com/hyperledger/fabric-lib-go/common/flogging"
 )
 
 type ShardMapper interface {
@@ -18,20 +16,17 @@ type ShardMapper interface {
 }
 
 type MapperCRC64 struct {
-	Logger     *flogging.FabricLogger
 	ShardCount uint16
 }
 
-func CreateMapperCRC64(logger *flogging.FabricLogger, shardCount uint16) MapperCRC64 {
+func CreateMapperCRC64(shardCount uint16) MapperCRC64 {
 	return MapperCRC64{
-		Logger:     logger,
 		ShardCount: shardCount,
 	}
 }
 
 func (m MapperCRC64) Map(request []byte) (shard uint16, reqID []byte) {
 	reqID, shardID := CRC64RequestToShard(m.ShardCount)(request)
-	m.Logger.Debugf("Forwarding request %d to shard %d", reqID, shardID)
 	return shardID, reqID
 }
 

--- a/node/router/mapper_test.go
+++ b/node/router/mapper_test.go
@@ -13,16 +13,13 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hyperledger/fabric-x-orderer/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMultiShardMapper(t *testing.T) {
-	logger := testutil.CreateLogger(t, 0)
-
 	// test MapperCRC64 with 4 shards
 	var numShards uint16 = 4
-	m := MapperCRC64{logger, numShards}
+	m := MapperCRC64{numShards}
 
 	// check that a request consistently receives the same shard and request-ID (i.e., no randomness in the mapping).
 	t.Run("Remap Test", func(t *testing.T) {
@@ -73,10 +70,8 @@ func TestMultiShardMapper(t *testing.T) {
 }
 
 func TestOneShardMapper(t *testing.T) {
-	logger := testutil.CreateLogger(t, 0)
-
 	// test MapperCRC64 with 1 shard
-	m := MapperCRC64{logger, 1}
+	m := MapperCRC64{1}
 
 	// check that with a single shard, requests are consistently mapped to the same shard.
 	t.Run("One Shard Test", func(t *testing.T) {

--- a/node/router/router.go
+++ b/node/router/router.go
@@ -95,7 +95,7 @@ func NewRouter(config *nodeconfig.RouterNodeConfig, configuration *config.Config
 		signer:       signer,
 		mainExitChan: mainExitChan,
 		shardIDs:     shardIDs,
-		mapper:       CreateMapperCRC64(logger, uint16(len(shardIDs))),
+		mapper:       CreateMapperCRC64(uint16(len(shardIDs))),
 		status:       node_utils.NodeStatus{},
 	}
 
@@ -482,7 +482,6 @@ func (r *Router) initRand() *rand2.Rand {
 func (r *Router) getShardRouterAndReqID(req *protos.Request) ([]byte, *ShardRouter) {
 	shardIndex, reqID := r.mapper.Map(req.Payload)
 	shardId := r.shardIDs[shardIndex]
-	r.logger.Debugf("request %x is mapped to shard %d", req.Payload, shardId)
 	shardRouter, exists := r.shardRouters[shardId]
 	if !exists {
 		r.logger.Panicf("Mapped request %d to a non existent shard", shardId)
@@ -502,8 +501,6 @@ func (r *Router) Submit(ctx context.Context, request *protos.Request) (*protos.S
 	tr := &TrackedRequest{request: request, responses: feedbackChan, reqID: reqID, trace: trace}
 	tr.request.ConfigSeq = r.configSeq
 	shardRouter.Forward(tr)
-
-	r.logger.Debugf("Forwarded request %x", request.Payload)
 
 	var response Response
 	select {

--- a/node/router/shard_router.go
+++ b/node/router/shard_router.go
@@ -140,7 +140,6 @@ func (sr *ShardRouter) Forward(trackedReq *TrackedRequest) {
 		trackedReq.request.TraceId = trackedReq.trace
 	}
 
-	sr.logger.Debugf("enter request %x to the requests list", trackedReq.reqID)
 	stream.requestsChannel <- trackedReq
 }
 

--- a/node/router/stream.go
+++ b/node/router/stream.go
@@ -58,7 +58,6 @@ func (s *stream) readResponses() {
 				s.cancelOnServerError(withBackoff)
 				return
 			}
-			s.logger.Debugf("read response from batcher %s on request with trace id %x", s.endpoint, resp.TraceId)
 			err = s.forwardResponseToClient(resp)
 			if err != nil {
 				s.logger.Debugf("received a response from batcher %s for a request with trace id %x, which does not exist in the map, dropping response", s.endpoint, resp.TraceId)
@@ -93,7 +92,6 @@ func (s *stream) sendRequests() {
 				// forward to consenter. configSubmitter will handle sending response to client.
 				s.configSubmitter.Forward(tr)
 			} else {
-				s.logger.Debugf("received request with type %s, forwarding to batcher %s", reqType, s.endpoint)
 				err = s.requestTransmitSubmitStreamClient.Send(tr.request)
 				if err != nil {
 					s.logger.Errorf("Failed sending request to batcher %s", s.endpoint)
@@ -149,7 +147,6 @@ func (s *stream) forwardResponseToClient(response *protos.SubmitResponse) error 
 	s.reconnectBackoffInterval = minRetryInterval
 	s.lock.Unlock()
 	if exists {
-		s.logger.Debugf("registration for request with trace id %x was removed upon receiving a response", traceID)
 		ch <- Response{
 			SubmitResponse: response,
 		}

--- a/testutil/tx/tx_utils.go
+++ b/testutil/tx/tx_utils.go
@@ -227,16 +227,33 @@ func PrepareUnsignedEnvelope(txNumber int, envSize int, sessionNumber []byte) *c
 
 // PrepareSignedEnvelopeWithCertificate prepares an fully signed envelope.
 // this method will be used for creating signed envelope for full signing mode.
-func PrepareSignedEnvelopeWithCertificate(txNumber int, envSize int, sessionNumber []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
-	data := PrepareTxWithTimestamp(txNumber, envSize, sessionNumber)
+// dataSize sizes the transaction, not the envelope: unlike PrepareUnsignedEnvelope, what the envelope
+// carries around the transaction is not subtracted from it.
+func PrepareSignedEnvelopeWithCertificate(
+	txNumber int,
+	dataSize int,
+	sessionNumber []byte,
+	signer *crypto.ECDSASigner,
+	certBytes []byte,
+	org string,
+) *common.Envelope {
+	data := PrepareTxWithTimestamp(txNumber, dataSize, sessionNumber)
 	return CreateSignedStructuredEnvelope(data, signer, certBytes, org)
 }
 
 // PrepareSignedEnvelopeWithCertificateID is used for creating signed envelopes for the "short" (known-identity) signing mode.
-// A caller that prepares many envelopes for one signing identity should use ShortModeEnvelopeBuilder
-// instead, because this function derives the identity's invariant parts on every call.
-func PrepareSignedEnvelopeWithCertificateID(txNumber int, envSize int, sessionNumber []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
-	data := PrepareTxWithTimestamp(txNumber, envSize, sessionNumber)
+// dataSize sizes the transaction, not the envelope. A caller that wants an envelope of a given size, or
+// that prepares many envelopes for one signing identity, should use ShortModeEnvelopeBuilder instead:
+// this function sizes only the transaction and derives the identity's invariant parts on every call.
+func PrepareSignedEnvelopeWithCertificateID(
+	txNumber int,
+	dataSize int,
+	sessionNumber []byte,
+	signer *crypto.ECDSASigner,
+	certBytes []byte,
+	org string,
+) *common.Envelope {
+	data := PrepareTxWithTimestamp(txNumber, dataSize, sessionNumber)
 	return CreateSignedStructuredEnvelopeWithCertID(data, signer, certBytes, org)
 }
 
@@ -265,10 +282,21 @@ type ShortModeEnvelopeBuilder struct {
 	signer          *crypto.ECDSASigner
 	channelHeader   []byte
 	signatureHeader []byte
+	overheadSize    int
 }
 
+// shortModeOverheadProbes is how many envelopes are built to measure the overhead. The DER encoding of
+// an ECDSA signature is a byte or two shorter whenever a leading zero drops out, so the largest of
+// several measurements is taken, which keeps an envelope at or just under the size asked for.
+const shortModeOverheadProbes = 16
+
+// shortModeProbeDataSize is the transaction size the overhead is measured at. A payload is prefixed
+// with its length as a varint, so the overhead grows by a byte at each of that prefix's boundaries;
+// measuring past the first boundary is right for every envelope size a load run asks for.
+const shortModeProbeDataSize = 128
+
 // NewShortModeEnvelopeBuilder derives everything a "short" mode envelope carries besides the
-// transaction and its signature.
+// transaction and its signature, and measures what all of it adds to an envelope.
 func NewShortModeEnvelopeBuilder(
 	signer *crypto.ECDSASigner,
 	certBytes []byte,
@@ -284,16 +312,52 @@ func NewShortModeEnvelopeBuilder(
 		Nonce:   []byte("nonce"),
 	}
 
-	return &ShortModeEnvelopeBuilder{
+	builder := &ShortModeEnvelopeBuilder{
 		signer:          signer,
 		channelHeader:   deterministicMarshall(createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)),
 		signatureHeader: deterministicMarshall(signatureHeader),
-	}, nil
+	}
+
+	builder.overheadSize, err = builder.measureOverhead()
+	if err != nil {
+		return nil, err
+	}
+
+	return builder, nil
 }
 
-// Envelope builds and signs an envelope carrying one transaction of the given size.
+// measureOverhead returns how many bytes an envelope adds to the transaction it carries: both headers,
+// the creator identity naming the signer's certificate, the signature, and the protobuf framing of all
+// of them.
+func (b *ShortModeEnvelopeBuilder) measureOverhead() (int, error) {
+	data := make([]byte, shortModeProbeDataSize)
+
+	overhead := 0
+	for i := 0; i < shortModeOverheadProbes; i++ {
+		envelope, err := b.envelopeForData(data)
+		if err != nil {
+			return 0, err
+		}
+
+		if measured := proto.Size(envelope) - len(data); measured > overhead {
+			overhead = measured
+		}
+	}
+
+	return overhead, nil
+}
+
+// Envelope builds and signs an envelope of envSize bytes, counting what the envelope carries around
+// the transaction as well as the transaction itself, so that an envelope is the size a load run asks
+// for whichever signing mode produced it. An envelope cannot be smaller than its own overhead, so an
+// envSize below that sizes the transaction instead, as the unsigned mode does.
 func (b *ShortModeEnvelopeBuilder) Envelope(txNumber int, envSize int, sessionNumber []byte) (*common.Envelope, error) {
-	return b.envelopeForData(PrepareTxWithTimestamp(txNumber, envSize, sessionNumber))
+	dataSize := envSize
+	if envSize > b.overheadSize {
+		dataSize = envSize - b.overheadSize
+	}
+
+	return b.envelopeForData(PrepareTxWithTimestamp(txNumber, dataSize, sessionNumber))
 }
 
 // envelopeForData signs the given transaction content. The header bytes it places in the payload are

--- a/testutil/tx/tx_utils.go
+++ b/testutil/tx/tx_utils.go
@@ -233,6 +233,8 @@ func PrepareSignedEnvelopeWithCertificate(txNumber int, envSize int, sessionNumb
 }
 
 // PrepareSignedEnvelopeWithCertificateID is used for creating signed envelopes for the "short" (known-identity) signing mode.
+// A caller that prepares many envelopes for one signing identity should use ShortModeEnvelopeBuilder
+// instead, because this function derives the identity's invariant parts on every call.
 func PrepareSignedEnvelopeWithCertificateID(txNumber int, envSize int, sessionNumber []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
 	data := PrepareTxWithTimestamp(txNumber, envSize, sessionNumber)
 	return CreateSignedStructuredEnvelopeWithCertID(data, signer, certBytes, org)
@@ -242,17 +244,79 @@ func PrepareSignedEnvelopeWithCertificateID(txNumber int, envSize int, sessionNu
 // certificate-ID (hex SHA256 of the DER-encoded cert) rather than the full PEM certificate.
 // The verifying MSP must have the corresponding certificate registered in its known-identities list.
 func CreateSignedStructuredEnvelopeWithCertID(data []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
-	payload := createSignedStructuredPayloadWithCertID(data, certBytes, org)
-	payloadBytes := deterministicMarshall(payload)
+	builder, err := NewShortModeEnvelopeBuilder(signer, certBytes, org)
+	if err != nil {
+		panic(err)
+	}
 
-	signature, err := signer.Sign(payloadBytes)
+	envelope, err := builder.envelopeForData(data)
 	if err != nil {
 		return nil
 	}
+	return envelope
+}
+
+// ShortModeEnvelopeBuilder holds the parts of a "short" mode envelope that do not depend on the
+// transaction: the identifier of the signer's certificate, the marshalled creator identity naming it,
+// and both marshalled headers. All of them are a function of the signing identity alone, so a builder
+// derives them once and every envelope it produces reuses them. Deriving the certificate identifier
+// is the expensive part, since it decodes and parses the certificate to hash it.
+type ShortModeEnvelopeBuilder struct {
+	signer          *crypto.ECDSASigner
+	channelHeader   []byte
+	signatureHeader []byte
+}
+
+// NewShortModeEnvelopeBuilder derives everything a "short" mode envelope carries besides the
+// transaction and its signature.
+func NewShortModeEnvelopeBuilder(
+	signer *crypto.ECDSASigner,
+	certBytes []byte,
+	org string,
+) (*ShortModeEnvelopeBuilder, error) {
+	certID, err := computeCertID(certBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	signatureHeader := &common.SignatureHeader{
+		Creator: deterministicMarshall(msppb.NewIdentityWithIDOfCert(org, certID)),
+		Nonce:   []byte("nonce"),
+	}
+
+	return &ShortModeEnvelopeBuilder{
+		signer:          signer,
+		channelHeader:   deterministicMarshall(createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)),
+		signatureHeader: deterministicMarshall(signatureHeader),
+	}, nil
+}
+
+// Envelope builds and signs an envelope carrying one transaction of the given size.
+func (b *ShortModeEnvelopeBuilder) Envelope(txNumber int, envSize int, sessionNumber []byte) (*common.Envelope, error) {
+	return b.envelopeForData(PrepareTxWithTimestamp(txNumber, envSize, sessionNumber))
+}
+
+// envelopeForData signs the given transaction content. The header bytes it places in the payload are
+// shared with every other envelope the builder produces, so they are only ever read.
+func (b *ShortModeEnvelopeBuilder) envelopeForData(data []byte) (*common.Envelope, error) {
+	payload := &common.Payload{
+		Header: &common.Header{
+			ChannelHeader:   b.channelHeader,
+			SignatureHeader: b.signatureHeader,
+		},
+		Data: data,
+	}
+	payloadBytes := deterministicMarshall(payload)
+
+	signature, err := b.signer.Sign(payloadBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed signing the payload: %w", err)
+	}
+
 	return &common.Envelope{
 		Payload:   payloadBytes,
 		Signature: signature,
-	}
+	}, nil
 }
 
 func computeCertID(certBytes []byte) (string, error) {
@@ -261,28 +325,6 @@ func computeCertID(certBytes []byte) (string, error) {
 		return "", fmt.Errorf("failed computing cert ID: %w", err)
 	}
 	return hex.EncodeToString(digest), nil
-}
-
-// createSignedStructuredPayloadWithCertID builds a Payload whose creator identity uses a certificate-ID
-// (hash) instead of the full certificate PEM.
-func createSignedStructuredPayloadWithCertID(data []byte, certBytes []byte, org string) *common.Payload {
-	payloadChannelHeader := createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)
-
-	certID, err := computeCertID(certBytes)
-	if err != nil {
-		panic(err)
-	}
-
-	sId := msppb.NewIdentityWithIDOfCert(org, certID)
-
-	payloadSignatureHeader := &common.SignatureHeader{
-		Creator: deterministicMarshall(sId),
-		Nonce:   []byte("nonce"),
-	}
-	return &common.Payload{
-		Header: createPayloadHeader(payloadChannelHeader, payloadSignatureHeader),
-		Data:   data,
-	}
 }
 
 func CreateSignedStructuredEnvelope(data []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {

--- a/testutil/tx/tx_utils_test.go
+++ b/testutil/tx/tx_utils_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tx
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/msppb"
+	"github.com/hyperledger/fabric-x-orderer/node/crypto"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tlsgen"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// signingIdentity returns a signer and the PEM certificate it corresponds to.
+func signingIdentity(t *testing.T) (*crypto.ECDSASigner, []byte) {
+	t.Helper()
+
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	pair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(pair.Key)
+	require.NotNil(t, block)
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: block.Bytes})
+	privateKey, err := CreateECDSAPrivateKey(keyPEM)
+	require.NoError(t, err)
+
+	return (*crypto.ECDSASigner)(privateKey), pair.Cert
+}
+
+// publicKeyOf returns the public key the given PEM certificate carries.
+func publicKeyOf(t *testing.T, certPEM []byte) *ecdsa.PublicKey {
+	t.Helper()
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	publicKey, isECDSA := cert.PublicKey.(*ecdsa.PublicKey)
+	require.True(t, isECDSA)
+
+	return publicKey
+}
+
+// headersOf returns the two marshalled headers of an envelope's payload.
+func headersOf(t *testing.T, envelope *common.Envelope) (channelHeader []byte, signatureHeader []byte) {
+	t.Helper()
+
+	payload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(envelope.Payload, payload))
+	require.NotNil(t, payload.Header)
+
+	return payload.Header.ChannelHeader, payload.Header.SignatureHeader
+}
+
+func TestShortModeEnvelopeBuilderMatchesPerTransactionPath(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Build an envelope for one transaction with a builder.
+	// 3. Build an envelope for the same transaction with the per-transaction function.
+	// 4. Compare the two marshalled headers of both envelopes.
+	// 5. Compare the size of the transaction both envelopes carry.
+	signer, certPEM := signingIdentity(t)
+	sessionNumber := []byte("0123456789abcdef")
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	built, err := builder.Envelope(7, 125, sessionNumber)
+	require.NoError(t, err)
+
+	perTransaction := PrepareSignedEnvelopeWithCertificateID(7, 125, sessionNumber, signer, certPEM, "org1")
+	require.NotNil(t, perTransaction)
+
+	builtChannelHeader, builtSignatureHeader := headersOf(t, built)
+	expectedChannelHeader, expectedSignatureHeader := headersOf(t, perTransaction)
+	require.Equal(t, expectedChannelHeader, builtChannelHeader)
+	require.Equal(t, expectedSignatureHeader, builtSignatureHeader)
+
+	builtPayload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(built.Payload, builtPayload))
+	expectedPayload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(perTransaction.Payload, expectedPayload))
+	require.Len(t, builtPayload.Data, len(expectedPayload.Data))
+}
+
+func TestShortModeEnvelopeBuilderNamesTheSignersCertificate(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Build an envelope with a builder.
+	// 3. Extract the creator identity from the envelope's signature header.
+	// 4. Compare the certificate identifier it names against the hash of the certificate.
+	// 5. Confirm the identity carries no certificate.
+	signer, certPEM := signingIdentity(t)
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	envelope, err := builder.Envelope(1, 125, []byte("0123456789abcdef"))
+	require.NoError(t, err)
+
+	_, signatureHeaderBytes := headersOf(t, envelope)
+	signatureHeader := &common.SignatureHeader{}
+	require.NoError(t, proto.Unmarshal(signatureHeaderBytes, signatureHeader))
+
+	identity := &msppb.Identity{}
+	require.NoError(t, proto.Unmarshal(signatureHeader.Creator, identity))
+
+	expectedCertID, err := computeCertID(certPEM)
+	require.NoError(t, err)
+	require.Equal(t, "org1", identity.MspId)
+	require.Equal(t, expectedCertID, identity.GetCertificateId())
+	require.Empty(t, identity.GetCertificate())
+}
+
+func TestShortModeEnvelopeBuilderSignsEveryEnvelope(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Build three envelopes for three transactions with one builder.
+	// 3. Verify each signature against the public key of the signer's certificate.
+	// 4. Confirm all three envelopes share the same two marshalled headers.
+	// 5. Confirm the three payloads differ from one another.
+	signer, certPEM := signingIdentity(t)
+	publicKey := publicKeyOf(t, certPEM)
+	sessionNumber := []byte("0123456789abcdef")
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	envelopes := make([]*common.Envelope, 3)
+	for i := range envelopes {
+		envelopes[i], err = builder.Envelope(i, 125, sessionNumber)
+		require.NoError(t, err)
+
+		digest := sha256.Sum256(envelopes[i].Payload)
+		require.True(t, ecdsa.VerifyASN1(publicKey, digest[:], envelopes[i].Signature))
+	}
+
+	firstChannelHeader, firstSignatureHeader := headersOf(t, envelopes[0])
+	for _, envelope := range envelopes[1:] {
+		channelHeader, signatureHeader := headersOf(t, envelope)
+		require.Equal(t, firstChannelHeader, channelHeader)
+		require.Equal(t, firstSignatureHeader, signatureHeader)
+	}
+
+	require.NotEqual(t, envelopes[0].Payload, envelopes[1].Payload)
+	require.NotEqual(t, envelopes[1].Payload, envelopes[2].Payload)
+}
+
+func TestShortModeEnvelopeBuilderRejectsACertificateItCannotParse(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Construct a builder with content that is not a PEM certificate.
+	// 3. Confirm the construction fails and returns no builder.
+	signer, _ := signingIdentity(t)
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, []byte("not a certificate"), "org1")
+	require.Error(t, err)
+	require.Nil(t, builder)
+}

--- a/testutil/tx/tx_utils_test.go
+++ b/testutil/tx/tx_utils_test.go
@@ -162,6 +162,56 @@ func TestShortModeEnvelopeBuilderSignsEveryEnvelope(t *testing.T) {
 	require.NotEqual(t, envelopes[1].Payload, envelopes[2].Payload)
 }
 
+func TestShortModeEnvelopeBuilderSizesTheWholeEnvelope(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity and a builder.
+	// 2. Build an envelope for each of several requested sizes above the envelope's own overhead.
+	// 3. Confirm no envelope exceeds the size requested.
+	// 4. Confirm every envelope is within four bytes of the size requested.
+	// 5. Compare each size against the envelope the unsigned mode produces for the same request.
+	signer, certPEM := signingIdentity(t)
+	sessionNumber := []byte("0123456789abcdef")
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	// A DER encoded signature loses a byte whenever a leading zero drops out of r or s, so a run of
+	// envelopes covers the sizes one identity produces rather than a single one.
+	for _, envSize := range []int{300, 500, 1000, 4096} {
+		for txNumber := 0; txNumber < 64; txNumber++ {
+			envelope, err := builder.Envelope(txNumber, envSize, sessionNumber)
+			require.NoError(t, err)
+
+			size := proto.Size(envelope)
+			require.LessOrEqual(t, size, envSize)
+			require.Greater(t, size, envSize-4)
+		}
+
+		unsigned := PrepareUnsignedEnvelope(0, envSize, sessionNumber)
+		require.Equal(t, envSize, proto.Size(unsigned))
+	}
+}
+
+func TestShortModeEnvelopeBuilderSizesTheTransactionWhenTheEnvelopeCannotFit(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity and a builder.
+	// 2. Request an envelope smaller than the overhead an envelope carries.
+	// 3. Confirm the transaction in it is the size requested instead.
+	signer, certPEM := signingIdentity(t)
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+	require.Greater(t, builder.overheadSize, 0)
+
+	envSize := builder.overheadSize - 1
+	envelope, err := builder.Envelope(1, envSize, []byte("0123456789abcdef"))
+	require.NoError(t, err)
+
+	payload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(envelope.Payload, payload))
+	require.Len(t, payload.Data, envSize)
+}
+
 func TestShortModeEnvelopeBuilderRejectsACertificateItCannotParse(t *testing.T) {
 	// Scenario:
 	// 1. Create a signing identity.


### PR DESCRIPTION
Convert the signature set to identities once in `SigFilter` instead of letting every sub-policy of the implicit meta `Writers` tree re-derive them, cutting ECDSA verifications per request from up to one per organization to exactly one.