### PR TITLE
armageddon: build the invariant envelope parts once, and size the envelope as asked

### DIFF
--- a/common/tools/armageddon/armageddon.go
+++ b/common/tools/armageddon/armageddon.go
@@ -616,10 +616,17 @@ func SendTxsToAllAvailableRouters(userConfig *UserConfig, numOfTxs int, rate int
 			broadcastClient.SendTxToAllRouters(env)
 		}
 	case "short":
+		// Everything an envelope carries besides the transaction and its signature is a function of
+		// the signing identity, so it is derived once for the whole run rather than per transaction.
+		builder, builderErr := tx.NewShortModeEnvelopeBuilder(signer, certBytes, org)
+		if builderErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to prepare the signing material for signed mode %s: %v", signedMode, builderErr)
+			os.Exit(3)
+		}
 		for i := 0; i < numOfTxs; i++ {
-			env = tx.PrepareSignedEnvelopeWithCertificateID(i, txSize, sessionNumber, signer, certBytes, org)
-			if env == nil {
-				fmt.Fprintf(os.Stderr, "failed to prepare envelope %d in signed mode %s", i+1, signedMode)
+			env, err = builder.Envelope(i, txSize, sessionNumber)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to prepare envelope %d in signed mode %s: %v", i+1, signedMode, err)
 				os.Exit(3)
 			}
 			status := rl.GetToken()

--- a/testutil/tx/tx_utils.go
+++ b/testutil/tx/tx_utils.go
@@ -227,16 +227,33 @@ func PrepareUnsignedEnvelope(txNumber int, envSize int, sessionNumber []byte) *c
 
 // PrepareSignedEnvelopeWithCertificate prepares an fully signed envelope.
 // this method will be used for creating signed envelope for full signing mode.
-func PrepareSignedEnvelopeWithCertificate(txNumber int, envSize int, sessionNumber []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
-	data := PrepareTxWithTimestamp(txNumber, envSize, sessionNumber)
+// dataSize sizes the transaction, not the envelope: unlike PrepareUnsignedEnvelope, what the envelope
+// carries around the transaction is not subtracted from it.
+func PrepareSignedEnvelopeWithCertificate(
+	txNumber int,
+	dataSize int,
+	sessionNumber []byte,
+	signer *crypto.ECDSASigner,
+	certBytes []byte,
+	org string,
+) *common.Envelope {
+	data := PrepareTxWithTimestamp(txNumber, dataSize, sessionNumber)
 	return CreateSignedStructuredEnvelope(data, signer, certBytes, org)
 }
 
 // PrepareSignedEnvelopeWithCertificateID is used for creating signed envelopes for the "short" (known-identity) signing mode.
-// A caller that prepares many envelopes for one signing identity should use ShortModeEnvelopeBuilder
-// instead, because this function derives the identity's invariant parts on every call.
-func PrepareSignedEnvelopeWithCertificateID(txNumber int, envSize int, sessionNumber []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
-	data := PrepareTxWithTimestamp(txNumber, envSize, sessionNumber)
+// dataSize sizes the transaction, not the envelope. A caller that wants an envelope of a given size, or
+// that prepares many envelopes for one signing identity, should use ShortModeEnvelopeBuilder instead:
+// this function sizes only the transaction and derives the identity's invariant parts on every call.
+func PrepareSignedEnvelopeWithCertificateID(
+	txNumber int,
+	dataSize int,
+	sessionNumber []byte,
+	signer *crypto.ECDSASigner,
+	certBytes []byte,
+	org string,
+) *common.Envelope {
+	data := PrepareTxWithTimestamp(txNumber, dataSize, sessionNumber)
 	return CreateSignedStructuredEnvelopeWithCertID(data, signer, certBytes, org)
 }
 
@@ -265,10 +282,21 @@ type ShortModeEnvelopeBuilder struct {
 	signer          *crypto.ECDSASigner
 	channelHeader   []byte
 	signatureHeader []byte
+	overheadSize    int
 }
 
+// shortModeOverheadProbes is how many envelopes are built to measure the overhead. The DER encoding of
+// an ECDSA signature is a byte or two shorter whenever a leading zero drops out, so the largest of
+// several measurements is taken, which keeps an envelope at or just under the size asked for.
+const shortModeOverheadProbes = 16
+
+// shortModeProbeDataSize is the transaction size the overhead is measured at. A payload is prefixed
+// with its length as a varint, so the overhead grows by a byte at each of that prefix's boundaries;
+// measuring past the first boundary is right for every envelope size a load run asks for.
+const shortModeProbeDataSize = 128
+
 // NewShortModeEnvelopeBuilder derives everything a "short" mode envelope carries besides the
-// transaction and its signature.
+// transaction and its signature, and measures what all of it adds to an envelope.
 func NewShortModeEnvelopeBuilder(
 	signer *crypto.ECDSASigner,
 	certBytes []byte,
@@ -284,16 +312,52 @@ func NewShortModeEnvelopeBuilder(
 		Nonce:   []byte("nonce"),
 	}
 
-	return &ShortModeEnvelopeBuilder{
+	builder := &ShortModeEnvelopeBuilder{
 		signer:          signer,
 		channelHeader:   deterministicMarshall(createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)),
 		signatureHeader: deterministicMarshall(signatureHeader),
-	}, nil
+	}
+
+	builder.overheadSize, err = builder.measureOverhead()
+	if err != nil {
+		return nil, err
+	}
+
+	return builder, nil
 }
 
-// Envelope builds and signs an envelope carrying one transaction of the given size.
+// measureOverhead returns how many bytes an envelope adds to the transaction it carries: both headers,
+// the creator identity naming the signer's certificate, the signature, and the protobuf framing of all
+// of them.
+func (b *ShortModeEnvelopeBuilder) measureOverhead() (int, error) {
+	data := make([]byte, shortModeProbeDataSize)
+
+	overhead := 0
+	for i := 0; i < shortModeOverheadProbes; i++ {
+		envelope, err := b.envelopeForData(data)
+		if err != nil {
+			return 0, err
+		}
+
+		if measured := proto.Size(envelope) - len(data); measured > overhead {
+			overhead = measured
+		}
+	}
+
+	return overhead, nil
+}
+
+// Envelope builds and signs an envelope of envSize bytes, counting what the envelope carries around
+// the transaction as well as the transaction itself, so that an envelope is the size a load run asks
+// for whichever signing mode produced it. An envelope cannot be smaller than its own overhead, so an
+// envSize below that sizes the transaction instead, as the unsigned mode does.
 func (b *ShortModeEnvelopeBuilder) Envelope(txNumber int, envSize int, sessionNumber []byte) (*common.Envelope, error) {
-	return b.envelopeForData(PrepareTxWithTimestamp(txNumber, envSize, sessionNumber))
+	dataSize := envSize
+	if envSize > b.overheadSize {
+		dataSize = envSize - b.overheadSize
+	}
+
+	return b.envelopeForData(PrepareTxWithTimestamp(txNumber, dataSize, sessionNumber))
 }
 
 // envelopeForData signs the given transaction content. The header bytes it places in the payload are

--- a/testutil/tx/tx_utils.go
+++ b/testutil/tx/tx_utils.go
@@ -233,6 +233,8 @@ func PrepareSignedEnvelopeWithCertificate(txNumber int, envSize int, sessionNumb
 }
 
 // PrepareSignedEnvelopeWithCertificateID is used for creating signed envelopes for the "short" (known-identity) signing mode.
+// A caller that prepares many envelopes for one signing identity should use ShortModeEnvelopeBuilder
+// instead, because this function derives the identity's invariant parts on every call.
 func PrepareSignedEnvelopeWithCertificateID(txNumber int, envSize int, sessionNumber []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
 	data := PrepareTxWithTimestamp(txNumber, envSize, sessionNumber)
 	return CreateSignedStructuredEnvelopeWithCertID(data, signer, certBytes, org)
@@ -242,17 +244,79 @@ func PrepareSignedEnvelopeWithCertificateID(txNumber int, envSize int, sessionNu
 // certificate-ID (hex SHA256 of the DER-encoded cert) rather than the full PEM certificate.
 // The verifying MSP must have the corresponding certificate registered in its known-identities list.
 func CreateSignedStructuredEnvelopeWithCertID(data []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {
-	payload := createSignedStructuredPayloadWithCertID(data, certBytes, org)
-	payloadBytes := deterministicMarshall(payload)
+	builder, err := NewShortModeEnvelopeBuilder(signer, certBytes, org)
+	if err != nil {
+		panic(err)
+	}
 
-	signature, err := signer.Sign(payloadBytes)
+	envelope, err := builder.envelopeForData(data)
 	if err != nil {
 		return nil
 	}
+	return envelope
+}
+
+// ShortModeEnvelopeBuilder holds the parts of a "short" mode envelope that do not depend on the
+// transaction: the identifier of the signer's certificate, the marshalled creator identity naming it,
+// and both marshalled headers. All of them are a function of the signing identity alone, so a builder
+// derives them once and every envelope it produces reuses them. Deriving the certificate identifier
+// is the expensive part, since it decodes and parses the certificate to hash it.
+type ShortModeEnvelopeBuilder struct {
+	signer          *crypto.ECDSASigner
+	channelHeader   []byte
+	signatureHeader []byte
+}
+
+// NewShortModeEnvelopeBuilder derives everything a "short" mode envelope carries besides the
+// transaction and its signature.
+func NewShortModeEnvelopeBuilder(
+	signer *crypto.ECDSASigner,
+	certBytes []byte,
+	org string,
+) (*ShortModeEnvelopeBuilder, error) {
+	certID, err := computeCertID(certBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	signatureHeader := &common.SignatureHeader{
+		Creator: deterministicMarshall(msppb.NewIdentityWithIDOfCert(org, certID)),
+		Nonce:   []byte("nonce"),
+	}
+
+	return &ShortModeEnvelopeBuilder{
+		signer:          signer,
+		channelHeader:   deterministicMarshall(createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)),
+		signatureHeader: deterministicMarshall(signatureHeader),
+	}, nil
+}
+
+// Envelope builds and signs an envelope carrying one transaction of the given size.
+func (b *ShortModeEnvelopeBuilder) Envelope(txNumber int, envSize int, sessionNumber []byte) (*common.Envelope, error) {
+	return b.envelopeForData(PrepareTxWithTimestamp(txNumber, envSize, sessionNumber))
+}
+
+// envelopeForData signs the given transaction content. The header bytes it places in the payload are
+// shared with every other envelope the builder produces, so they are only ever read.
+func (b *ShortModeEnvelopeBuilder) envelopeForData(data []byte) (*common.Envelope, error) {
+	payload := &common.Payload{
+		Header: &common.Header{
+			ChannelHeader:   b.channelHeader,
+			SignatureHeader: b.signatureHeader,
+		},
+		Data: data,
+	}
+	payloadBytes := deterministicMarshall(payload)
+
+	signature, err := b.signer.Sign(payloadBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed signing the payload: %w", err)
+	}
+
 	return &common.Envelope{
 		Payload:   payloadBytes,
 		Signature: signature,
-	}
+	}, nil
 }
 
 func computeCertID(certBytes []byte) (string, error) {
@@ -261,28 +325,6 @@ func computeCertID(certBytes []byte) (string, error) {
 		return "", fmt.Errorf("failed computing cert ID: %w", err)
 	}
 	return hex.EncodeToString(digest), nil
-}
-
-// createSignedStructuredPayloadWithCertID builds a Payload whose creator identity uses a certificate-ID
-// (hash) instead of the full certificate PEM.
-func createSignedStructuredPayloadWithCertID(data []byte, certBytes []byte, org string) *common.Payload {
-	payloadChannelHeader := createChannelHeader(common.HeaderType_MESSAGE, 0, "channelID", 0)
-
-	certID, err := computeCertID(certBytes)
-	if err != nil {
-		panic(err)
-	}
-
-	sId := msppb.NewIdentityWithIDOfCert(org, certID)
-
-	payloadSignatureHeader := &common.SignatureHeader{
-		Creator: deterministicMarshall(sId),
-		Nonce:   []byte("nonce"),
-	}
-	return &common.Payload{
-		Header: createPayloadHeader(payloadChannelHeader, payloadSignatureHeader),
-		Data:   data,
-	}
 }
 
 func CreateSignedStructuredEnvelope(data []byte, signer *crypto.ECDSASigner, certBytes []byte, org string) *common.Envelope {

--- a/testutil/tx/tx_utils_test.go
+++ b/testutil/tx/tx_utils_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tx
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/msppb"
+	"github.com/hyperledger/fabric-x-orderer/node/crypto"
+	"github.com/hyperledger/fabric-x-orderer/testutil/tlsgen"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// signingIdentity returns a signer and the PEM certificate it corresponds to.
+func signingIdentity(t *testing.T) (*crypto.ECDSASigner, []byte) {
+	t.Helper()
+
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	pair, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(pair.Key)
+	require.NotNil(t, block)
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: block.Bytes})
+	privateKey, err := CreateECDSAPrivateKey(keyPEM)
+	require.NoError(t, err)
+
+	return (*crypto.ECDSASigner)(privateKey), pair.Cert
+}
+
+// publicKeyOf returns the public key the given PEM certificate carries.
+func publicKeyOf(t *testing.T, certPEM []byte) *ecdsa.PublicKey {
+	t.Helper()
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	publicKey, isECDSA := cert.PublicKey.(*ecdsa.PublicKey)
+	require.True(t, isECDSA)
+
+	return publicKey
+}
+
+// headersOf returns the two marshalled headers of an envelope's payload.
+func headersOf(t *testing.T, envelope *common.Envelope) (channelHeader []byte, signatureHeader []byte) {
+	t.Helper()
+
+	payload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(envelope.Payload, payload))
+	require.NotNil(t, payload.Header)
+
+	return payload.Header.ChannelHeader, payload.Header.SignatureHeader
+}
+
+func TestShortModeEnvelopeBuilderMatchesPerTransactionPath(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Build an envelope for one transaction with a builder.
+	// 3. Build an envelope for the same transaction with the per-transaction function.
+	// 4. Compare the two marshalled headers of both envelopes.
+	// 5. Compare the size of the transaction both envelopes carry.
+	signer, certPEM := signingIdentity(t)
+	sessionNumber := []byte("0123456789abcdef")
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	built, err := builder.Envelope(7, 125, sessionNumber)
+	require.NoError(t, err)
+
+	perTransaction := PrepareSignedEnvelopeWithCertificateID(7, 125, sessionNumber, signer, certPEM, "org1")
+	require.NotNil(t, perTransaction)
+
+	builtChannelHeader, builtSignatureHeader := headersOf(t, built)
+	expectedChannelHeader, expectedSignatureHeader := headersOf(t, perTransaction)
+	require.Equal(t, expectedChannelHeader, builtChannelHeader)
+	require.Equal(t, expectedSignatureHeader, builtSignatureHeader)
+
+	builtPayload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(built.Payload, builtPayload))
+	expectedPayload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(perTransaction.Payload, expectedPayload))
+	require.Len(t, builtPayload.Data, len(expectedPayload.Data))
+}
+
+func TestShortModeEnvelopeBuilderNamesTheSignersCertificate(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Build an envelope with a builder.
+	// 3. Extract the creator identity from the envelope's signature header.
+	// 4. Compare the certificate identifier it names against the hash of the certificate.
+	// 5. Confirm the identity carries no certificate.
+	signer, certPEM := signingIdentity(t)
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	envelope, err := builder.Envelope(1, 125, []byte("0123456789abcdef"))
+	require.NoError(t, err)
+
+	_, signatureHeaderBytes := headersOf(t, envelope)
+	signatureHeader := &common.SignatureHeader{}
+	require.NoError(t, proto.Unmarshal(signatureHeaderBytes, signatureHeader))
+
+	identity := &msppb.Identity{}
+	require.NoError(t, proto.Unmarshal(signatureHeader.Creator, identity))
+
+	expectedCertID, err := computeCertID(certPEM)
+	require.NoError(t, err)
+	require.Equal(t, "org1", identity.MspId)
+	require.Equal(t, expectedCertID, identity.GetCertificateId())
+	require.Empty(t, identity.GetCertificate())
+}
+
+func TestShortModeEnvelopeBuilderSignsEveryEnvelope(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Build three envelopes for three transactions with one builder.
+	// 3. Verify each signature against the public key of the signer's certificate.
+	// 4. Confirm all three envelopes share the same two marshalled headers.
+	// 5. Confirm the three payloads differ from one another.
+	signer, certPEM := signingIdentity(t)
+	publicKey := publicKeyOf(t, certPEM)
+	sessionNumber := []byte("0123456789abcdef")
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	envelopes := make([]*common.Envelope, 3)
+	for i := range envelopes {
+		envelopes[i], err = builder.Envelope(i, 125, sessionNumber)
+		require.NoError(t, err)
+
+		digest := sha256.Sum256(envelopes[i].Payload)
+		require.True(t, ecdsa.VerifyASN1(publicKey, digest[:], envelopes[i].Signature))
+	}
+
+	firstChannelHeader, firstSignatureHeader := headersOf(t, envelopes[0])
+	for _, envelope := range envelopes[1:] {
+		channelHeader, signatureHeader := headersOf(t, envelope)
+		require.Equal(t, firstChannelHeader, channelHeader)
+		require.Equal(t, firstSignatureHeader, signatureHeader)
+	}
+
+	require.NotEqual(t, envelopes[0].Payload, envelopes[1].Payload)
+	require.NotEqual(t, envelopes[1].Payload, envelopes[2].Payload)
+}
+
+func TestShortModeEnvelopeBuilderRejectsACertificateItCannotParse(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity.
+	// 2. Construct a builder with content that is not a PEM certificate.
+	// 3. Confirm the construction fails and returns no builder.
+	signer, _ := signingIdentity(t)
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, []byte("not a certificate"), "org1")
+	require.Error(t, err)
+	require.Nil(t, builder)
+}

--- a/testutil/tx/tx_utils_test.go
+++ b/testutil/tx/tx_utils_test.go
@@ -162,6 +162,56 @@ func TestShortModeEnvelopeBuilderSignsEveryEnvelope(t *testing.T) {
 	require.NotEqual(t, envelopes[1].Payload, envelopes[2].Payload)
 }
 
+func TestShortModeEnvelopeBuilderSizesTheWholeEnvelope(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity and a builder.
+	// 2. Build an envelope for each of several requested sizes above the envelope's own overhead.
+	// 3. Confirm no envelope exceeds the size requested.
+	// 4. Confirm every envelope is within four bytes of the size requested.
+	// 5. Compare each size against the envelope the unsigned mode produces for the same request.
+	signer, certPEM := signingIdentity(t)
+	sessionNumber := []byte("0123456789abcdef")
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+
+	// A DER encoded signature loses a byte whenever a leading zero drops out of r or s, so a run of
+	// envelopes covers the sizes one identity produces rather than a single one.
+	for _, envSize := range []int{300, 500, 1000, 4096} {
+		for txNumber := 0; txNumber < 64; txNumber++ {
+			envelope, err := builder.Envelope(txNumber, envSize, sessionNumber)
+			require.NoError(t, err)
+
+			size := proto.Size(envelope)
+			require.LessOrEqual(t, size, envSize)
+			require.Greater(t, size, envSize-4)
+		}
+
+		unsigned := PrepareUnsignedEnvelope(0, envSize, sessionNumber)
+		require.Equal(t, envSize, proto.Size(unsigned))
+	}
+}
+
+func TestShortModeEnvelopeBuilderSizesTheTransactionWhenTheEnvelopeCannotFit(t *testing.T) {
+	// Scenario:
+	// 1. Create a signing identity and a builder.
+	// 2. Request an envelope smaller than the overhead an envelope carries.
+	// 3. Confirm the transaction in it is the size requested instead.
+	signer, certPEM := signingIdentity(t)
+
+	builder, err := NewShortModeEnvelopeBuilder(signer, certPEM, "org1")
+	require.NoError(t, err)
+	require.Greater(t, builder.overheadSize, 0)
+
+	envSize := builder.overheadSize - 1
+	envelope, err := builder.Envelope(1, envSize, []byte("0123456789abcdef"))
+	require.NoError(t, err)
+
+	payload := &common.Payload{}
+	require.NoError(t, proto.Unmarshal(envelope.Payload, payload))
+	require.Len(t, payload.Data, envSize)
+}
+
 func TestShortModeEnvelopeBuilderRejectsACertificateItCannotParse(t *testing.T) {
 	// Scenario:
 	// 1. Create a signing identity.


### PR DESCRIPTION
armageddon: build the invariant parts of a signed envelope once per run

armageddon: size a short mode envelope to the size a load run asks for